### PR TITLE
Returning standard response on device-manager/device:search

### DIFF
--- a/lib/controllers/CRUDController.ts
+++ b/lib/controllers/CRUDController.ts
@@ -64,7 +64,7 @@ export class CRUDController {
     const index = request.getIndex();
     const { searchBody } = request.getSearchParams();
 
-    return this.as(request.context.user).query(
+    const res = await this.as(request.context.user).query(
       {
         controller: 'document',
         action: 'search',
@@ -74,6 +74,8 @@ export class CRUDController {
         ...request.input.args
       }
     );
+
+    return res.result
   }
 
   /**


### PR DESCRIPTION
Fixes response structure for `device-manager/device:search`

* Before 👉 `res.result.result`
* After 👉 `res.result`

⚠️ This PR introduces a breaking change. Let's ensure this doesn't break stuff, before merging.