### PR TITLE
HOTFIX: Add the full asset content in measure event payload

### DIFF
--- a/doc/1/guides/assets/index.md
+++ b/doc/1/guides/assets/index.md
@@ -90,21 +90,22 @@ It is possible to override the [Decoder.copyToAsset](/official-plugins/device-ma
 
 Assets are historized in the `assets-history` collection when a new measure is received.
 
-Before historization, the `tenant:<tenant-id>:asset:measure:new` event is emitted. This event allows to enrich the asset before it is historized.
+Before historization, the `tenant:<tenant-id>:asset:measure:new` event is emitted.
 
-The payload contains the new `measures` and the `assetId`.
+The payload contain the asset updated content and the types of the new added measures.
 
-The content of `request.result.asset` will be used to update the asset measures and then create the history document.
+At the end of the processing, the asset will be updated and historized with the content of the `request.result.asset._source`.
 
 ```js
 app.pipe.register(`tenant:<tenant-id>:asset:measures:new`, async (request: KuzzleRequest) => {
-  const measures: AssetMeasures = request.result.asset.measures;
-  const assetId: string = request.result.assetId;
+  const asset = request.result.asset;
+  const measureTypes = request.result.measureTypes;
 
-  request.result.asset.metadata = {
-    enriched: true,
-    assetId: request.result.assetId
-  };
+  if (measureTypes.includes('position')) {
+    request.result.asset._source.metadata = {
+      city: 'Adrasan',
+    };
+  }
 
   return request;
 });

--- a/features/PayloadController.feature
+++ b/features/PayloadController.feature
@@ -147,7 +147,7 @@ Feature: Payloads Controller
       | measures.temperature.qos.battery | 40                               |
       # Enriched with the event
       | metadata.enriched                | true                             |
-      | metadata.assetId                 | "MART-linked"                    |
+      | metadata.measureTypes            | ["temperature"]                  |
     And I should receive a result matching:
       | device._id | "DummyTemp-attached_ayse_linked" |
       | asset._id  | "MART-linked"                    |
@@ -160,10 +160,10 @@ Feature: Payloads Controller
       | batteryLevel | 0.42                   |
     And I refresh the collection "tenant-ayse":"assets-history"
     And The last document from "tenant-ayse":"assets-history" content match:
-      | assetId                 | "MART-linked"   |
-      | measureTypes            | ["temperature"] |
-      | assetId                 | "MART-linked"   |
-      | asset.model             | "MART"          |
-      | asset.reference         | "linked"        |
-      | asset.metadata.enriched | true            |
-      | asset.metadata.assetId  | "MART-linked"   |
+      | assetId                     | "MART-linked"   |
+      | measureTypes                | ["temperature"] |
+      | assetId                     | "MART-linked"   |
+      | asset.model                 | "MART"          |
+      | asset.reference             | "linked"        |
+      | asset.metadata.enriched     | true            |
+      | asset.metadata.measureTypes | ["temperature"] |

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -62,13 +62,13 @@ deviceManager.assets.register('hevSuit', {
 
 // Register a pipe to enrich a tenant asset
 app.pipe.register(`tenant:tenant-ayse:asset:measures:new`, async (request: KuzzleRequest) => {
-  if (request.result.assetId !== 'MART-linked') {
+  if (request.result.asset._id !== 'MART-linked') {
     return request;
   }
 
-  request.result.asset.metadata = {
+  request.result.asset._source.metadata = {
     enriched: true,
-    assetId: request.result.assetId
+    measureTypes: request.result.measureTypes
   };
 
   return request;

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 export * from './lib/DeviceManagerPlugin';
 
-export * from './lib/core-classes/Decoder';
+export * from './lib/core-classes';
 
 export * from './lib/models';
 

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -290,15 +290,24 @@ export class PayloadService {
   ): Promise<BaseAsset> {
     const measures = await decoder.copyToAsset(updatedDevice);
 
+    const measureTypes = Object.keys(measures);
+
+    const asset = await this.batchController.get(
+      tenantId,
+      'assets',
+      assetId);
+
+    asset._source.measures = _.merge(asset._source.measures, measures);
+
     const { result } = await global.app.trigger(
       `tenant:${tenantId}:asset:measures:new`,
-      eventPayload({ asset: { measures }, assetId }));
+      eventPayload({ asset, measureTypes }));
 
     const assetDocument = await this.batchController.update(
       tenantId,
       'assets',
       assetId,
-      result.asset,
+      result.asset._source,
       { source: true, retryOnConflict: 10 });
 
     return new BaseAsset(assetDocument._source as any, assetDocument._id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuzzleio/plugin-device-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kuzzleio/plugin-device-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Manage your IoT devices and assets. Choose a provisionning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {


### PR DESCRIPTION
## Description

Fetch the entire asset before triggering the `tenant:{tenant-id}:asset:measure:new` event