### PR TITLE
Throw NotFoundError when a device is not found

### DIFF
--- a/doc/1/controllers/device/attach-tenant/index.md
+++ b/doc/1/controllers/device/attach-tenant/index.md
@@ -11,6 +11,8 @@ Attach a device to a tenant.
 
 The device document will be duplicated inside the tenant `devices` collection.
 
+If the device does not exists, process will throw a NotFoundError.
+
 ---
 
 ## Query Syntax

--- a/doc/1/controllers/device/m-attach/index.md
+++ b/doc/1/controllers/device/m-attach/index.md
@@ -11,6 +11,8 @@ Attach multiple devices to multiple tenants.
 
 The device document will be duplicated inside the tenant "devices" collection.
 
+If a device does not exists on the list, process will throw a NotFoundError
+
 ---
 
 ## Query Syntax

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -8,6 +8,13 @@ Feature: Device Manager device controller
       | tenantId | "tenant-kuzzle" |
     And The document "tenant-kuzzle":"devices":"DummyTemp-detached" exists
 
+  Scenario: Attech a non-existing device to a tenant should throw an error
+    When I execute the action "device-manager/device":"attachTenant" with args:
+      | _id   | "Not-existing-device" |
+      | index | "tenant-kuzzle"       |
+    Then I should receive an error matching:
+      | message | "Device(s) \"Not-existing-device\" not found" |
+
   Scenario: Attach multiple devices to a tenant using JSON
     When I successfully execute the action "device-manager/device":"mAttach" with args:
       | body.records.0.tenantId | "tenant-kuzzle"                    |

--- a/lib/controllers/DeviceController.ts
+++ b/lib/controllers/DeviceController.ts
@@ -3,7 +3,8 @@ import {
   KuzzleRequest,
   EmbeddedSDK,
   BadRequestError,
-  Plugin
+  Plugin,
+  NotFoundError
 } from 'kuzzle';
 
 import { CRUDController } from './CRUDController';
@@ -256,6 +257,12 @@ export class DeviceController extends CRUDController {
       'devices',
       deviceIds
     )
+
+    if (result.errors.length > 0) {
+      const ids = result.errors.join(',');
+      throw(new NotFoundError(`Device(s) "${ids}" not found`));
+    }
+
     return result.successes.map((document: any) => new Device(document._source, document._id));
   }
 


### PR DESCRIPTION
This PR aim to fix #104 

Error that is thrown by the process match how are thrown errors in this plugin.