### PR TITLE
Feat/events linkasset

### DIFF
--- a/doc/1/controllers/device/link-asset/index.md
+++ b/doc/1/controllers/device/link-asset/index.md
@@ -71,8 +71,12 @@ kourou device-manager/device:linkAsset <index> --id <deviceId> -a assetId=<asset
 Two events when this action is called, allowing to modify the device before it is linked to the asset:
 
 ```js
+import set from 'lodash/set';
+
 app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
   app.log.debug('before link-asset trigered');
+
+  set(asset, 'body.metadata.enrichedByBeforeLinkAsset', true);
 
   return { device, asset };
 })

--- a/doc/1/controllers/device/link-asset/index.md
+++ b/doc/1/controllers/device/link-asset/index.md
@@ -71,13 +71,13 @@ kourou device-manager/device:linkAsset <index> --id <deviceId> -a assetId=<asset
 Two events when this action is called, allowing to modify the device before it is linked to the asset:
 
 ```js
-app.pipe.register('device-manager:device:link-asset:before', data => {
+app.pipe.register('device-manager:device:link-asset:before', async data => {
   app.log.debug('before link-asset trigered');
 
   return data;
 })
 
-app.pipe.register('device-manager:device:link-asset:after', data => {
+app.pipe.register('device-manager:device:link-asset:after', async data => {
   app.log.debug('after link-asset trigered');
 
   return data;

--- a/doc/1/controllers/device/link-asset/index.md
+++ b/doc/1/controllers/device/link-asset/index.md
@@ -65,3 +65,21 @@ kourou device-manager/device:linkAsset <index> --id <deviceId> -a assetId=<asset
   "result": {}
 }
 ```
+
+## Events
+
+Two events when this action is called, allowing to modify the device before it is linked to the asset:
+
+```js
+app.pipe.register('device-manager:device:link-asset:before', data => {
+  app.log.debug('before link-asset trigered');
+
+  return data;
+})
+
+app.pipe.register('device-manager:device:link-asset:after', data => {
+  app.log.debug('after link-asset trigered');
+
+  return data;
+})
+```

--- a/doc/1/controllers/device/link-asset/index.md
+++ b/doc/1/controllers/device/link-asset/index.md
@@ -71,15 +71,15 @@ kourou device-manager/device:linkAsset <index> --id <deviceId> -a assetId=<asset
 Two events when this action is called, allowing to modify the device before it is linked to the asset:
 
 ```js
-app.pipe.register('device-manager:device:link-asset:before', async data => {
+app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
   app.log.debug('before link-asset trigered');
 
-  return data;
+  return { device, asset };
 })
 
-app.pipe.register('device-manager:device:link-asset:after', async data => {
+app.pipe.register('device-manager:device:link-asset:after', async ({ device, asset }) => {
   app.log.debug('after link-asset trigered');
 
-  return data;
+  return { device, asset };
 })
 ```

--- a/doc/1/controllers/device/m-link-assets/index.md
+++ b/doc/1/controllers/device/m-link-assets/index.md
@@ -89,8 +89,12 @@ Body properties, must contain at least one of the following:
 Two events when this action is called, allowing to modify the device before it is linked to the asset:
 
 ```js
+import set from 'lodash/set';
+
 app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
   app.log.debug('before link-asset trigered');
+
+  set(asset, 'body.metadata.enrichedByBeforeLinkAsset', true);
 
   return { device, asset };
 })

--- a/doc/1/controllers/device/m-link-assets/index.md
+++ b/doc/1/controllers/device/m-link-assets/index.md
@@ -84,3 +84,20 @@ Body properties, must contain at least one of the following:
     }
 }
 ```
+## Events
+
+Two events when this action is called, allowing to modify the device before it is linked to the asset:
+
+```js
+app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
+  app.log.debug('before link-asset trigered');
+
+  return { device, asset };
+})
+
+app.pipe.register('device-manager:device:link-asset:after', async ({ device, asset }) => {
+  app.log.debug('after link-asset trigered');
+
+  return { device, asset };
+})
+```

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -131,13 +131,29 @@ Feature: Device Manager device controller
       | measures.temperature.degree             | 23.3                               |
       | measures.temperature.origin.qos.battery | 80                                 |
 
-    Scenario: Link the same device to another asset should fail
+  Scenario: Link device to an asset and enriching the asset with before and after events
+    When I successfully execute the action "device-manager/device":"linkAsset" with args:
+      | _id     | "DummyTemp-attached_ayse_unlinked" |
+      | assetId | "PERFO-unlinked"                   |
+    Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
+      | assetId | "PERFO-unlinked" |
+    And The document "tenant-ayse":"devices":"DummyTemp-attached_ayse_unlinked" content match:
+      | assetId | "PERFO-unlinked" |
+    And The document "tenant-ayse":"assets":"PERFO-unlinked" content match:
+      | metadata.enrichedByBeforeLinkAsset | true |
+    And I successfully execute the action "collection":"refresh" with args:
+      | index      | "tenant-ayse" |
+      | collection | "assets"      |
+    And The document "tenant-ayse":"assets":"PERFO-unlinked" content match:
+      | metadata.enrichedByAfterLinkAsset | true |
+
+  Scenario: Link the same device to another asset should fail
     When I successfully execute the action "device-manager/device":"linkAsset" with args:
       | _id     | "DummyTemp-attached_ayse_unlinked" |
       | assetId | "PERFO-unlinked"                   |
     And I execute the action "device-manager/device":"linkAsset" with args:
       | _id     | "DummyTemp-attached_ayse_unlinked" |
-      | assetId | "TIKO-unlinked"                   |
+      | assetId | "TIKO-unlinked"                    |
     Then I should receive an error matching:
       | message | "Device \"DummyTemp-attached_ayse_unlinked\" is already linked to the asset \"PERFO-unlinked\" you need to detach it first." |
 

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -131,21 +131,12 @@ Feature: Device Manager device controller
       | measures.temperature.degree             | 23.3                               |
       | measures.temperature.origin.qos.battery | 80                                 |
 
-  Scenario: Link device to an asset and enriching the asset with before and after events
+  Scenario: Link device to an asset and enriching the asset with before event
     When I successfully execute the action "device-manager/device":"linkAsset" with args:
       | _id     | "DummyTemp-attached_ayse_unlinked" |
       | assetId | "PERFO-unlinked"                   |
-    Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
-      | assetId | "PERFO-unlinked" |
-    And The document "tenant-ayse":"devices":"DummyTemp-attached_ayse_unlinked" content match:
-      | assetId | "PERFO-unlinked" |
     And The document "tenant-ayse":"assets":"PERFO-unlinked" content match:
       | metadata.enrichedByBeforeLinkAsset | true |
-    And I successfully execute the action "collection":"refresh" with args:
-      | index      | "tenant-ayse" |
-      | collection | "assets"      |
-    And The document "tenant-ayse":"assets":"PERFO-unlinked" content match:
-      | metadata.enrichedByAfterLinkAsset | true |
 
   Scenario: Link the same device to another asset should fail
     When I successfully execute the action "device-manager/device":"linkAsset" with args:

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -73,6 +73,18 @@ app.pipe.register(`tenant:tenant-ayse:asset:measures:new`, async (request: Kuzzl
   return request;
 });
 
+app.pipe.register('device-manager:device:link-asset:before', data => {
+  app.log.debug('before link-asset trigered');
+
+  return data;
+})
+
+app.pipe.register('device-manager:device:link-asset:after', data => {
+  app.log.debug('after link-asset trigered');
+
+  return data;
+})
+
 app.plugin.use(deviceManager);
 
 app.hook.register('request:onError', async (request: KuzzleRequest) => {

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -1,3 +1,4 @@
+import set from 'lodash/set'; 
 import { Backend, KuzzleRequest } from 'kuzzle';
 
 import { DeviceManagerPlugin } from '../../../index';
@@ -76,11 +77,24 @@ app.pipe.register(`tenant:tenant-ayse:asset:measures:new`, async (request: Kuzzl
 app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
   app.log.debug('before link-asset trigered');
 
+  set(asset, 'body.metadata.enrichedByBeforeLinkAsset', true);
+
   return { device, asset };
 })
 
 app.pipe.register('device-manager:device:link-asset:after', async ({ device, asset }) => {
   app.log.debug('after link-asset trigered');
+
+  app.sdk.query({
+    controller: 'device-manager/assets',
+    action: 'update',
+    _id: asset._id,
+    body: {
+      metadata: {
+        enrichedByAfterLinkAsset: true
+      }
+    }
+  })
 
   return { device, asset };
 })

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -73,13 +73,13 @@ app.pipe.register(`tenant:tenant-ayse:asset:measures:new`, async (request: Kuzzl
   return request;
 });
 
-app.pipe.register('device-manager:device:link-asset:before', data => {
+app.pipe.register('device-manager:device:link-asset:before', async data => {
   app.log.debug('before link-asset trigered');
 
   return data;
 })
 
-app.pipe.register('device-manager:device:link-asset:after', data => {
+app.pipe.register('device-manager:device:link-asset:after', async data => {
   app.log.debug('after link-asset trigered');
 
   return data;

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -85,17 +85,6 @@ app.pipe.register('device-manager:device:link-asset:before', async ({ device, as
 app.pipe.register('device-manager:device:link-asset:after', async ({ device, asset }) => {
   app.log.debug('after link-asset trigered');
 
-  app.sdk.query({
-    controller: 'device-manager/assets',
-    action: 'update',
-    _id: asset._id,
-    body: {
-      metadata: {
-        enrichedByAfterLinkAsset: true
-      }
-    }
-  })
-
   return { device, asset };
 })
 

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -73,16 +73,16 @@ app.pipe.register(`tenant:tenant-ayse:asset:measures:new`, async (request: Kuzzl
   return request;
 });
 
-app.pipe.register('device-manager:device:link-asset:before', async data => {
+app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
   app.log.debug('before link-asset trigered');
 
-  return data;
+  return { device, asset };
 })
 
-app.pipe.register('device-manager:device:link-asset:after', async data => {
+app.pipe.register('device-manager:device:link-asset:after', async ({ device, asset }) => {
   app.log.debug('after link-asset trigered');
 
-  return data;
+  return { device, asset };
 })
 
 app.plugin.use(deviceManager);

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -419,8 +419,8 @@ export class DeviceService {
           { strict, ...options });
 
         return {
-          success: results.successes.push(...created.successes),
-          errors: results.errors.push(...created.errors)
+          successes: results.successes.concat(created.successes),
+          errors: results.errors.concat(created.errors)
         }
       });
 

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -297,7 +297,7 @@ export class DeviceService {
 
     await global.app.trigger(
       'device-manager:device:link-asset:after',
-      { devices, bulkData }
+      { devices: _devices, bulkData: _bulkData }
     );
 
     return results;

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -291,7 +291,7 @@ export class DeviceService {
             successes: results.successes.concat(updated.successes),
             errors: results.errors.concat(updated.errors)
           }
-        })
+        });
       
 
       results.successes.concat(updatedDevice.successes, updatedAssets.successes);


### PR DESCRIPTION
# Description

This PR allow the user to connect to two different events that are triggered before and after an asset is linked to a device.

Two events when this action is called, allowing to modify the device before it is linked to the asset:

## Events

Two events when this action is called, allowing to modify the device before it is linked to the asset:

```js
app.pipe.register('device-manager:device:link-asset:before', async ({ device, asset }) => {
  app.log.debug('before link-asset trigered');
  return { device, asset };
})
app.pipe.register('device-manager:device:link-asset:after', async ({ device, asset }) => {
  app.log.debug('after link-asset trigered');
  return { device, asset };
})
```

close #122 