### PR TITLE
[breaking] Rename tenant event to engine event

### DIFF
--- a/doc/1/guides/assets/index.md
+++ b/doc/1/guides/assets/index.md
@@ -90,14 +90,14 @@ It is possible to override the [Decoder.copyToAsset](/official-plugins/device-ma
 
 Assets are historized in the `asset-history` collection when a new measure is received.
 
-Before historization, the `tenant:<tenant-id>:asset:measure:new` event is emitted.
+Before historization, the `engine:<engine-index>:asset:measure:new` event is emitted.
 
 The payload contain the asset updated content and the types of the new added measures.
 
 At the end of the processing, the asset will be updated and historized with the content of the `request.result.asset._source`.
 
 ```js
-app.pipe.register(`tenant:<tenant-id>:asset:measures:new`, async (request: KuzzleRequest) => {
+app.pipe.register(`engine:<engine-index>:asset:measures:new`, async (request: KuzzleRequest) => {
   const asset = request.result.asset;
   const measureTypes = request.result.measureTypes;
 

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -60,7 +60,7 @@ deviceManager.assets.register('hevSuit', {
 
 
 // Register a pipe to enrich a tenant asset
-app.pipe.register(`tenant:tenant-ayse:asset:measures:new`, async (request: KuzzleRequest) => {
+app.pipe.register(`engine:tenant-ayse:asset:measures:new`, async (request: KuzzleRequest) => {
   if (request.result.asset._id !== 'MART-linked') {
     return request;
   }

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -300,7 +300,7 @@ export class PayloadService {
     asset._source.measures = _.merge(asset._source.measures, measures);
 
     const { result } = await global.app.trigger(
-      `tenant:${tenantId}:asset:measures:new`,
+      `engine:${tenantId}:asset:measures:new`,
       eventPayload({ asset, measureTypes }));
 
     const assetDocument = await this.batchController.update(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Manage your IoT devices and assets. Choose a provisionning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {


### PR DESCRIPTION
## Description

Rename the event `tenant:<tenant-id>:asset:measures:new` to `engine:<tenant-id>:asset:measures:new`

### Migrate

You should replace usage of event `tenant:<tenant-id>:asset:measures:new` by `engine:<tenant-id>:asset:measures:new`

```
// before
app.pipe.register('tenant:tenant-kuzzle:asset:measures:new', async () => {
  // ...
});

// after
app.pipe.register('engine:tenant-kuzzle:asset:measures:new', async () => {
  // ...
});

```