### PR TITLE
event before after attachtenant

### DIFF
--- a/doc/1/controllers/device/attach-tenant/index.md
+++ b/doc/1/controllers/device/attach-tenant/index.md
@@ -65,3 +65,23 @@ kourou device-manager/device:attachTenant <index> --id <deviceId>
   "result": {}
 }
 ```
+
+## Events
+
+Two events when this action is called, allowing to modify the device before it is attached to tenant:
+
+```js
+app.pipe.register('device-manager:device:attach-tenant:before', async ({ index, device }) => {
+  app.log.debug('before attach-tenant trigered');
+
+  set(device, 'body.metadata.enrichedByBeforeAttachTenant', true);
+
+  return { index, device };
+})
+
+app.pipe.register('device-manager:device:attach-tenant:after', async ({ index, device }) => {
+  app.log.debug('after attach-tenant trigered');
+
+  return { index, device };
+})
+```

--- a/doc/1/controllers/device/m-attach-tenants/index.md
+++ b/doc/1/controllers/device/m-attach-tenants/index.md
@@ -88,3 +88,23 @@ Body properties, must contain at least one of
     }
 }
 ```
+
+## Events
+
+Two events when this action is called, allowing to modify the device before it is attached to tenant:
+
+```js
+app.pipe.register('device-manager:device:attach-tenant:before', async ({ index, device }) => {
+  app.log.debug('before attach-tenant trigered');
+
+  set(device, 'body.metadata.enrichedByBeforeAttachTenant', true);
+
+  return { index, device };
+})
+
+app.pipe.register('device-manager:device:attach-tenant:after', async ({ index, device }) => {
+  app.log.debug('after attach-tenant trigered');
+
+  return { index, device };
+})
+```

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -24,6 +24,9 @@ Feature: Device Manager device controller
     And The document "tenant-kuzzle":"devices":"DummyTemp-detached" exists
     And The document "tenant-kuzzle":"devices":"DummyTemp-detached" content match:
       | metadata.enrichedByBeforeAttachTenant | true |
+    And I refresh the collection "tenant-kuzzle":"devices"
+    And The document "tenant-kuzzle":"devices":"DummyTemp-detached" content match:
+      | metadata.enrichedByAfterAttachTenant | true |
 
   Scenario: Attach multiple devices to a tenant using JSON
     When I successfully execute the action "device-manager/device":"mAttachTenants" with args:

--- a/features/DeviceController.feature
+++ b/features/DeviceController.feature
@@ -14,6 +14,16 @@ Feature: Device Manager device controller
       | index | "tenant-kuzzle"       |
     Then I should receive an error matching:
       | message | "Device(s) \"Not-existing-device\" not found" |
+  
+  Scenario: Attach a device to a tenant and enrich it with event
+    When I successfully execute the action "device-manager/device":"attachTenant" with args:
+      | _id   | "DummyTemp-detached" |
+      | index | "tenant-kuzzle"      |
+    Then The document "device-manager":"devices":"DummyTemp-detached" content match:
+      | tenantId | "tenant-kuzzle" |
+    And The document "tenant-kuzzle":"devices":"DummyTemp-detached" exists
+    And The document "tenant-kuzzle":"devices":"DummyTemp-detached" content match:
+      | metadata.enrichedByBeforeAttachTenant | true |
 
   Scenario: Attach multiple devices to a tenant using JSON
     When I successfully execute the action "device-manager/device":"mAttachTenants" with args:

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -88,6 +88,20 @@ app.pipe.register('device-manager:device:link-asset:after', async ({ device, ass
   return { device, asset };
 })
 
+app.pipe.register('device-manager:device:attach-tenant:before', async ({ index, device }) => {
+  app.log.debug('before attach-tenant trigered');
+
+  set(device, 'body.metadata.enrichedByBeforeAttachTenant', true);
+
+  return { index, device };
+})
+
+app.pipe.register('device-manager:device:attach-tenant:after', async ({ index, device }) => {
+  app.log.debug('after attach-tenant trigered');
+
+  return { index, device };
+})
+
 app.plugin.use(deviceManager);
 
 app.hook.register('request:onError', async (request: KuzzleRequest) => {

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -99,6 +99,19 @@ app.pipe.register('device-manager:device:attach-tenant:before', async ({ index, 
 app.pipe.register('device-manager:device:attach-tenant:after', async ({ index, device }) => {
   app.log.debug('after attach-tenant trigered');
 
+  if (device.body.metadata.enrichedByBeforeAttachTenant) {
+    set(device, 'body.metadata.enrichedByAfterAttachTenant', true);
+
+
+    await app.sdk.document.update(
+      device.body.tenantId,
+      'devices',
+      device._id,
+      device.body
+    )
+  
+  }
+
   return { index, device };
 })
 

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -102,13 +102,12 @@ app.pipe.register('device-manager:device:attach-tenant:after', async ({ index, d
   if (device.body.metadata.enrichedByBeforeAttachTenant) {
     set(device, 'body.metadata.enrichedByAfterAttachTenant', true);
 
-
     await app.sdk.document.update(
       device.body.tenantId,
       'devices',
       device._id,
       device.body
-    )
+    );
   
   }
 

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -85,9 +85,10 @@ export class DeviceService {
       const enrichedDocuments = [];
 
       for (const deviceDocument of deviceDocuments) {
-        const response = await global.app.trigger(
-          'device-manager:device:attach-tenant:before',
-          { index: document.tenantId, device: deviceDocument }
+        const response = await global.app.trigger('device-manager:device:attach-tenant:before', {
+            index: document.tenantId,
+            device: deviceDocument
+          }
         );
 
         enrichedDocuments.push(response.device);
@@ -118,10 +119,10 @@ export class DeviceService {
       results.errors.concat(errors);
 
       for (const deviceDocument of enrichedDocuments) {
-        await global.app.trigger(
-          'device-manager:device:attach-tenant:after',
-          { index: document.tenantId, device: deviceDocument }
-        );
+        await global.app.trigger('device-manager:device:attach-tenant:after', {
+          index: document.tenantId,
+          device: deviceDocument
+        });
       }
     }
 

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -93,9 +93,8 @@ export class DeviceService {
           'device-manager:device:attach-tenant:before',
           { index: document.tenantId, device: deviceDocument }
         );
-        
-        const deviceData = response && response.device ? response.device : deviceDocument;
-        enrichedDocuments.push(deviceData);
+
+        enrichedDocuments.push(response.device);
       }
 
       const { errors, successes } = await this.writeToDatabase(
@@ -124,7 +123,7 @@ export class DeviceService {
 
       for (const deviceDocument of enrichedDocuments) {
         await global.app.trigger(
-          'device-manager:device:attach-tenant:before',
+          'device-manager:device:attach-tenant:after',
           { index: document.tenantId, device: deviceDocument }
         );
       }

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -86,9 +86,20 @@ export class DeviceService {
       }
 
       const deviceDocuments = this.formatDevicesContent(devices, document);
+      const enrichedDocuments = [];
+
+      for (const deviceDocument of deviceDocuments) {
+        const response = await global.app.trigger(
+          'device-manager:device:attach-tenant:before',
+          { index: document.tenantId, device: deviceDocument }
+        );
+        
+        const deviceData = response && response.device ? response.device : deviceDocument;
+        enrichedDocuments.push(deviceData);
+      }
 
       const { errors, successes } = await this.writeToDatabase(
-        deviceDocuments,
+        enrichedDocuments,
         async (result: DeviceMRequestContent[]): Promise<JSONObject> => {
           const updated = await this.sdk.document.mUpdate(
             this.config.adminIndex,
@@ -110,6 +121,13 @@ export class DeviceService {
 
       results.successes.concat(successes);
       results.errors.concat(errors);
+
+      for (const deviceDocument of enrichedDocuments) {
+        await global.app.trigger(
+          'device-manager:device:attach-tenant:before',
+          { index: document.tenantId, device: deviceDocument }
+        );
+      }
     }
 
     return results;


### PR DESCRIPTION

## Events

Two events when this action is called, allowing to modify the device before it is attached to tenant:

```js
app.pipe.register('device-manager:device:attach-tenant:before', async ({ index, device }) => {
  app.log.debug('before attach-tenant trigered');
  set(device, 'body.metadata.enrichedByBeforeAttachTenant', true);
  return { index, device };
})
app.pipe.register('device-manager:device:attach-tenant:after', async ({ index, device }) => {
  app.log.debug('after attach-tenant trigered');
  return { index, device };
})
```