### PR TITLE
[events] Add before/after events on asset:update

### DIFF
--- a/doc/1/controllers/asset/update/index.md
+++ b/doc/1/controllers/asset/update/index.md
@@ -94,3 +94,35 @@ Returns information about the updated asset:
   }
 }
 ```
+
+## Events
+
+Two events are triggered by this action, that can be used as follow:
+
+```js
+app.pipe.register('device-manager:asset:update:before', async ({ asset, updates }) => {
+  app.log.debug('before asset update triggered');
+
+  set(updates, 'metadata.enrichedByBeforeAssetUpdate', true);
+
+  return { asset, updates };
+})
+
+app.pipe.register('device-manager:asset:update:after', async ({ asset, updates }) => {
+  app.log.debug('after asset update triggered');
+
+  if (updates.metadata.enrichedByBeforeAssetUpdate) {
+    set(updates, 'metadata.enrichedByAfterAssetUpdate', true);
+
+    await app.sdk.document.update(
+      updates.metadata.index,
+      'assets',
+      asset._id,
+      updates,
+    )
+  }
+
+  return { asset, updates };
+})
+
+```

--- a/features/AssetController.feature
+++ b/features/AssetController.feature
@@ -11,18 +11,37 @@ Feature: Device Manager asset controller
       | index                | "tenant-kuzzle"         |
       | _id                  | "outils-PERFO-asset_01" |
       | body.metadata.foobar | 42                      |
+      | body.metadata.index  | "tenant-kuzzle"         |
     And I successfully execute the action "device-manager/asset":"delete" with args:
       | index | "tenant-kuzzle"         |
       | _id   | "outils-PERFO-asset_01" |
     Then The document "tenant-kuzzle":"assets":"outils-PERFO-asset_01" does not exists
 
+  Scenario: Create, update and modify with events before/after
+    When I successfully execute the action "device-manager/asset":"create" with args:
+      | index          | "tenant-kuzzle" |
+      | body.type      | "outils"        |
+      | body.model     | "PERFO"         |
+      | body.reference | "asset_01"      |
+    Then The document "tenant-kuzzle":"assets":"outils-PERFO-asset_01" exists
+    When I successfully execute the action "device-manager/asset":"update" with args:
+      | index                | "tenant-kuzzle"         |
+      | _id                  | "outils-PERFO-asset_01" |
+      | body.metadata.foobar | 42                      |
+      | body.metadata.index  | "tenant-kuzzle"         |
+    And The document "tenant-kuzzle":"assets":"outils-PERFO-asset_01" content match:
+      | metadata.enrichedByBeforeAssetUpdate | true |
+    And The document "tenant-kuzzle":"assets":"outils-PERFO-asset_01" content match:
+      | metadata.enrichedByAfterAssetUpdate | true |
+
+
   Scenario: Import assets using csv
     When I successfully execute the action "device-manager/asset":"importAssets" with args:
-      | index    | "tenant-kuzzle"                                       |
+      | index    | "tenant-kuzzle"                                |
       | body.csv | "reference,model,type\\nimported,PERFO,outils" |
     Then I successfully execute the action "collection":"refresh" with args:
       | index      | "tenant-kuzzle" |
-      | collection | "assets"         |
+      | collection | "assets"        |
     Then The document "tenant-kuzzle":"assets":"outils-PERFO-imported" content match:
       | reference | "imported" |
       | model     | "PERFO"    |

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -88,6 +88,31 @@ app.pipe.register('device-manager:device:link-asset:after', async ({ device, ass
   return { device, asset };
 })
 
+app.pipe.register('device-manager:asset:update:before', async ({ asset, updates }) => {
+  app.log.debug('before asset update triggered');
+
+  set(updates, 'metadata.enrichedByBeforeAssetUpdate', true);
+
+  return { asset, updates };
+})
+
+app.pipe.register('device-manager:asset:update:after', async ({ asset, updates }) => {
+  app.log.debug('after asset update triggered');
+
+  if (updates.metadata.enrichedByBeforeAssetUpdate) {
+    set(updates, 'metadata.enrichedByAfterAssetUpdate', true);
+
+    await app.sdk.document.update(
+      updates.metadata.index,
+      'assets',
+      asset._id,
+      updates,
+    )
+  }
+
+  return { asset, updates };
+})
+
 app.plugin.use(deviceManager);
 
 app.hook.register('request:onError', async (request: KuzzleRequest) => {

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -72,8 +72,7 @@ export class AssetController extends CRUDController {
     request.input.body = response.updates;
     const result = await super.update(request);
 
-    await global.app.trigger(
-      'device-manager:asset:update:after', {
+    await global.app.trigger('device-manager:asset:update:after', {
       asset,
       updates: result._source,
     });

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -53,6 +53,34 @@ export class AssetController extends CRUDController {
     };
   }
 
+  async update (request: KuzzleRequest) {
+    const id = request.getId();
+    const index = request.getIndex();
+    const body = request.getBody();
+    const asset = await this.sdk.document.get(
+      index,
+      this.collection,
+      id
+    );
+
+    const response = await global.app.trigger(
+      'device-manager:asset:update:before', {
+      asset,
+      updates: body,
+    });
+
+    request.input.body = response.updates;
+    const result = await super.update(request);
+
+    await global.app.trigger(
+      'device-manager:asset:update:after', {
+      asset,
+      updates: result._source,
+    });
+
+    return result;
+  }
+
   async create (request: KuzzleRequest) {
     const type = request.getBodyString('type');
     const model = request.getBodyString('model');

--- a/lib/controllers/CRUDController.ts
+++ b/lib/controllers/CRUDController.ts
@@ -9,8 +9,10 @@ import { DeviceManagerConfig } from '../DeviceManagerPlugin';
 export class CRUDController {
   protected context: PluginContext;
   protected config: DeviceManagerConfig;
-  private collection: string;
+  protected collection: string;
   public definition: ControllerDefinition;
+
+
 
   constructor (plugin: Plugin, collection: string) {
     this.config = plugin.config as any;


### PR DESCRIPTION
## Events

Two events are triggered by this action, that can be used as follow:

```js
app.pipe.register('device-manager:asset:update:before', async ({ asset, updates }) => {
  app.log.debug('before asset update triggered');

  set(updates, 'metadata.enrichedByBeforeAssetUpdate', true);

  return { asset, updates };
})

app.pipe.register('device-manager:asset:update:after', async ({ asset, updates }) => {
  app.log.debug('after asset update triggered');

  if (updates.metadata.enrichedByBeforeAssetUpdate) {
    set(updates, 'metadata.enrichedByAfterAssetUpdate', true);

    await app.sdk.document.update(
      updates.metadata.index,
      'assets',
      asset._id,
      updates,
    )
  }

  return { asset, updates };
})
```