### PR TITLE
Fix passing options containing potential ID

### DIFF
--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -75,13 +75,13 @@ export class DeviceService {
             this.config.adminIndex,
             'devices',
             deviceDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           await this.sdk.document.mCreate(
             document.tenantId,
             'devices',
             deviceDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
             return {
               successes: results.successes.concat(updated.successes),
@@ -146,13 +146,13 @@ export class DeviceService {
           this.config.adminIndex,
           'devices',
           deviceDocuments,
-          { strict, ...options });
+          { strict, refresh: options.refresh });
 
           await this.sdk.document.mDelete(
             document.tenantId,
             'devices',
             deviceDocuments.map(device => device._id),
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           return {
             successes: results.successes.concat(updated.successes),
@@ -225,13 +225,13 @@ export class DeviceService {
             this.config.adminIndex,
             'devices',
             deviceDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           await this.sdk.document.mUpdate(
             document.tenantId,
             'devices',
             deviceDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           return {
             successes: results.successes.concat(updated.successes),
@@ -246,7 +246,7 @@ export class DeviceService {
             document.tenantId,
             'assets',
             assetDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           return {
             successes: results.successes.concat(updated.successes),
@@ -308,13 +308,13 @@ export class DeviceService {
             this.config.adminIndex,
             'devices',
             deviceDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           await this.sdk.document.mUpdate(
             document.tenantId,
             'devices',
             deviceDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           return {
             successes: results.successes.concat(updated.successes),
@@ -330,7 +330,7 @@ export class DeviceService {
             document.tenantId,
             'assets',
             assetDocuments,
-            { strict, ...options });
+            { strict, refresh: options.refresh });
 
           return {
             successes: results.successes.concat(updated.successes),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Manage your IoT devices and assets. Choose a provisionning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {


### PR DESCRIPTION
## Description

The entire `options` object was given to `mCreate` and `mUpdate` methods and it could contains `_id` or other arguments than were also passed to Kuzzle 