### PR TITLE
Add API action te retrieve measures linked to an asset

### DIFF
--- a/features/AssetController.feature
+++ b/features/AssetController.feature
@@ -27,3 +27,31 @@ Feature: Device Manager asset controller
     Then The document "engine-kuzzle":"assets":"outils-PERFO-imported" content match:
       | reference | "imported" |
       | model     | "PERFO"    |
+
+  Scenario: Retrieve asset measures history
+    Given I successfully receive a "dummy-temp" payload with:
+      | deviceEUI    | "attached_ayse_linked" |
+      | register55   | 42.2                   |
+      | batteryLevel | 0.4                    |
+    Given I successfully receive a "dummy-temp" payload with:
+      | deviceEUI    | "attached_ayse_linked" |
+      | register55   | 21.1                   |
+      | batteryLevel | 0.4                    |
+    Given I successfully receive a "dummy-temp" payload with:
+      | deviceEUI    | "attached_ayse_linked" |
+      | register55   | 11.3                   |
+      | batteryLevel | 0.4                    |
+    Given I refresh the collection "engine-ayse":"measures"
+    When I successfully execute the action "device-manager/asset":"measures" with args:
+      | engineId | "engine-ayse"       |
+      | _id      | "tools-MART-linked" |
+      | size     | 5                   |
+    # there is 6 measures with the 3 from fixtures
+    Then I should receive a "measures" array of objects matching:
+      | _source.origin.assetId | _source.origin.id                |
+      | "tools-MART-linked"    | "DummyTemp-attached_ayse_linked" |
+      | "tools-MART-linked"    | "DummyTemp-attached_ayse_linked" |
+      | "tools-MART-linked"    | "DummyTemp-attached_ayse_linked" |
+      | "tools-MART-linked"    | "DummyTemp-attached_ayse_linked" |
+      | "tools-MART-linked"    | "DummyTemp-attached_ayse_linked" |
+

--- a/features/DeviceController/LinkAsset.feature
+++ b/features/DeviceController/LinkAsset.feature
@@ -16,7 +16,6 @@ Feature: LinkAsset
       | measures[0].values.temperature | 23.3                               |
       | measures[0].origin.id          | "DummyTemp-attached_ayse_unlinked" |
       | measures[0].origin.model       | "DummyTemp"                        |
-      | measures[0].origin.reference   | "attached_ayse_unlinked"           |
       | measures[0].origin.type        | "device"                           |
       | measures[0].unit.name          | "Degree"                           |
       | measures[0].unit.sign          | "°"                                |
@@ -27,7 +26,6 @@ Feature: LinkAsset
       | measures[1].values.battery     | 80                                 |
       | measures[1].origin.id          | "DummyTemp-attached_ayse_unlinked" |
       | measures[1].origin.model       | "DummyTemp"                        |
-      | measures[1].origin.reference   | "attached_ayse_unlinked"           |
       | measures[1].origin.type        | "device"                           |
       | measures[1].unit.name          | "Volt"                             |
       | measures[1].unit.sign          | "v"                                |
@@ -68,7 +66,6 @@ Feature: LinkAsset
       | measures[0].values.temperature | 23.3                               |
       | measures[0].origin.id          | "DummyTemp-attached_ayse_unlinked" |
       | measures[0].origin.model       | "DummyTemp"                        |
-      | measures[0].origin.reference   | "attached_ayse_unlinked"           |
       | measures[0].origin.type        | "device"                           |
       | measures[0].unit.name          | "Degree"                           |
       | measures[0].unit.sign          | "°"                                |
@@ -78,7 +75,6 @@ Feature: LinkAsset
       | measures[1].values.battery     | 80                                 |
       | measures[1].origin.id          | "DummyTemp-attached_ayse_unlinked" |
       | measures[1].origin.model       | "DummyTemp"                        |
-      | measures[1].origin.reference   | "attached_ayse_unlinked"           |
       | measures[1].origin.type        | "device"                           |
       | measures[1].unit.name          | "Volt"                             |
       | measures[1].unit.sign          | "v"                                |
@@ -97,7 +93,6 @@ Feature: LinkAsset
       | measures[0].values.temperature | 23.3                               |
       | measures[0].origin.id          | "DummyTemp-attached_ayse_unlinked" |
       | measures[0].origin.model       | "DummyTemp"                        |
-      | measures[0].origin.reference   | "attached_ayse_unlinked"           |
       | measures[0].origin.type        | "device"                           |
       | measures[0].unit.name          | "Degree"                           |
       | measures[0].unit.sign          | "°"                                |
@@ -107,7 +102,6 @@ Feature: LinkAsset
       | measures[1].values.battery     | 80                                 |
       | measures[1].origin.id          | "DummyTemp-attached_ayse_unlinked" |
       | measures[1].origin.model       | "DummyTemp"                        |
-      | measures[1].origin.reference   | "attached_ayse_unlinked"           |
       | measures[1].origin.type        | "device"                           |
       | measures[1].unit.name          | "Volt"                             |
       | measures[1].unit.sign          | "v"                                |

--- a/features/DeviceController/UnlinkAsset.feature
+++ b/features/DeviceController/UnlinkAsset.feature
@@ -47,7 +47,6 @@ Feature: UnlinkAsset
       | measures[0].values.temperature  | 23.3                               |
       | measures[0].origin.id           | "DummyTemp-attached_ayse_unlinked" |
       | measures[0].origin.model        | "DummyTemp"                        |
-      | measures[0].origin.reference    | "attached_ayse_unlinked"           |
       | measures[0].origin.type         | "device"                           |
       | measures[0].unit.name           | "Degree"                           |
       | measures[0].unit.sign           | "°"                                |
@@ -57,7 +56,6 @@ Feature: UnlinkAsset
       | measures[1].values.battery      | 80                                 |
       | measures[1].origin.id           | "DummyTemp-attached_ayse_unlinked" |
       | measures[1].origin.model        | "DummyTemp"                        |
-      | measures[1].origin.reference    | "attached_ayse_unlinked"           |
       | measures[1].origin.type         | "device"                           |
       | measures[1].unit.name           | "Volt"                             |
       | measures[1].unit.sign           | "v"                                |
@@ -69,7 +67,6 @@ Feature: UnlinkAsset
       | measures[2].values.accuracy     | 42                                 |
       | measures[2].origin.id           | "DummyTemp-detached"               |
       | measures[2].origin.model        | "DummyTemp"                        |
-      | measures[2].origin.reference    | "detached"                         |
       | measures[2].origin.type         | "device"                           |
       | measures[2].unit.name           | "GPS"                              |
       | measures[2].unit.type           | "geo_point"                        |
@@ -87,7 +84,6 @@ Feature: UnlinkAsset
       | measures[0].values.accuracy     | 42                   |
       | measures[0].origin.id           | "DummyTemp-detached" |
       | measures[0].origin.model        | "DummyTemp"          |
-      | measures[0].origin.reference    | "detached"           |
       | measures[0].origin.type         | "device"             |
       | measures[0].unit.name           | "GPS"                |
       | measures[0].unit.type           | "geo_point"          |

--- a/features/PayloadController.feature
+++ b/features/PayloadController.feature
@@ -13,7 +13,6 @@ Feature: Payloads Controller
       | measures[0].values.temperature | 23.3              |
       | measures[0].origin.id          | "DummyTemp-12345" |
       | measures[0].origin.model       | "DummyTemp"       |
-      | measures[0].origin.reference   | "12345"           |
       | measures[0].origin.type        | "device"          |
       | measures[0].unit.name          | "Degree"          |
       | measures[0].unit.sign          | "°"               |
@@ -23,7 +22,6 @@ Feature: Payloads Controller
       | measures[1].values.battery     | 80                |
       | measures[1].origin.id          | "DummyTemp-12345" |
       | measures[1].origin.model       | "DummyTemp"       |
-      | measures[1].origin.reference   | "12345"           |
       | measures[1].origin.type        | "device"          |
       | measures[1].unit.name          | "Volt"            |
       | measures[1].unit.sign          | "v"               |
@@ -81,8 +79,8 @@ Feature: Payloads Controller
       | measures[0].values.temperature  | 23.3                      |
       | measures[0].origin.id           | "DummyTempPosition-12345" |
       | measures[0].origin.model        | "DummyTempPosition"       |
-      | measures[0].origin.reference    | "12345"                   |
       | measures[0].origin.type         | "device"                  |
+      | measures[0].origin.assetId      | null                      |
       | measures[0].unit.name           | "Degree"                  |
       | measures[0].unit.sign           | "°"                       |
       | measures[0].unit.type           | "number"                  |
@@ -93,7 +91,6 @@ Feature: Payloads Controller
       | measures[1].values.accuracy     | 2100                      |
       | measures[1].origin.id           | "DummyTempPosition-12345" |
       | measures[1].origin.model        | "DummyTempPosition"       |
-      | measures[1].origin.reference    | "12345"                   |
       | measures[1].origin.type         | "device"                  |
       | measures[1].unit.name           | "GPS"                     |
       | measures[1].unit.sign           | "_NULL_"                  |
@@ -103,7 +100,6 @@ Feature: Payloads Controller
       | measures[2].values.battery      | 80                        |
       | measures[2].origin.id           | "DummyTempPosition-12345" |
       | measures[2].origin.model        | "DummyTempPosition"       |
-      | measures[2].origin.reference    | "12345"                   |
       | measures[2].origin.type         | "device"                  |
       | measures[2].unit.name           | "Volt"                    |
       | measures[2].unit.sign           | "v"                       |
@@ -152,7 +148,6 @@ Feature: Payloads Controller
       | measures[0].values.temperature | 42.2                             |
       | measures[0].origin.id          | "DummyTemp-attached_ayse_linked" |
       | measures[0].origin.model       | "DummyTemp"                      |
-      | measures[0].origin.reference   | "attached_ayse_linked"           |
       | measures[0].origin.type        | "device"                         |
       | measures[0].unit.name          | "Degree"                         |
       | measures[0].unit.sign          | "°"                              |
@@ -162,7 +157,7 @@ Feature: Payloads Controller
       | measures[1].values.battery     | 40                               |
       | measures[1].origin.id          | "DummyTemp-attached_ayse_linked" |
       | measures[1].origin.model       | "DummyTemp"                      |
-      | measures[1].origin.reference   | "attached_ayse_linked"           |
+      | measures[1].origin.assetId     | "tools-MART-linked"              |
       | measures[1].origin.type        | "device"                         |
       | measures[1].unit.name          | "Volt"                           |
       | measures[1].unit.sign          | "v"                              |
@@ -177,14 +172,15 @@ Feature: Payloads Controller
 
   Scenario: Historize the measures
     When I successfully receive a "dummy-temp" payload with:
-      | deviceEUI    | "attached_ayse_unlinked" |
-      | register55   | 42.2                     |
-      | batteryLevel | 0.4                      |
+      | deviceEUI    | "attached_ayse_linked" |
+      | register55   | 42.2                   |
+      | batteryLevel | 0.4                    |
     And I refresh the collection "engine-ayse":"measures"
     Then When I successfully execute the action "document":"search" with args:
       | index      | "engine-ayse" |
       | collection | "measures"    |
     And I should receive a "hits" array of objects matching:
-      | _source.type  |
-      | "temperature" |
-      | "battery"     |
+      | _source.type  | _source.origin.assetId |
+      | "temperature" | "tools-MART-linked"    |
+      | "battery"     | "tools-MART-linked"    |
+

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -17,7 +17,6 @@ const dummyTempAttachedAyseUnLinked = {
         id: 'DummyTemp-attached_ayse_unlinked',
         type: 'device',
         model: 'DummyTemp',
-        reference: 'attached_ayse_unlinked',
         payloadUuids: ['some-uuid'],
       }
     },
@@ -36,7 +35,6 @@ const dummyTempAttachedAyseUnLinked = {
         id: 'DummyTemp-attached_ayse_unlinked',
         type: 'device',
         model: 'DummyTemp',
-        reference: 'attached_ayse_unlinked',
         payloadUuids: ['some-uuid'],
       }
     }
@@ -64,7 +62,6 @@ const dummyTempAttachedAyseUnLinked2 = {
         id: 'DummyTemp-attached_ayse_unlinked_2',
         type: 'device',
         model: 'DummyTemp',
-        reference: 'attached_ayse_unlinked_2',
         payloadUuids: ['some-uuid'],
       }
     },
@@ -83,7 +80,6 @@ const dummyTempAttachedAyseUnLinked2 = {
         id: 'DummyTemp-attached_ayse_unlinked_2',
         type: 'device',
         model: 'DummyTemp',
-        reference: 'attached_ayse_unlinked_2',
         payloadUuids: ['some-uuid'],
       }
     }
@@ -110,8 +106,8 @@ const measuresAttachedAyseLinked = [
       id: 'DummyTemp-attached_ayse_linked',
       type: 'device',
       model: 'DummyTemp',
-      reference: 'attached_ayse_linked',
       payloadUuids: ['some-uuid'],
+      assetId: 'tools-MART-linked',
     }
   },
   {
@@ -130,8 +126,8 @@ const measuresAttachedAyseLinked = [
       id: 'DummyTemp-attached_ayse_linked',
       type: 'device',
       model: 'DummyTemp',
-      reference: 'attached_ayse_linked',
       payloadUuids: ['some-uuid'],
+      assetId: 'tools-MART-linked',
     }
   }
 ];
@@ -173,7 +169,6 @@ module.exports = {
               id: 'DummyTemp-detached',
               type: 'device',
               model: 'DummyTemp',
-              reference: 'detached',
               payloadUuids: ['some-uuid'],
             }
           }

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -81,12 +81,18 @@ Before({ timeout: 30 * 1000 }, async function () {
     truncateCollection(this.sdk, 'tests', 'events'),
   ]);
 
-  await this.sdk.query({
-    controller: 'admin',
-    action: 'loadFixtures',
-    refresh: 'false',
-    body: defaultFixtures,
-  });
+  try {
+    await this.sdk.query({
+      controller: 'admin',
+      action: 'loadFixtures',
+      refresh: 'false',
+      body: defaultFixtures,
+    });
+  }
+  catch (error) {
+    console.dir(error, { depth: 10 });
+    throw error;
+  }
 });
 
 After(async function () {

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -21,6 +21,7 @@ export class AssetController extends CRUDController {
 
     this.assetService = assetService;
 
+    /* eslint-disable sort-keys */
     this.definition = {
       actions: {
         create: {
@@ -52,6 +53,7 @@ export class AssetController extends CRUDController {
         }
       },
     };
+    /* eslint-enable sort-keys */
   }
 
   async measures (request: KuzzleRequest) {

--- a/lib/core-classes/AssetService.ts
+++ b/lib/core-classes/AssetService.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { PluginContext, Plugin, JSONObject, KDocument, BadRequestError, User } from 'kuzzle';
+import { PluginContext, Plugin, JSONObject, KDocument, BadRequestError } from 'kuzzle';
 
 import { mRequest, mResponse, writeToDatabase } from '../utils/writeMany';
 import { BaseAsset } from '../models/BaseAsset';

--- a/lib/core-classes/AssetService.ts
+++ b/lib/core-classes/AssetService.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { PluginContext, Plugin, JSONObject } from 'kuzzle';
+import { PluginContext, Plugin, JSONObject, KDocument, BadRequestError, User } from 'kuzzle';
 
 import { mRequest, mResponse, writeToDatabase } from '../utils/writeMany';
 import { BaseAsset } from '../models/BaseAsset';
-import { BaseAssetContent, DeviceManagerConfiguration } from '../types';
+import { BaseAssetContent, DeviceManagerConfiguration, MeasureContent } from '../types';
 
 export class AssetService {
   private config: DeviceManagerConfiguration;
@@ -16,6 +16,50 @@ export class AssetService {
   constructor(plugin: Plugin) {
     this.config = plugin.config as any;
     this.context = plugin.context;
+  }
+
+  /**
+   * Returns measures history for an asset
+   *
+   * @param engineId Engine ID
+   * @param assetId Asset ID
+   * @param options.size Number of measures to return
+   * @param options.startAt Returns measures starting from this date (ISO8601)
+   * @param options.endAt Returns measures until this date (ISO8601)
+   */
+  async measureHistory (
+    engineId: string,
+    assetId: string,
+    { size=25, startAt, endAt }: { size?: number, startAt?: string, endAt?: string },
+  ): Promise<KDocument<MeasureContent>[]> {
+    await this.getAsset(engineId, assetId);
+
+    const query = {
+      range: {
+        measuredAt: {
+          gte: 0,
+          lte: Number.MAX_SAFE_INTEGER,
+        }
+      }
+    };
+
+    if (startAt) {
+      query.range.measuredAt.gte = this.iso8601(startAt, 'startAt').getTime();
+    }
+
+    if (endAt) {
+      query.range.measuredAt.lte = this.iso8601(startAt, 'endAt').getTime();
+    }
+
+    const sort = { 'measuredAt': 'desc' };
+
+    const measures = await this.sdk.document.search<MeasureContent>(
+      engineId,
+      'measures',
+      { query, sort },
+      { size: size || 25 });
+
+    return measures.hits;
   }
 
   async importAssets(
@@ -56,5 +100,20 @@ export class AssetService {
     );
 
     return results;
+  }
+
+  private getAsset (engineId: string, assetId: string): Promise<KDocument<BaseAssetContent>> {
+    return this.sdk.document.get<BaseAssetContent>(engineId, 'assets', assetId);
+  }
+
+  // @todo remove when we have the date extractor in the core
+  private iso8601 (value: string, name: string): Date {
+    const parsed: any = new Date(value);
+
+    if (isNaN(parsed)) {
+      throw new BadRequestError(`"${name}" is not a valid ISO8601 date`);
+    }
+
+    return parsed;
   }
 }

--- a/lib/core-classes/Decoder.ts
+++ b/lib/core-classes/Decoder.ts
@@ -70,6 +70,9 @@ export abstract class Decoder {
   /**
    * @param deviceModel Device model for this decoder
    * @param deviceMeasures Devices measure types for this decoder
+   *
+   * @example
+   * super('AbeewayGPS', ['position']);
    */
   constructor (deviceModel: string, deviceMeasures: string[]) {
     this.deviceModel = deviceModel;
@@ -97,7 +100,6 @@ export abstract class Decoder {
    * Decode the payload:
    *  - set "reference"
    *  - fetch measures
-   *  - fetch qos
    *
    * @param payload Raw payload received in the API action body
    * @param request Original request

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -84,10 +84,10 @@ export class PayloadService {
       newMeasures.push({
         measuredAt: measure.measuredAt,
         origin: {
+          assetId: null,
           id: deviceId,
           model: decoder.deviceModel,
           payloadUuids: [uuid],
-          reference: decodedPayload.reference,
           type: 'device',
         },
         type,
@@ -103,6 +103,12 @@ export class PayloadService {
         deviceId);
 
       const device = new Device(deviceDoc._source);
+
+      if (device._source.assetId) {
+        for (const measure of newMeasures) {
+          measure.origin.assetId = device._source.assetId;
+        }
+      }
 
       return await this.update(device, newMeasures, { refresh });
     }

--- a/lib/mappings/measuresMappings.ts
+++ b/lib/mappings/measuresMappings.ts
@@ -1,8 +1,9 @@
+/* eslint-disable sort-keys */
+
 export const measuresMappings = {
   dynamic: 'strict',
   properties: {
-
-    measuredAt: { type: 'float' },
+    measuredAt: { type: 'double' },
 
     /**
      * A device may have different measures for the same type (e.g. measure temperature 2 times)
@@ -11,25 +12,23 @@ export const measuresMappings = {
     name: { type: 'keyword' },
 
     origin: {
+      type: 'nested',
+
       properties: {
         // ID of the device (document _id)
         id: { type: 'keyword' },
 
-
         // E.g. "AbeewayTemp"
         model: { type: 'keyword' },
-
 
         // Array of payload uuids that were used to create this measure.
         payloadUuids: { type: 'keyword' },
 
-
-        // Reference of the data source (e.g. a device manufacturer ID)
-        reference: { type: 'keyword' },
-
-
         // E.g. "device"
         type: { type: 'keyword' },
+
+        // Asset linked to the device when the measure was made
+        assetId: { type: 'keyword' },
       }
     },
 
@@ -45,17 +44,14 @@ export const measuresMappings = {
      * Measure self-description
      */
     unit: {
-      properties: {
-        name: { type: 'keyword' },
-
-        sign: { type: 'keyword' },
-
-        type: { type: 'keyword' },
-      }
+      dynamic: 'false',
+      properties: {}
     },
 
     values: {
       properties: {},
-    }
+    },
   }
 };
+
+/* eslint-enable sort-keys */

--- a/lib/measures/MovementMeasure.ts
+++ b/lib/measures/MovementMeasure.ts
@@ -2,9 +2,9 @@ import { Measurement, MeasureDefinition } from '../types';
 
 /* eslint-disable sort-keys */
 
-export interface MovementMeasure extends Measurement {
+export interface MovementMeasurement extends Measurement {
   values: {
-    movement: number;
+    movement: boolean;
   }
 }
 

--- a/lib/types/DecodedPayload.ts
+++ b/lib/types/DecodedPayload.ts
@@ -1,5 +1,34 @@
 import { Measurement } from './measures/Measurement';
 
+/**
+ * Result of the `Decoder.decode` method.
+ *
+ * Contains the decoded measures.
+ *
+ * @example
+ *
+ *  const decodedPayload: DecodedPayload = {
+ *    reference: 'BZH42AZF',
+ *    measures: {
+ *      temperature: {
+ *        measuredAt: Date.now(),
+ *        values: {
+ *          temperature: 23.8,
+ *        }
+ *      },
+ *      position: {
+ *        measuredAt: Date.now(),
+ *        values: {
+ *          position: {
+ *            lat: 21.297,
+ *            lon: 4.8421,
+ *          },
+ *          accuracy: 100,
+ *        }
+ *      },
+ *    },
+ *  };
+ */
 export interface DecodedPayload {
   /**
    * Device unique reference

--- a/lib/types/measures/MeasureContent.ts
+++ b/lib/types/measures/MeasureContent.ts
@@ -55,15 +55,13 @@ export interface MeasureContent extends KDocumentContent {
     model: string;
 
     /**
-     * Reference of the data source (e.g. a device manufacturer ID)
-     */
-    reference: string;
-
-    /**
      * Array of payload uuids that were used to create this measure.
      */
     payloadUuids: string[];
-  };
 
-  // @todo Add assetId if an asset was linked to the device when the measure was done
+    /**
+     * Asset ID linked to the device when the measure was made
+     */
+    assetId?: string;
+  };
 }


### PR DESCRIPTION
## Description

When a measure is made, the device may be linked to an asset. We might want to find an asset measure history across many devices so we need to keep a property containing the `assetId`.

This PR save the `assetId` in the measure document and expose a new API action to retrieve measures history for an asset: `device-manager/asset:measures`