### PR TITLE
measures name in link between assets and devices

### DIFF
--- a/features/DeviceController/LinkAsset.feature
+++ b/features/DeviceController/LinkAsset.feature
@@ -30,7 +30,7 @@ Feature: LinkAsset
       | measures[1].unit.name          | "Volt"                             |
       | measures[1].unit.sign          | "v"                                |
       | measures[1].unit.type          | "number"                           |
-      | deviceIds[0]                   | "DummyTemp-attached_ayse_unlinked" |
+      | deviceLinks[0].deviceId        | "DummyTemp-attached_ayse_unlinked" |
 
   Scenario: Link device to an asset and enriching the asset with before event
     When I successfully execute the action "device-manager/device":"linkAsset" with args:

--- a/features/DeviceController/MultipleLink.feature
+++ b/features/DeviceController/MultipleLink.feature
@@ -1,0 +1,22 @@
+Feature: multipleLink
+
+    Scenario: Link two devices to an asset
+      When I successfully execute the action "device-manager/device":"linkAsset" with args:
+        | _id                            | "DummyTemp-attached_ayse_unlinked" |
+        | assetId                        | "tools-MART-linked"                |
+        | body.measuresNames.temperature | "External temperature"             |
+        | body.measuresNames.battery     | "Battery2"                         |
+      Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
+        | assetId | "tools-MART-linked" |
+      And The document "engine-ayse":"devices":"DummyTemp-attached_ayse_unlinked" content match:
+        | assetId | "tools-MART-linked" |
+      And The document "engine-ayse":"assets":"tools-MART-linked" content match:
+        | measures[0].type               | "temperature"                      |
+        | measures[1].type               | "battery"                          |
+        | measures[2].type               | "temperature"                      |
+        | measures[3].type               | "battery"                          |
+        | measures[0].name               | "External temperature"             |
+        | measures[1].name               | "Battery2"                         |
+        | measures[2].name               | "temperature"                      |
+        | measures[3].name               | "battery"                          |
+

--- a/features/DeviceController/UnlinkAsset.feature
+++ b/features/DeviceController/UnlinkAsset.feature
@@ -11,14 +11,14 @@ Feature: UnlinkAsset
       | _id     | "DummyTemp-attached_ayse_unlinked" |
       | assetId | "tools-PERFO-unlinked"             |
     When I successfully execute the action "device-manager/device":"mUnlinkAssets" with args:
-      | body.records.0.deviceId | "DummyTemp-attached_ayse_unlinked" |
+      | body.records.0.deviceId | "DummyTemp-attached_ayse_unlinked" |  
     Then The document "device-manager":"devices":"DummyTemp-attached_ayse_unlinked" content match:
       | assetId | null |
     Then The document "engine-ayse":"devices":"DummyTemp-attached_ayse_unlinked" content match:
       | assetId | null |
     And The document "engine-ayse":"assets":"tools-PERFO-unlinked" content match:
       | measures   | {} |
-      | deviceIds  | [] |
+      | deviceLinks  | [] |
 
   Scenario: Unlink multiple device from multiple assets using CSV
     Given I successfully execute the action "device-manager/device":"linkAsset" with args:

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -201,6 +201,7 @@ module.exports = {
         model: 'PERFO',
         reference: 'unlinked',
         measures: [],
+        deviceLinks: [],
       },
       { index: { _id: 'tools-SCREW-unlinked' } },
       {
@@ -208,6 +209,7 @@ module.exports = {
         model: 'SCREW',
         reference: 'unlinked',
         measures: [],
+        deviceLinks: [],
       },
       { index: { _id: 'tools-MART-linked' } },
       {
@@ -215,6 +217,7 @@ module.exports = {
         model: 'MART',
         reference: 'linked',
         measures: measuresAttachedAyseLinked,
+        deviceLinks: [],
       }
     ]
   },

--- a/features/support/assertions.js
+++ b/features/support/assertions.js
@@ -5,8 +5,8 @@ should.Assertion.add(
   'matchObject',
   function (expected) {
     this.params = { operator: 'match object' };
-
     for (const [keyPath, expectedValue] of Object.entries(expected)) {
+
       const objectValue = _.get(this.obj, keyPath);
 
       if (expectedValue === '_ANY_') {
@@ -33,13 +33,13 @@ should.Assertion.add(
       else if (expectedValue === '_DATE_NOW_SEC_') {
         should(objectValue).be.approximately(Date.now() / 1000, 1000);
       }
-      else if (_.isPlainObject(objectValue)) {
+      else if (_.isPlainObject(expectedValue)) {
         should(objectValue).matchObject(
           expectedValue,
           `"${keyPath}" does not match. Expected "${JSON.stringify(expectedValue)}" have "${JSON.stringify(objectValue)}"`);
       }
-      else if (Array.isArray(objectValue)) {
-        for (let i = 0; i < objectValue.length; i++) {
+      else if (Array.isArray(expectedValue)) {
+        for (let i = 0; i < expectedValue.length; i++) {
           should(objectValue[i]).matchObject(
             expectedValue[i],
             `"${keyPath}[${i}]" does not match. Expected "${JSON.stringify(expectedValue[i])}" have "${JSON.stringify(objectValue[i])}"`);

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -111,6 +111,7 @@ export class AssetController extends CRUDController {
 
     request.input.args.index = request.getString('engineId');
     request.input.body.measures = [];
+    request.input.body.deviceLinks = [];
 
     return super.create(request);
   }

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -138,10 +138,10 @@ export class AssetController extends CRUDController {
     const assetId = request.getId();
     const refresh = request.getRefresh();
     const strict = request.getBoolean('strict');
-    const devices = (await this.assetService.getAsset(engineId, assetId))._source.deviceIds;
-    if(Array.isArray(devices)) {
-      for(const device of devices) {
-        await this.deviceService.unlinkAsset(device, { refresh, strict });
+    const devicesLinks = (await this.assetService.getAsset(engineId, assetId))._source.deviceLinks;
+    if(Array.isArray(devicesLinks)) {
+      for(const deviceLink of devicesLinks) {
+        await this.deviceService.unlinkAsset(deviceLink.deviceId, { refresh, strict });
       }
     }
     return super.delete(request);

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -138,9 +138,9 @@ export class AssetController extends CRUDController {
     const assetId = request.getId();
     const refresh = request.getRefresh();
     const strict = request.getBoolean('strict');
-    const devicesLinks = (await this.assetService.getAsset(engineId, assetId))._source.deviceLinks;
-    if (Array.isArray(devicesLinks)) {
-      for (const deviceLink of devicesLinks) {
+    const devicesLinks = await this.assetService.getAsset(engineId, assetId);
+    if (Array.isArray(devicesLinks._source.deviceLinks)) {
+      for (const deviceLink of devicesLinks._source.deviceLinks) {
         await this.deviceService.unlinkAsset(deviceLink.deviceId, { refresh, strict });
       }
     }

--- a/lib/controllers/DeviceController.ts
+++ b/lib/controllers/DeviceController.ts
@@ -88,6 +88,7 @@ export class DeviceController extends CRUDController {
 
     const deviceContent: DeviceContent = {
       measures: [],
+      measuresName: [],
       metadata,
       model,
       reference,

--- a/lib/core-classes/AssetService.ts
+++ b/lib/core-classes/AssetService.ts
@@ -103,19 +103,4 @@ export class AssetService {
     }
     return parsed;
   }
-
-
-  async getDeviceByAsset(assetId :string) {
-    const filter = {
-      'query': {
-        'term': {
-          'assetId': {
-            'value': assetId
-          }
-        }
-      }
-    } ;
-    return this.sdk.document.search('device-manager', 'devices', filter);
-  }
-
 }

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -257,10 +257,8 @@ export class DeviceService {
     asset._source.measures = measures;
     device._source.assetId = linkRequest.assetId;
 
-    if (! asset._source.deviceLinks) {
-      asset._source.deviceLinks = [];
-    }
-    asset._source.deviceLinks.push({ deviceId: linkRequest.deviceId, measuresName: listMeasures }); //TODO : gérer les measuresName
+
+    asset._source.deviceLinks.push({ deviceId: linkRequest.deviceId, measuresName: listMeasures }); 
     
     const response = await global.app.trigger(
       'device-manager:device:link-asset:before',

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import _ from 'lodash';
 
 import { BaseAsset, Device } from '../models';
-import { BaseAssetContent, MeasureContent, DeviceContent, DeviceManagerConfiguration } from '../types';
+import { BaseAssetContent, MeasureContent, DeviceContent, DeviceManagerConfiguration, MeasureName } from '../types';
 import { mRequest, mResponse, writeToDatabase } from '../utils/';
 
 export type DeviceBulkContent = {
@@ -235,10 +235,10 @@ export class DeviceService {
     });
 
   
-    const listMeasures = []; // contain name and type of each measure to keep this data in device element
+    const listMeasures: Array<MeasureName> = []; // contain name and type of each measure to keep this data in device element
     for(const measure of measures) {
       listMeasures.push({name : measure.name, type : measure.type});
-    }
+    } 
   
     const newMeasuresNames = measures.map(m => m.name);
         
@@ -361,8 +361,10 @@ export class DeviceService {
         engineId,
         'assets',
         asset._id,
-        { deviceLinks: response.asset._source.deviceLinks,
-          measures: response.asset._source.measures },
+        { 
+          deviceLinks: response.asset._source.deviceLinks,
+          measures: response.asset._source.measures 
+        },
         { refresh }),
     ]);
 

--- a/lib/core-classes/PayloadService.ts
+++ b/lib/core-classes/PayloadService.ts
@@ -16,7 +16,7 @@ import {
   DeviceContent,
   DeviceManagerConfiguration,
   BaseAssetContent,
-  MeasureName,
+  LinkedMeasureName,
 } from '../types';
 import { MeasuresRegister } from './registers/MeasuresRegister';
 import { DeviceManagerPlugin } from '../DeviceManagerPlugin';
@@ -145,9 +145,10 @@ export class PayloadService {
 
     const deviceId = Device.id(model, reference);
     const deviceContent: DeviceContent = {
-      measures,
-      model,
-      reference,
+      measures: measures,
+      measuresName: [],
+      model: model,
+      reference: reference,
     };
 
     return this.register(deviceId, deviceContent, { refresh });
@@ -285,7 +286,7 @@ export class PayloadService {
     engineId: string,
     newMeasures: MeasureContent[],
     assetId: string,
-    measuresNames: MeasureName[]
+    measuresNames: LinkedMeasureName[],
   ): Promise<BaseAsset> {
     // dup array reference
     const measureNameMap = new Map<string, string>();
@@ -314,7 +315,7 @@ export class PayloadService {
     // Keep previous measures that were not updated
     // array are updated in place so we need to keep previous elements
     for (const previousMeasure of asset._source.measures) {
-      if (! measures.find(m => (m.type === previousMeasure.type && m.name === previousMeasure.name ))) { 
+      if (! measures.find(m => (m.name === previousMeasure.name ))) {
         measures.push(previousMeasure);
       }
     }

--- a/lib/mappings/assetsMappings.ts
+++ b/lib/mappings/assetsMappings.ts
@@ -1,11 +1,31 @@
 export const assetsMappings = {
   dynamic: 'strict',
   properties: {
-    deviceIds: {
-      fields: {
-        text: { type: 'text' }
-      },
-      type: 'keyword'
+    deviceLinks: {
+      properties: {
+        deviceId: {
+          fields: {
+            text: { type: 'text' }
+          },
+          type: 'keyword'
+        },
+        measuresName: {
+          properties: {
+            name : {
+              fields: {
+                text: { type: 'text' }
+              },
+              type : 'keyword'
+            },
+            type : {
+              fields: {
+                text: { type: 'text' }
+              },
+              type : 'keyword'
+            }
+          }
+        }
+      }
     },
     measures: {
       properties: {

--- a/lib/mappings/deviceMappings.ts
+++ b/lib/mappings/deviceMappings.ts
@@ -6,7 +6,7 @@ export const devicesMappings = {
         text: { type: 'text' }
       },
       type: 'keyword'
-    },
+    },  
     engineId: {
       fields: {
         text: { type: 'text' }
@@ -16,6 +16,22 @@ export const devicesMappings = {
     measures: {
       properties: {
         // measures mappings will be injected by the plugin
+      }
+    },
+    measuresName: {
+      properties: {
+        name : {
+          fields: {
+            text: { type: 'text' }
+          },
+          type : 'keyword'
+        },
+        type : {
+          fields: {
+            text: { type: 'text' }
+          },
+          type : 'keyword'
+        }
       }
     },
     metadata: {

--- a/lib/types/BaseAssetContent.ts
+++ b/lib/types/BaseAssetContent.ts
@@ -2,11 +2,11 @@ import { JSONObject } from 'kuzzle';
 import { KDocumentContent } from 'kuzzle-sdk';
 
 import { MeasureContent } from './measures/MeasureContent';
-import { MeasureName } from './measures/MeasureDefinition';
+import { LinkedMeasureName } from './measures/MeasureDefinition';
 
 export interface DeviceLink {
   deviceId : string,
-  measuresName?: MeasureName[];
+  measuresName: LinkedMeasureName[];
 }
 
 /**

--- a/lib/types/BaseAssetContent.ts
+++ b/lib/types/BaseAssetContent.ts
@@ -2,6 +2,12 @@ import { JSONObject } from 'kuzzle';
 import { KDocumentContent } from 'kuzzle-sdk';
 
 import { MeasureContent } from './measures/MeasureContent';
+import { MeasureName } from './measures/MeasureDefinition';
+
+export interface DeviceLink {
+  deviceId : string,
+  measuresName?: MeasureName[];
+}
 
 /**
  * Asset document
@@ -17,5 +23,5 @@ export interface BaseAssetContent extends KDocumentContent {
 
   metadata?: JSONObject,
 
-  deviceIds?: string[]
+  deviceLinks?: DeviceLink[]
 }

--- a/lib/types/BaseAssetContent.ts
+++ b/lib/types/BaseAssetContent.ts
@@ -23,5 +23,5 @@ export interface BaseAssetContent extends KDocumentContent {
 
   metadata?: JSONObject,
 
-  deviceLinks?: DeviceLink[]
+  deviceLinks: DeviceLink[]
 }

--- a/lib/types/DeviceContent.ts
+++ b/lib/types/DeviceContent.ts
@@ -2,7 +2,7 @@ import { JSONObject } from 'kuzzle';
 import { KDocumentContent } from 'kuzzle-sdk';
 
 import { MeasureContent } from './measures/MeasureContent';
-import { MeasureName } from './measures/MeasureDefinition';
+import { LinkedMeasureName } from './measures/MeasureDefinition';
 
 
 export interface DeviceContent extends KDocumentContent {
@@ -35,7 +35,7 @@ export interface DeviceContent extends KDocumentContent {
   /**
    * correspondence table between measures types and names
    */
-  measuresName?: MeasureName[];
+  measuresName: LinkedMeasureName[];
 
   /**
    * Attached engine ID (index name)

--- a/lib/types/DeviceContent.ts
+++ b/lib/types/DeviceContent.ts
@@ -2,6 +2,8 @@ import { JSONObject } from 'kuzzle';
 import { KDocumentContent } from 'kuzzle-sdk';
 
 import { MeasureContent } from './measures/MeasureContent';
+import { MeasureName } from './measures/MeasureDefinition';
+
 
 export interface DeviceContent extends KDocumentContent {
   /**
@@ -29,6 +31,11 @@ export interface DeviceContent extends KDocumentContent {
    * Linked asset unique identifier
    */
   assetId?: string;
+
+  /**
+   * correspondence table between measures types and names
+   */
+  measuresName?: MeasureName[];
 
   /**
    * Attached engine ID (index name)

--- a/lib/types/measures/MeasureDefinition.ts
+++ b/lib/types/measures/MeasureDefinition.ts
@@ -43,3 +43,12 @@ export interface MeasureDefinition {
    */
    valuesMappings: JSONObject;
 }
+
+
+/**
+ * mapping between measure name and type (include in devices and assets)
+ */
+export interface MeasureName {
+  name : string;
+  type : string;
+}

--- a/lib/types/measures/MeasureDefinition.ts
+++ b/lib/types/measures/MeasureDefinition.ts
@@ -48,7 +48,7 @@ export interface MeasureDefinition {
 /**
  * mapping between measure name and type (include in devices and assets)
  */
-export interface MeasureName {
+export interface LinkedMeasureName {
   name : string;
   type : string;
 }


### PR DESCRIPTION
## What does this PR do ?
Add name to measures from devices in asset to attach multiple devices with same measures name in one asset.

### How should this be manually tested?
 - Create engine, one asset and two devices.
 - attach one device to the asset 
 - attach the other device with  "measuresNames" in the body
 - send payload from the two devices. 
 - check the asset state.
 

### Other changes

<!--
  Please outline any changes not directly linked to the main issue, but made because of it.
  For instance: on-the-fly fixes, dependencies updates and so on.
-->

### Boyscout

correct the "content match" step for tables. 
