### PR TITLE
add new metadata types, and correct some minor error

### DIFF
--- a/doc/2/controllers/asset-category/create/index.md
+++ b/doc/2/controllers/asset-category/create/index.md
@@ -1,0 +1,83 @@
+---
+code: true
+type: page
+title: create
+description: Creates a new asset-category
+---
+
+# create
+
+Creates a new asset-category inside a tenant index.
+
+Returns an error if the document already exists.
+
+See also the [document:create](/core/2/api/controllers/document/create) API action.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory[?refresh=wait_for]
+Method: POST
+Body:
+```
+
+```js
+{
+  // asset content
+  //Exemple :
+  {"name" : "myAsset"}
+}
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<index>",
+  "controller": "device-manager/assetCategory",
+  "action": "create",
+  "body": {
+    // asset content
+  }
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/assetCategory:create <engineId> --body '{ 
+  name: "<asset category name>"
+  }'
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine id
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created document is indexed
+---
+
+## Body properties
+
+Asset content to create.
+
+Assets must contains at least the following properties:
+- `name`: Asset category name.
+
+---
+
+## Response
+
+Returns an object with the following properties:
+
+- `_id`: created document unique identifier
+- `_source`: document content
+- `_version`: version of the created document (should be `1`)

--- a/doc/2/controllers/asset-category/delete/index.md
+++ b/doc/2/controllers/asset-category/delete/index.md
@@ -1,0 +1,60 @@
+---
+code: true
+type: page
+title: delete
+description: Deletes an asset-category
+---
+
+# delete
+
+Deletes an asset-category.
+
+See also the [document:delete](/core/2/api/controllers/document/delete) API action.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory/:_id[?refresh=wait_for][&source]
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<engineId>",
+  "controller": "device-manager/assetCategory",
+  "action": "delete",
+  "_id": "<assetCategoryId>"
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/assetCategory:delete <engineId> --id <assetCategoryId>
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine id
+- `_id`: id of element to delete
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the delete is indexed
+- `source`: if set to `true` Kuzzle will return the entire deleted document body in the response.
+
+---
+
+## Response
+
+Returns information about the deleted assetCategory:
+
+- `_id`: assetCategory unique identifier

--- a/doc/2/controllers/asset-category/get/index.md
+++ b/doc/2/controllers/asset-category/get/index.md
@@ -1,0 +1,80 @@
+---
+code: true
+type: page
+title: delete
+description: Deletes an asset-category
+---
+
+# get
+
+Get an asset-category.
+
+You can also use [document:get](/core/2/api/controllers/document/get) API action if you have proper rights, but if you use this specific controller, the data is preprocessed and easier to use.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory/:_id
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<engineId>",
+  "controller": "device-manager/assetCategory",
+  "action": "get",
+  "_id": "<assetCategoryId>"
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/assetCategory:get <engineId> --id <assetCategoryId>
+```
+
+---
+
+- `engineId`: engine id
+
+---
+
+## Response
+
+```js
+{
+    "action": "get",
+    "controller": "device-manager/assetCategory",
+    "error": null,
+    "headers": {},
+    "node": "knode-accessible-orwell-15416",
+    "requestId": "8fd1b8b5-1dfd-4fba-a12f-4b570622980e",
+    "result": {
+        "name": "myCategory",
+        "assetMetadata": [
+            {
+                "mandatory": true,
+                "name": "myMetadata",
+                "valueType": "string"
+            },
+            {
+                "mandatory": true,
+                "name": "myOtherMetadata",
+                "valueType": "string"
+            }
+        ],
+        "metadataValues": {
+            "myMetadata": "myValue"
+        }
+    },
+    "status": 200,
+    "volatile": null
+}
+```
+

--- a/doc/2/controllers/asset-category/index.md
+++ b/doc/2/controllers/asset-category/index.md
@@ -1,0 +1,6 @@
+---
+code: true
+type: branch
+title: asset-category
+description: Kuzzle IoT - Device Manager AssetCategory Controller
+---

--- a/doc/2/controllers/asset-category/linkMetadata/index.md
+++ b/doc/2/controllers/asset-category/linkMetadata/index.md
@@ -1,0 +1,65 @@
+---
+code: true
+type: page
+title: link metadata
+description: link a metadata with an asset-category
+---
+
+# create
+link a metadata with an asset-category
+<!--- TODO : lister les erreurs qui peuvent arriver -->
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory/:_id/_link/metadata/:metadataId
+Method: PUT
+Body:
+```
+
+```js
+{
+  // value of the metadata, if it's defined by category and not by assets
+  //Exemple :
+  {"value" : "myValue"}
+}
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<index>",
+  "controller": "device-manager/assetCategory",
+  "action": "linkMetadata",
+  "body": {
+    // value optionally
+  }
+}
+```
+
+## Arguments
+
+- `engineId`: engine id
+- `_id` : Asset Category that need to be linked
+- `metadataId` : metadata Id that will be linked with asset category.
+
+## Body properties
+
+value of the metadata, if it's defined by category and not by assets
+
+---
+
+## Response
+
+Returns an object with the following properties:
+
+- `_id`: created document unique identifier
+- `_source`: assetCategory document content
+- `_version`: version of the updated document
+
+Return has same caracteristics as update API action. More information at [document:update](/core/2/api/controllers/document/update).
+

--- a/doc/2/controllers/asset-category/linkParent/index.md
+++ b/doc/2/controllers/asset-category/linkParent/index.md
@@ -1,0 +1,56 @@
+---
+code: true
+type: page
+title: link metadata
+description: link an asset-category with a parent category
+---
+
+# create
+
+link an asset-category with a parent category
+<!--- TODO : lister les erreurs qui peuvent arriver -->
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory/:_id/_link/parent/:parentId
+Method: PUT
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<index>",
+  "controller": "device-manager/assetCategory",
+  "action": "linkParent"
+}
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine id
+- `_id` : Asset Category that need to be linked
+- `metadataId` : metadata Id that will be linked with asset category.
+
+## Body properties
+
+value of the metadata, if it's defined by category and not by assets
+
+---
+
+## Response
+
+Returns an object with the following properties:
+
+- `_id`: created document unique identifier
+- `_source`: assetCategory document content
+- `_version`: version of the updated document
+
+Return has same caracteristics as update API action. More information at [document:update](/core/2/api/controllers/document/update).
+

--- a/doc/2/controllers/asset-category/unlinkMetadata/index.md
+++ b/doc/2/controllers/asset-category/unlinkMetadata/index.md
@@ -1,0 +1,49 @@
+---
+code: true
+type: page
+title: unlink metadata
+description: unlink a metadata with an asset-category
+---
+
+# create
+unlink a metadata with an asset-category
+<!--- TODO : lister les erreurs qui peuvent arriver -->
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory/:_id/_unlink/metadata/:metadataId
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<index>",
+  "controller": "device-manager/assetCategory",
+  "action": "unlinkMetadata"
+}
+```
+
+## Arguments
+
+- `engineId`: engine id
+- `_id` : Asset Category that need to be unlinked
+- `metadataId` : metadata Id that will be unlinked with asset category.
+
+---
+
+## Response
+
+Returns an object with the following properties:
+
+- `_id`: created document unique identifier
+- `_source`: assetCategory document content
+- `_version`: version of the updated document
+
+Return has same caracteristics as update API action. More information at [document:update](/core/2/api/controllers/document/update).
+

--- a/doc/2/controllers/asset-category/unlinkParent/index.md
+++ b/doc/2/controllers/asset-category/unlinkParent/index.md
@@ -1,0 +1,49 @@
+---
+code: true
+type: page
+title: unlink metadata
+description: unlink a metadata with its parent
+---
+
+# create
+unlink a metadata with its parent
+<!--- TODO : lister les erreurs qui peuvent arriver -->
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assetCategory/:_id/_unlink/parent/:parentId
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<index>",
+  "controller": "device-manager/assetCategory",
+  "action": "unlinkParent"
+}
+```
+
+## Arguments
+
+- `engineId`: engine id
+- `_id` : Asset Category that need to be unlinked
+- `parentId` : parent Id.
+
+---
+
+## Response
+
+Returns an object with the following properties:
+
+- `_id`: created document unique identifier
+- `_source`: assetCategory document content
+- `_version`: version of the updated document
+
+Return has same caracteristics as update API action. More information at [document:update](/core/2/api/controllers/document/update).
+

--- a/doc/2/controllers/asset-category/update/index.md
+++ b/doc/2/controllers/asset-category/update/index.md
@@ -1,0 +1,80 @@
+---
+code: true
+type: page
+title: update
+description: Updates an asset-category
+---
+
+# update
+
+Applies partial changes to an asset-Category.
+
+See also the [document:update](/core/2/api/controllers/document/update) API action.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: device-manager/:engineId/assetCategory/:_id[?refresh=wait_for][&retryOnConflict=<int>][&source]
+Method: PUT
+Body:
+```
+
+```js
+{
+  //  asset-category changes
+}
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<engineId>",
+  "controller": "device-manager/assetCategory",
+  "action": "update",
+  "_id": "<assetCategoryId>",
+  "body": {
+    // metadata changes
+  }
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/assetCategory:update <engineId> --id <assetCategoryId> --body '{ 
+  // asset changes
+}'
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine Id
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
+- `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
+- `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
+
+---
+
+## Body properties
+
+Partial changes to apply to the assetCategory.
+
+---
+
+## Response
+
+Returns information about the updated assetCategory:
+
+- `_id`: assetCategory unique identifier
+- `_version`: updated assetCategory version
+- `_source`: contains only changes or the full assetCategory if `source` is set to `true`

--- a/doc/2/controllers/metadata/create/index.md
+++ b/doc/2/controllers/metadata/create/index.md
@@ -1,0 +1,89 @@
+---
+code: true
+type: page
+title: create
+description: Creates a new metadata type
+---
+
+# create
+
+Creates a new metadata type inside a tenant index.
+
+Returns an error if the document already exists.
+
+See also the [document:create](/core/2/api/controllers/document/create) API action.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/metadata[?refresh=wait_for]
+Method: POST
+Body:
+```
+
+```js
+{
+  // metadata type content
+  //Example : 
+  "name" : "model",
+  "valueType" : "string",
+  "mandatory" : true
+  
+}
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<engineId>",
+  "controller": "device-manager/metadata",
+  "action": "create",
+  "body": {
+    //metadata content
+  }
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/metadata:create <engineId> --body '{ 
+  //metadata content 
+}'
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine Id
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the newly created document is indexed
+
+---
+
+## Body properties
+
+metadata type content to create.
+
+Assets must contains at least the following properties:
+- `name`: name of the metadata
+- `valueType`: type of the metadata
+
+---
+
+## Response
+
+Returns an object with the following properties:
+
+- `_id`: created document unique identifier
+- `_source`: document content
+- `_version`: version of the created document (should be `1`)
+

--- a/doc/2/controllers/metadata/delete/index.md
+++ b/doc/2/controllers/metadata/delete/index.md
@@ -1,0 +1,60 @@
+---
+code: true
+type: page
+title: delete
+description: Deletes a metadata
+---
+
+# delete
+
+Deletes an asset.
+
+See also the [document:delete](/core/2/api/controllers/document/delete) API action.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/metadata/:_id[?refresh=wait_for][&source]
+Method: DELETE
+```
+
+### Other protocols
+
+```js
+{
+  "index": "<engineId>",
+  "controller": "device-manager/metadata",
+  "action": "delete",
+  "_id": "<assetId>"
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/metadata:delete <engineId> --id <assetId>
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine id
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the delete is indexed
+- `source`: if set to `true` Kuzzle will return the entire deleted document body in the response.
+
+---
+
+## Response
+
+Returns information about the deleted asset:
+
+- `_id`: asset unique identifier
+- `_source`: deleted asset source, only if the `source` option is set to `true`

--- a/doc/2/controllers/metadata/index.md
+++ b/doc/2/controllers/metadata/index.md
@@ -1,0 +1,6 @@
+---
+code: true
+type: branch
+title: metadata
+description: Kuzzle IoT - Device Manager Metadata Controller
+---

--- a/doc/2/controllers/metadata/update/index.md
+++ b/doc/2/controllers/metadata/update/index.md
@@ -1,0 +1,80 @@
+---
+code: true
+type: page
+title: update
+description: Updates a metadata
+---
+
+# update
+
+Applies partial changes to a metadata.
+
+See also the [document:update](/core/2/api/controllers/document/update) API action.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: device-manager/:engineId/metadata/:_id[?refresh=wait_for][&retryOnConflict=<int>][&source]
+Method: PUT
+Body:
+```
+
+```js
+{
+  // metadata changes
+}
+```
+
+### Other protocols
+
+```js
+{
+  "engineId": "<engineId>",
+  "controller": "device-manager/metadata",
+  "action": "update",
+  "_id": "<metadataId>",
+  "body": {
+    // metadata changes
+  }
+}
+```
+
+### Kourou
+
+```bash
+kourou device-manager/metadata:update <engineId> --id <metadataId> --body '{ 
+  // asset changes
+}'
+```
+
+---
+
+## Arguments
+
+- `engineId`: engine Id
+
+### Optional:
+
+- `refresh`: if set to `wait_for`, Kuzzle will not respond until the update is indexed
+- `retryOnConflict`: conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the `retryOnConflict` optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error.
+- `source`: if set to `true` Kuzzle will return the entire updated document body in the response.
+
+---
+
+## Body properties
+
+Partial changes to apply to the metadata.
+
+---
+
+## Response
+
+Returns information about the updated metadata:
+
+- `_id`: metadata unique identifier
+- `_version`: updated metadata version
+- `_source`: contains only changes or the full metadata if `source` is set to `true`

--- a/features/AssetCategory.feature
+++ b/features/AssetCategory.feature
@@ -306,18 +306,22 @@ Feature: AssetCategory
       | _id        | "coloredTruck" |
       | metadataId | "color"        |
       | body.value | "red"          |
+    Then The document "engine-ayse":"asset-category":"coloredTruck" content match:
+      | metadataValues[0].key           | "color" |
+      | metadataValues[0].value.keyword | "red"   |
     When I successfully execute the action "device-manager/assetCategory":"unlinkMetadata" with args:
-      | engineId   | "engine-ayse"  |
-      | _id        | "coloredTruck" |
-      | metadataId | "color"        |
+          | engineId   | "engine-ayse"  |
+          | _id        | "coloredTruck" |
+          | metadataId | "color"        |
+    Then The document "engine-ayse":"asset-category":"coloredTruck" content match:
+      | metadataValues | [] |
     When I execute the action "device-manager/assetCategory":"linkMetadata" with args:
       | engineId   | "engine-ayse"  |
       | _id        | "coloredTruck" |
       | metadataId | "color"        |
       | body.value | "black"        |
     Then I should receive an error matching:
-      | status | 400 |
-
+      | id | "device-manager.asset_controller.enum_metadata" |
 
   Scenario: Use metadata enum type link with assetCategory, and create asset with
     When I successfully execute the action "device-manager/assetCategory":"create" with args:
@@ -330,9 +334,9 @@ Feature: AssetCategory
       | body.valueList | ["big","small"] |
       | body.mandatory | true            |
     When I successfully execute the action "device-manager/assetCategory":"linkMetadata" with args:
-      | engineId   | "engine-ayse"  |
-      | _id        | "typedTruck" |
-      | metadataId | "truckType"        |
+      | engineId   | "engine-ayse" |
+      | _id        | "typedTruck"  |
+      | metadataId | "truckType"   |
     When I execute the action "device-manager/asset":"create" with args:
       | engineId                | "engine-ayse" |
       | body.type               | "truck"       |
@@ -341,7 +345,7 @@ Feature: AssetCategory
       | body.category           | "typedTruck"  |
       | body.metadata.truckType | "super"       |
     Then I should receive an error matching:
-      | status | 400 |
+      | id | "device-manager.asset_controller.enum_metadata" |
     When I successfully execute the action "device-manager/asset":"create" with args:
       | engineId                | "engine-ayse" |
       | body.type               | "truck"       |
@@ -349,6 +353,12 @@ Feature: AssetCategory
       | body.reference          | "asset_02"    |
       | body.category           | "typedTruck"  |
       | body.metadata.truckType | "big"         |
+    When I successfully execute the action "device-manager/asset":"get" with args:
+      | engineId | "engine-ayse"      |
+      | _id      | "truck-M-asset_02" |
+    Then I should receive a result matching:
+      | metadata.truckType | "big" |
+
 
   Scenario: Use geopoint
     When I successfully execute the action "device-manager/metadata":"create" with args:

--- a/lib/controllers/AssetCategoryController.ts
+++ b/lib/controllers/AssetCategoryController.ts
@@ -1,6 +1,11 @@
 import { KuzzleRequest, Plugin } from 'kuzzle';
 import { RelationalController } from './RelationalController';
-import { AssetCategoryContent, FormattedValue, ProcessedAssetCategoryContent } from '../types/AssetCategoryContent';
+import {
+  AssetCategoryContent,
+  FormattedMetadata,
+  FormattedValue,
+  ProcessedAssetCategoryContent
+} from '../types/AssetCategoryContent';
 import { AssetCategoryService } from '../core-classes/AssetCategoryService';
 import { MetadataContent } from '../types/MetadataContent';
 
@@ -12,7 +17,7 @@ export class AssetCategoryController extends RelationalController {
     super(plugin, 'asset-category');
     this.assetCategoryService = assetCategoryService;
 
-    global.app.errors.register('device-manager', 'relational', 'forbiddenParent', {
+    global.app.errors.register('device-manager', 'relational_controller', 'forbidden_parent', {
       class: 'BadRequestError',
       description: 'you can\'t have a parent that is a subcategory',
       message: 'you can\'t have a parent that is a subcategory',
@@ -79,6 +84,26 @@ export class AssetCategoryController extends RelationalController {
   }
 
   async update (request: KuzzleRequest) {
+    const id = request.getId();
+    const engineId = request.getString('engineId');
+    const assetMetadata = request.input.body.assetMetadata as String[];
+    if (assetMetadata) {
+      //if elemets are removed in assetMetadata, we need to also remove the values associated in metadataValues
+      if (! request.input.body.metadataValues) {
+        const document = await this.sdk.document.get<AssetCategoryContent>(engineId, this.collection, id);
+        request.input.body.metadataValues = document._source.metadataValues;
+      }
+      let index = 0;
+      const metadataValues = request.input.body.metadataValues as FormattedMetadata[];
+      for (const values of metadataValues) {
+        if (! assetMetadata.includes(values.key)) {
+          metadataValues.splice(index);
+        }
+        else {
+          index++;
+        } 
+      }
+    }
     return super.genericUpdate(request);
   }
 
@@ -92,7 +117,7 @@ export class AssetCategoryController extends RelationalController {
     const parent = request.getString('parentId');
     const document = await this.sdk.document.get(request.getString('engineId'), 'asset-category', parent);
     if (document._source.parentId) {
-      throw global.app.errors.get('device-manager', 'assetController', 'forbiddenParent');
+      throw global.app.errors.get('device-manager', 'asset_controller', 'forbidden_parent');
     }
     request.input.body = {
       parent
@@ -125,13 +150,14 @@ export class AssetCategoryController extends RelationalController {
     const metadataId = request.getString('metadataId');
     const value = request.input.body?.value;
 
-    const metadataContent = await this.sdk.document.get<MetadataContent>(engineId, 'metadata', metadataId); 
-    const category = await this.sdk.document.get<AssetCategoryContent>(engineId, 'asset-category', id);
+    const [metadataContent, category] = await Promise.all([
+      await this.sdk.document.get<MetadataContent>(engineId, 'metadata', metadataId),
+      await this.sdk.document.get<AssetCategoryContent>(engineId, 'asset-category', id)]);
     const metadata = category._source.assetMetadata ? category._source.assetMetadata : [];
     let metadataValues = category._source.metadataValues;
 
     if (metadata.includes(metadataId)) {
-      throw global.app.errors.get('device-manager', 'relational', 'linkAlreadyExist');
+      throw global.app.errors.get('device-manager', 'relational_controller', 'link_already_exist');
     }
     metadata.push(metadataId);
     request.input.body = {
@@ -141,7 +167,7 @@ export class AssetCategoryController extends RelationalController {
     if (value) {
 
       if (metadataContent._source.valueList && ! metadataContent._source.valueList.includes(value) ) {
-        throw global.app.errors.get('device-manager', 'assetController', 'EnumMetadata', metadataContent._source.name, value);
+        throw global.app.errors.get('device-manager', 'asset_controller', 'enum_metadata', metadataContent._source.name, value);
 
       }
       const formattedValue : FormattedValue = await this.assetCategoryService.formatValue(value);

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -29,6 +29,11 @@ export class AssetController extends RelationalController {
       description: 'Metadata which are specified in AssetCategory as mandatory must be present',
       message: 'metadata %s is mandatory for the asset',
     });
+    global.app.errors.register('device-manager', 'assetController', 'EnumMetadata', {
+      class: 'BadRequestError',
+      description: 'Metadata must have one of the values specified in metadata valueList',
+      message: 'metadata %s cannot have %s value : value must have one of the value of metadata valueList ',
+    });
 
     this.assetCategoryService = assetCategoryService;
     this.assetService = assetService;

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -24,12 +24,12 @@ export class AssetController extends RelationalController {
   ) {
 
     super(plugin, 'assets');
-    global.app.errors.register('device-manager', 'assetController', 'MandatoryMetadata', {
+    global.app.errors.register('device-manager', 'asset_controller', 'mandatory_metadata', {
       class: 'BadRequestError',
       description: 'Metadata which are specified in AssetCategory as mandatory must be present',
       message: 'metadata %s is mandatory for the asset',
     });
-    global.app.errors.register('device-manager', 'assetController', 'EnumMetadata', {
+    global.app.errors.register('device-manager', 'asset_controller', 'enum_metadata', {
       class: 'BadRequestError',
       description: 'Metadata must have one of the values specified in metadata valueList',
       message: 'metadata %s cannot have %s value : value must have one of the value of metadata valueList ',
@@ -126,7 +126,7 @@ export class AssetController extends RelationalController {
     const categoryId = request.getString('categoryId');
     const document = await this.sdk.document.get(engineId, this.collection, id);
     if ( document._source.category !== categoryId && document._source.subCategory !== categoryId ) {
-      throw global.app.errors.get('device-manager', 'relational', 'removeUnexistingLink');
+      throw global.app.errors.get('device-manager', 'relational_controller', 'remove_unexisting_link');
     }
     request.input.body = { category: null, subCategory: null };
     return this.update(request);
@@ -144,7 +144,7 @@ export class AssetController extends RelationalController {
       subCategory: null
     };
     if ( document._source.category) {
-      throw global.app.errors.get('device-manager', 'relational', 'alreadyLinked', 'asset', 'category');
+      throw global.app.errors.get('device-manager', 'relational_controller', 'already_linked', 'asset', 'category');
     }
     else if (categoryDocument._source.parent) {
       updateRequest.category = categoryDocument._source.parent;

--- a/lib/controllers/RelationalController.ts
+++ b/lib/controllers/RelationalController.ts
@@ -29,17 +29,17 @@ export abstract class RelationalController extends CRUDController {
   public static init () {
     if (! this.isInit) {
       this.isInit = true;
-      global.app.errors.register('device-manager', 'relational', 'removeUnexistingLink', {
+      global.app.errors.register('device-manager', 'relational_controller', 'remove_unexisting_link', {
         class: 'BadRequestError',
         description: 'you can\'t remove an unexisting link',
         message: 'you can\'t remove an unexisting link',
       });
-      global.app.errors.register('device-manager', 'relational', 'alreadyLinked', {
+      global.app.errors.register('device-manager', 'relational_controller', 'already_linked', {
         class: 'BadRequestError',
         description: 'Creation of multiple relation on a OneToMany relation',
         message: '%s cannot have multiple %s relation',
       });
-      global.app.errors.register('device-manager', 'relational', 'linkAlreadyExist', {
+      global.app.errors.register('device-manager', 'relational_controller', 'link_already_exist', {
         class: 'BadRequestError',
         description: 'the link already exist',
         message: 'the link already exist',
@@ -262,7 +262,7 @@ export abstract class RelationalController extends CRUDController {
     if (! manyToMany) {
       const containerDocument = await this.getDocumentContent(container);
       if (containerDocument[container.field]) {
-        throw global.app.errors.get('device-manager', 'relational', 'alreadyLinked', container.collection, container.field);
+        throw global.app.errors.get('device-manager', 'relational_controller', 'already_linked', container.collection, container.field);
       }
     }
     
@@ -301,7 +301,7 @@ export abstract class RelationalController extends CRUDController {
   verifyNotAlreadyLinked (listList: FieldPath[], link: FieldPath) {
     for (const fieldPath of listList) {
       if (this.equal(fieldPath, link)) {
-        throw global.app.errors.get('device-manager', 'relational', 'linkAlreadyExist');
+        throw global.app.errors.get('device-manager', 'relational_controller', 'link_already_exist');
       }
     }
   }
@@ -316,11 +316,11 @@ export abstract class RelationalController extends CRUDController {
   async genericUnlink (request : KuzzleRequest, embedded : FieldPath, container : FieldPath, manyToMany :boolean) {
     const document = await this.getDocumentContent(embedded);
     if (! document[embedded.field]) {
-      global.app.errors.get('device-manager', 'relational', 'removeUnexistingLink');
+      global.app.errors.get('device-manager', 'relational_controller', 'remove_unexisting_link');
     }
     const index = document[embedded.field].findIndex(fieldPath => this.equal(fieldPath, container));
     if (index === -1) {
-      global.app.errors.get('device-manager', 'relational', 'removeUnexistingLink');
+      global.app.errors.get('device-manager', 'relational_controller', 'remove_unexisting_link');
     }
     document[embedded.field].splice(index, 1);
     const updateMessage = {};

--- a/lib/core-classes/AssetCategoryService.ts
+++ b/lib/core-classes/AssetCategoryService.ts
@@ -84,15 +84,19 @@ export class AssetCategoryService {
     ]);
     for (const metadata of metadataList) {
       if (metadata.mandatory) {
-        // eslint-disable-next-line no-prototype-builtins
         if (! (assetMetadata[metadata.name]) && ! this.containsValue(metadataValues, metadata.name)) {
           throw global.app.errors.get('device-manager', 'assetController', 'MandatoryMetadata', metadata.name);
+        }
+      }
+      if (metadata.valueList) {
+        if (! metadata.valueList.includes(assetMetadata[metadata.name])) {
+          throw global.app.errors.get('device-manager', 'assetController', 'EnumMetadata', metadata.name, assetMetadata[metadata.name]);
         }
       }
     }
   }
 
-  containsValue (metadataValues : FormattedMetadata[], name : string) {
+  containsValue (metadataValues : FormattedMetadata[], name : string): Boolean {
     for (const metadata of metadataValues) {
       if (metadata.key === name) {
         return true;
@@ -100,15 +104,26 @@ export class AssetCategoryService {
     } 
     return false;
   }
+
+  getMetadataValue (metadataValues : FormattedMetadata[], name : string) : FormattedMetadata {
+    for (const metadata of metadataValues) {
+      if (metadata.key === name) {
+        return metadata;
+      }
+    }
+    return null;
+  }
   
   
-  async formatValue (value : string) {
+  async formatValue (value : any) {
     let formattedValue : FormattedValue = {};
     if (typeof value === 'number' ) {
       formattedValue.integer = value;
     }
     else if (typeof value === 'boolean') {
       formattedValue.boolean = value;
+    } else if (value.lat){
+      formattedValue.geo_point = value;
     }
     else {
       formattedValue.keyword = value;
@@ -141,7 +156,10 @@ export class AssetCategoryService {
     }
     else if (value.integer || value.integer === 0) {
       return value.integer;
-    } 
+    }
+    else if (value.geo_point ) {
+      return value.geo_point;
+    }
     return value.boolean;
   }
   

--- a/lib/core-classes/AssetCategoryService.ts
+++ b/lib/core-classes/AssetCategoryService.ts
@@ -122,7 +122,8 @@ export class AssetCategoryService {
     }
     else if (typeof value === 'boolean') {
       formattedValue.boolean = value;
-    } else if (value.lat){
+    }
+    else if (value.lat) {
       formattedValue.geo_point = value;
     }
     else {

--- a/lib/core-classes/AssetCategoryService.ts
+++ b/lib/core-classes/AssetCategoryService.ts
@@ -85,12 +85,12 @@ export class AssetCategoryService {
     for (const metadata of metadataList) {
       if (metadata.mandatory) {
         if (! (assetMetadata[metadata.name]) && ! this.containsValue(metadataValues, metadata.name)) {
-          throw global.app.errors.get('device-manager', 'assetController', 'MandatoryMetadata', metadata.name);
+          throw global.app.errors.get('device-manager', 'asset_controller', 'mandatory_metadata', metadata.name);
         }
       }
       if (metadata.valueList) {
         if (! metadata.valueList.includes(assetMetadata[metadata.name])) {
-          throw global.app.errors.get('device-manager', 'assetController', 'EnumMetadata', metadata.name, assetMetadata[metadata.name]);
+          throw global.app.errors.get('device-manager', 'asset_controller', 'enum_metadata', metadata.name, assetMetadata[metadata.name]);
         }
       }
     }

--- a/lib/mappings/assetCategoryMappings.ts
+++ b/lib/mappings/assetCategoryMappings.ts
@@ -11,6 +11,7 @@ export const assetCategoryMappings = {
         value: {
           properties: {
             boolean: { type: 'boolean' },
+            geo_point: { type: 'geo_point' },
             integer: { type: 'integer' },
             keyword: { type: 'keyword' },
           }

--- a/lib/mappings/assetsMappings.ts
+++ b/lib/mappings/assetsMappings.ts
@@ -45,6 +45,7 @@ export const assetsMappings = {
         value: {
           properties: {
             boolean: { type: 'boolean' },
+            geo_point: { type: 'geo_point' },
             integer: { type: 'integer' },
             keyword: { type: 'keyword' },
           }

--- a/lib/types/AssetCategoryContent.ts
+++ b/lib/types/AssetCategoryContent.ts
@@ -5,7 +5,8 @@ import { JSONObject } from 'kuzzle';
 export interface FormattedValue {
   boolean? : boolean,
   integer? : number,
-  keyword? : string
+  keyword? : string,
+  geo_point? : {lat : number, lon : number}
 }
 
 export interface FormattedMetadata {


### PR DESCRIPTION
## What does this PR do ?

 - Create basic documentation for metadata and assetCategory controllers
 - add geopoint type and enum type in metadata (and functionnal tests)
 - correct some minor mistakes


### How should this be manually tested?
You can use Functionnal tests, or call different function of metadata, assetCategory and asset controllers with postman to create asset category and assets using the new metadata types. 

