### PR TITLE
2.0.0-rc8 : Allows to register measure with a value of same mappings

### DIFF
--- a/lib/core-classes/AssetCategoryService.ts
+++ b/lib/core-classes/AssetCategoryService.ts
@@ -2,7 +2,7 @@ import { MetadataContent } from '../types/MetadataContent';
 import { AssetCategoryContent, FormattedMetadata, FormattedValue } from '../types/AssetCategoryContent';
 import { JSONObject, Plugin, PluginContext } from 'kuzzle';
 import { DeviceManagerConfiguration } from '../types';
-import isEqual from 'lodash.isequal';
+import _ from 'lodash';
 
 export class AssetCategoryService {
 
@@ -33,7 +33,7 @@ export class AssetCategoryService {
       }
     }
   }
-  
+
   async getMetadata (assetCategory : AssetCategoryContent, engineId : string) : Promise<MetadataContent[]> {
     let metadataList;
     metadataList = [];
@@ -107,7 +107,7 @@ export class AssetCategoryService {
       let find = false;
       for (const objectValue of metadata.objectValueList) {
         const fromattedObjectValue = this.formatMetadataForGet(objectValue.object);
-        if (isEqual(fromattedObjectValue, value)) {
+        if (_.isEqual(fromattedObjectValue, value)) {
           find = true;
           break;
         }
@@ -123,7 +123,7 @@ export class AssetCategoryService {
       if (metadata.key === name) {
         return true;
       }
-    } 
+    }
     return false;
   }
 
@@ -188,7 +188,7 @@ export class AssetCategoryService {
     else if (value.object ) {
       if (format) {
         return this.formatMetadataForGet(value.object);
-      } 
+      }
       return value.object;
     }
     return value.boolean;

--- a/lib/core-classes/registers/MeasuresRegister.ts
+++ b/lib/core-classes/registers/MeasuresRegister.ts
@@ -39,7 +39,7 @@ export class MeasuresRegister {
 
     for (const [field, definition] of Object.entries(measure.valuesMappings)) {
       if (this.mappings.properties.values.properties[field] && ! _.isEqual(this.mappings.properties.values.properties[field], definition)) {
-        throw new PluginImplementationError(`Measure "${type}" register a different mappings for value "${field}".`);
+        throw new PluginImplementationError(`Measure "${type}" register a different type for value "${field}".`);
       }
 
       this.mappings.properties.values.properties[field] = definition;

--- a/lib/core-classes/registers/MeasuresRegister.ts
+++ b/lib/core-classes/registers/MeasuresRegister.ts
@@ -1,4 +1,5 @@
 import { JSONObject, PluginImplementationError } from 'kuzzle';
+import _ from 'lodash';
 
 import { measuresMappings } from '../../mappings';
 import { MeasureDefinition } from '../../types';
@@ -27,7 +28,7 @@ export class MeasuresRegister {
    *     sign: '%',
    *     type: 'number',
    *   },
-   *   mappings: { humidity: { type: 'float' } },
+   *   valuesMappings: { humidity: { type: 'float' } },
    * });
    * ```
    */
@@ -37,8 +38,8 @@ export class MeasuresRegister {
     }
 
     for (const [field, definition] of Object.entries(measure.valuesMappings)) {
-      if (this.mappings.properties.values.properties[field]) {
-        throw new PluginImplementationError(`Field "${type}" already exists in measures mappings.`);
+      if (this.mappings.properties.values.properties[field] && ! _.isEqual(this.mappings.properties.values.properties[field], definition)) {
+        throw new PluginImplementationError(`Measure "${type}" register a different mappings for value "${field}".`);
       }
 
       this.mappings.properties.values.properties[field] = definition;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3548,11 +3548,6 @@
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
       "dev": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc7",
+  "version": "2.0.0-rc8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc7",
+  "version": "2.0.0-rc8",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "csvtojson": "~2.0.10",
     "json-stable-stringify": "^1.0.1",
     "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.4.tar.gz",
-    "lodash.isequal": "^4.5.0",
-    "uuid": "~8.3.2"
+    "uuid": "~8.3.2",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/node": "^17.0.21",
@@ -40,7 +40,6 @@
     "eslint": "^8.10.0",
     "kuzzle": "^2.18.1",
     "kuzzle-sdk": "^7.9.1",
-    "lodash": "^4.17.21",
     "should": "^13.2.3",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.2"


### PR DESCRIPTION
## What does this PR do ?

Allows this
```
const m = new MeasuresRegister();

m.register('temperature1', {
  unit: {
    name: '',
    sign: '',
    type: ''
  },
  valuesMappings: { temperature: { type: 'keyword' } }
});

m.register('temperature2', {
  unit: {
    name: '',
    sign: '',
    type: ''
  },
  valuesMappings: { temperature: { type: 'keyword' } }
});
```