### PR TITLE
Improve DX for Decoder class

### DIFF
--- a/doc/1/controllers/decoder/list-decoders/index.md
+++ b/doc/1/controllers/decoder/list-decoders/index.md
@@ -16,7 +16,7 @@ List available registered decoders.
 ### HTTP
 
 ```http
-URL: http://localhost:7512/_/device-manager/decoders/_list
+URL: http://localhost:7512/_/device-manager/decoder/_list
 Method: GET
 ```
 
@@ -24,7 +24,7 @@ Method: GET
 
 ```js
 {
-  "controller": "device-manager/decoders",
+  "controller": "device-manager/decoder",
   "action": "list",
 }
 ```
@@ -32,7 +32,7 @@ Method: GET
 ### Kourou
 
 ```bash
-kourou device-manager/decoders:list
+kourou device-manager/decoder:list
 ```
 ---
 
@@ -41,7 +41,7 @@ kourou device-manager/decoders:list
 ```js
 {
   "action": "list",
-  "controller": "device-manager/decoders",
+  "controller": "device-manager/decoder",
   "error": null,
   "node": "knode-nine-hydra-22631",
   "requestId": "d888a8e1-2f80-4849-99d0-86ea70fe91e4",

--- a/features/Decoders.feature
+++ b/features/Decoders.feature
@@ -1,12 +1,5 @@
 Feature: Device Manager Decoders
 
-  Scenario: List all registered decoders
-    When When I successfully execute the action "device-manager/decoders":"list"
-    Then I should receive a result matching:
-      | decoders[0] | {"deviceModel":"DummyTemp","decoderMeasures":{"theBatteryLevel":"battery"}} |
-      | decoders[1] | {"deviceModel":"DummyMultiTemp","decoderMeasures":{"innerTemp":"temperature","outerTemp":"temperature","lvlBattery":"battery"}} |
-      | decoders[2] | {"deviceModel":"DummyTempPosition","decoderMeasures":{"theTemperature":"temperature","theBattery":"battery","thePosition":"position"}} |
-
   Scenario: Creates default roles, profiles and users
     Then I am able to get a role with id "payload-gateway.dummy-temp"
     Then I am able to get a role with id "payload-gateway.dummy-temp-position"

--- a/features/DeviceController/Misc.feature
+++ b/features/DeviceController/Misc.feature
@@ -39,17 +39,15 @@ Feature: Device Controller actions
     Then I should receive a result matching:
       | total | 1 |
 
-  Scenario: Get measure without deviceMeasureName
+  Scenario: Throw an error when decoding unknown measure name
     Given I successfully execute the action "device-manager/device":"create" with args:
-      | engineId        | "device-manager"  |
-      | body.model      | "DummyTemp"      |
-      | body.reference  | "test"           |
-    When I successfully receive a "dummy-temp" payload with:
-      | deviceEUI     | "test"  |
-      | register55    | 100     |
-      | batteryLevel  | 1       |
+      | engineId       | "device-manager" |
+      | body.model     | "DummyTemp"      |
+      | body.reference | "test"           |
+    When I receive a "dummy-temp" payload with:
+      | deviceEUI      | "test" |
+      | register55     | 100    |
+      | unknownMeasure | 100    |
+      | batteryLevel   | 1      |
     Then The document "device-manager":"devices":"DummyTemp-test" content match:
-      | measures[0].type              | "temperature"     |
-      | measures[0].deviceMeasureName | "temperature"     |
-      | measures[1].type              | "battery"         |
-      | measures[1].deviceMeasureName | "theBatteryLevel" |
+      | measures | [] |

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -14,9 +14,9 @@ const app = new Backend('kuzzle');
 
 const deviceManager = new DeviceManagerPlugin();
 
-deviceManager.decoders.register(new DummyTempDecoder(deviceManager.measures));
-deviceManager.decoders.register(new DummyMultiTempDecoder(deviceManager.measures));
-deviceManager.decoders.register(new DummyTempPositionDecoder(deviceManager.measures));
+deviceManager.decoders.register(new DummyTempDecoder());
+deviceManager.decoders.register(new DummyMultiTempDecoder());
+deviceManager.decoders.register(new DummyTempPositionDecoder());
 
 deviceManager.devices.registerMetadata({
   group: {

--- a/features/fixtures/application/decoders/DummyMultiTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyMultiTempDecoder.ts
@@ -36,12 +36,11 @@ export class DummyMultiTempDecoder extends Decoder {
   }
 
   async decode (payload: JSONObject): Promise<DecodedPayload> {
-    const decodedPayload = new DecodedPayload();
+    const decodedPayload = new DecodedPayload(this);
 
     for (const devicePayload of payload.payloads) {
       if (devicePayload.registerInner) {
         const innerTemp: TemperatureMeasurement = {
-          deviceMeasureName: 'innerTemp',
           measuredAt: devicePayload.measuredAtRegisterInner ?? Date.now(),
           type: 'temperature',
           values: {
@@ -49,12 +48,11 @@ export class DummyMultiTempDecoder extends Decoder {
           },
         }
 
-        decodedPayload.addMeasurement(devicePayload.deviceEUI, innerTemp);
+        decodedPayload.addMeasurement(devicePayload.deviceEUI, 'innerTemp', innerTemp);
       }
 
       if (devicePayload.registerOuter) {
         const outerTemp: TemperatureMeasurement = {
-          deviceMeasureName: 'outerTemp',
           measuredAt: devicePayload.measuredAtRegisterOuter ?? Date.now(),
           type: 'temperature',
           values: {
@@ -62,12 +60,11 @@ export class DummyMultiTempDecoder extends Decoder {
           },
         };
 
-        decodedPayload.addMeasurement(devicePayload.deviceEUI, outerTemp);
+        decodedPayload.addMeasurement(devicePayload.deviceEUI, 'outerTemp', outerTemp);
       }
 
       if (devicePayload.lvlBattery) {
         const battery: BatteryMeasurement = {
-          deviceMeasureName: 'lvlBattery',
           measuredAt: devicePayload.measuredAtLvlBattery ?? Date.now(),
           type: 'battery',
           values: {
@@ -75,7 +72,7 @@ export class DummyMultiTempDecoder extends Decoder {
           },
         }
 
-        decodedPayload.addMeasurement(devicePayload.deviceEUI, battery);
+        decodedPayload.addMeasurement(devicePayload.deviceEUI, 'lvlBattery', battery);
       }
     }
 

--- a/features/fixtures/application/decoders/DummyMultiTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyMultiTempDecoder.ts
@@ -9,14 +9,14 @@ import {
 } from '../../../../index';
 
 export class DummyMultiTempDecoder extends Decoder {
+  public measures = [
+    { name: 'innerTemp', type: 'temperature' },
+    { name: 'outerTemp', type: 'temperature' },
+    { name: 'lvlBattery', type: 'battery' },
+  ] as const;
+
   constructor () {
     super();
-
-    this.measures = [
-      { name: 'innerTemp', type: 'temperature' },
-      { name: 'outerTemp', type: 'temperature' },
-      { name: 'lvlBattery', type: 'battery' },
-    ];
 
     this.payloadsMappings = {
       deviceEUI: { type: 'keyword' }
@@ -35,8 +35,8 @@ export class DummyMultiTempDecoder extends Decoder {
     return true;
   }
 
-  async decode (payload: JSONObject): Promise<DecodedPayload> {
-    const decodedPayload = new DecodedPayload(this);
+  async decode (payload: JSONObject): Promise<DecodedPayload<Decoder>> {
+    const decodedPayload = new DecodedPayload<DummyMultiTempDecoder>(this);
 
     for (const devicePayload of payload.payloads) {
       if (devicePayload.registerInner) {

--- a/features/fixtures/application/decoders/DummyTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempDecoder.ts
@@ -8,13 +8,13 @@ import {
 } from '../../../../index';
 
 export class DummyTempDecoder extends Decoder {
+  public measures = [
+    { name: 'theBatteryLevel', type: 'battery' },
+    { name: 'temperature', type: 'temperature' },
+  ] as const;
+
   constructor () {
     super();
-
-    this.measures = [
-      { name: 'theBatteryLevel', type: 'battery' },
-      { name: 'temperature', type: 'temperature' },
-    ];
 
     this.payloadsMappings = {
       deviceEUI: { type: 'keyword' }
@@ -33,8 +33,8 @@ export class DummyTempDecoder extends Decoder {
     return true;
   }
 
-  async decode (payload: JSONObject): Promise<DecodedPayload> {
-    const decodedPayload = new DecodedPayload(this);
+  async decode (payload: JSONObject): Promise<DecodedPayload<Decoder>> {
+    const decodedPayload = new DecodedPayload<DummyTempDecoder>(this);
 
     decodedPayload.addMeasurement<TemperatureMeasurement>(
       payload.deviceEUI,
@@ -61,6 +61,7 @@ export class DummyTempDecoder extends Decoder {
     if (payload.unknownMeasure) {
       decodedPayload.addMeasurement<TemperatureMeasurement>(
         payload.deviceEUI,
+        // @ts-expect-error
         'unknownMeasureName',
         {
           measuredAt: Date.now(),

--- a/features/fixtures/application/decoders/DummyTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempDecoder.ts
@@ -1,25 +1,27 @@
-import { JSONObject, KuzzleRequest, PreconditionError } from 'kuzzle';
+import { JSONObject, PreconditionError } from 'kuzzle';
 
 import {
   Decoder,
   DecodedPayload,
   TemperatureMeasurement,
   BatteryMeasurement,
-  MeasuresRegister,
 } from '../../../../index';
 
 export class DummyTempDecoder extends Decoder {
-  constructor (measuresRegister: MeasuresRegister) {
-    super('DummyTemp',
-      { theBatteryLevel: 'battery', }, // Wrong decoderMeasure list on purpose, avoid this please
-      measuresRegister);
+  constructor () {
+    super();
+
+    // The list is missing the temperature measure on purpose
+    this.measures = [
+      { name: 'theBatteryLevel', type: 'battery' },
+    ];
 
     this.payloadsMappings = {
       deviceEUI: { type: 'keyword' }
     };
   }
 
-  async validate (payload: JSONObject, request: KuzzleRequest) {
+  async validate (payload: JSONObject) {
     if (! payload.deviceEUI) {
       throw new PreconditionError('Invalid payload: missing "deviceEUI"');
     }
@@ -31,24 +33,30 @@ export class DummyTempDecoder extends Decoder {
     return true;
   }
 
-  async decode (payload: JSONObject, request: KuzzleRequest): Promise<DecodedPayload> {
-    const temperature: TemperatureMeasurement = {
-      measuredAt: Date.now(),
-      type: 'temperature',
-      values: {
-        temperature: payload.register55,
-      },
-    };
+  async decode (payload: JSONObject): Promise<DecodedPayload> {
+    const decodedPayload = new DecodedPayload();
 
-    const battery: BatteryMeasurement = {
-      deviceMeasureName: 'theBatteryLevel',
-      measuredAt: Date.now(),
-      type: 'battery',
-      values: {
-        battery: payload.batteryLevel * 100,
-      },
-    };
+    decodedPayload.addMeasurement<TemperatureMeasurement>(
+      payload.deviceEUI,
+      {
+        measuredAt: Date.now(),
+        type: 'temperature',
+        values: {
+          temperature: payload.register55,
+        },
+      });
 
-    return { [payload.deviceEUI]: [temperature, battery] };
+    decodedPayload.addMeasurement<BatteryMeasurement>(
+      payload.deviceEUI,
+      {
+        deviceMeasureName: 'theBatteryLevel',
+        measuredAt: Date.now(),
+        type: 'battery',
+        values: {
+          battery: payload.batteryLevel * 100,
+        },
+      });
+
+    return decodedPayload;
   }
 }

--- a/features/fixtures/application/decoders/DummyTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempDecoder.ts
@@ -11,9 +11,9 @@ export class DummyTempDecoder extends Decoder {
   constructor () {
     super();
 
-    // The list is missing the temperature measure on purpose
     this.measures = [
       { name: 'theBatteryLevel', type: 'battery' },
+      { name: 'temperature', type: 'temperature' },
     ];
 
     this.payloadsMappings = {
@@ -34,10 +34,11 @@ export class DummyTempDecoder extends Decoder {
   }
 
   async decode (payload: JSONObject): Promise<DecodedPayload> {
-    const decodedPayload = new DecodedPayload();
+    const decodedPayload = new DecodedPayload(this);
 
     decodedPayload.addMeasurement<TemperatureMeasurement>(
       payload.deviceEUI,
+      'temperature',
       {
         measuredAt: Date.now(),
         type: 'temperature',
@@ -48,14 +49,27 @@ export class DummyTempDecoder extends Decoder {
 
     decodedPayload.addMeasurement<BatteryMeasurement>(
       payload.deviceEUI,
+      'theBatteryLevel',
       {
-        deviceMeasureName: 'theBatteryLevel',
         measuredAt: Date.now(),
         type: 'battery',
         values: {
           battery: payload.batteryLevel * 100,
         },
       });
+
+    if (payload.unknownMeasure) {
+      decodedPayload.addMeasurement<TemperatureMeasurement>(
+        payload.deviceEUI,
+        'unknownMeasureName',
+        {
+          measuredAt: Date.now(),
+          type: 'temperature',
+          values: {
+            temperature: payload.unknownMeasure,
+          },
+        });
+    }
 
     return decodedPayload;
   }

--- a/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
@@ -9,14 +9,15 @@ import {
 } from '../../../../index';
 
 export class DummyTempPositionDecoder extends Decoder {
+  public measures = [
+    { name: 'theTemperature', type: 'temperature' },
+    { name: 'theBattery', type: 'battery' },
+    { name: 'thePosition', type: 'position' },
+  ] as const;
+
   constructor () {
     super();
 
-    this.measures = [
-      { name: 'theTemperature', type: 'temperature' },
-      { name: 'theBattery', type: 'battery' },
-      { name: 'thePosition', type: 'position' },
-    ];
   }
 
   async validate (payload: JSONObject) {
@@ -27,8 +28,8 @@ export class DummyTempPositionDecoder extends Decoder {
     return true;
   }
 
-  async decode (payload: JSONObject): Promise<DecodedPayload> {
-    const decodedPayload = new DecodedPayload(this);
+  async decode (payload: JSONObject): Promise<DecodedPayload<Decoder>> {
+    const decodedPayload = new DecodedPayload<DummyTempPositionDecoder>(this);
 
     decodedPayload.addMeasurement<TemperatureMeasurement>(
       payload.deviceEUI,

--- a/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
@@ -28,42 +28,42 @@ export class DummyTempPositionDecoder extends Decoder {
   }
 
   async decode (payload: JSONObject): Promise<DecodedPayload> {
-    const decodedPayload = new DecodedPayload();
+    const decodedPayload = new DecodedPayload(this);
 
     decodedPayload.addMeasurement<TemperatureMeasurement>(
       payload.deviceEUI,
+      'theTemperature',
       {
-      deviceMeasureName: 'theTemperature',
-      measuredAt: Date.now(),
-      type: 'temperature',
-      values: { temperature: payload.register55 },
-    });
+        measuredAt: Date.now(),
+        type: 'temperature',
+        values: { temperature: payload.register55 },
+      });
 
     decodedPayload.addMeasurement<PositionMeasurement>(
       payload.deviceEUI,
+      'thePosition',
       {
-      deviceMeasureName: 'thePositition',
-      measuredAt: Date.now(),
-      type: 'position',
-      values: {
-        position: {
-          lat: payload.location.lat,
-          lon: payload.location.lon,
+        measuredAt: Date.now(),
+        type: 'position',
+        values: {
+          position: {
+            lat: payload.location.lat,
+            lon: payload.location.lon,
+          },
+          accuracy: payload.location.accu,
         },
-        accuracy: payload.location.accu,
-      },
-    });
+      });
 
     decodedPayload.addMeasurement<BatteryMeasurement>(
       payload.deviceEUI,
+      'theBattery',
       {
-      deviceMeasureName: 'theBattery',
-      measuredAt: Date.now(),
-      type: 'battery',
-      values: {
-        battery: payload.batteryLevel * 100,
-      },
-    });
+        measuredAt: Date.now(),
+        type: 'battery',
+        values: {
+          battery: payload.batteryLevel * 100,
+        },
+      });
 
     return decodedPayload;
   }

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -283,15 +283,20 @@ export class AssetController extends RelationalController {
     const assetId = request.getId();
     const refresh = request.getRefresh();
     const strict = request.getBoolean('strict');
-    const devicesLinks = await this.assetService.getAsset(engineId, assetId);
 
-    if (Array.isArray(devicesLinks._source.deviceLinks)) {
-      for (const deviceLink of devicesLinks._source.deviceLinks) {
-        // TODO : Refacto to only get the asset one time
-        await this.deviceService.unlinkAsset(deviceLink.deviceId, { refresh, strict });
-      }
+    const asset = await this.assetService.get(engineId, assetId);
+
+    for (const deviceLink of asset._source.deviceLinks) {
+      // TODO : Refacto to only get the asset one time
+      await this.deviceService.unlinkAsset(deviceLink.deviceId, { refresh, strict });
     }
+
     return super.delete(request);
   }
 
+  async search (request: KuzzleRequest) {
+    request.input.args.index = request.getString('engineId');
+
+    return super.search(request);
+  }
 }

--- a/lib/controllers/DecoderController.ts
+++ b/lib/controllers/DecoderController.ts
@@ -4,7 +4,7 @@ import { DeviceManagerPlugin } from '../DeviceManagerPlugin';
 import { DecodersRegister } from '../core-classes';
 import { DeviceManagerConfiguration } from '../types';
 
-export class DecodersController {
+export class DecoderController {
   private context: PluginContext;
   private config: DeviceManagerConfiguration;
   private decodersRegister: DecodersRegister;

--- a/lib/controllers/DeviceController.ts
+++ b/lib/controllers/DeviceController.ts
@@ -74,6 +74,18 @@ export class DeviceController extends CRUDController {
           handler: this.create.bind(this),
           http: [{ path: 'device-manager/:engineId/devices', verb: 'post' }]
         },
+        update: {
+          handler: this.update.bind(this),
+          http: [{ path: 'device-manager/:engineId/device/:deviceId', verb: 'post' }]
+        },
+        search: {
+          handler: this.search.bind(this),
+          http: [{ path: 'device-manager/:engineId/devices/_search', verb: 'post' }]
+        },
+        delete: {
+          handler: this.delete.bind(this),
+          http: [{ path: 'device-manager/:engineId/device/:deviceId', verb: 'delete' }]
+        },
       }
     };
     /* eslint-enable sort-keys */
@@ -124,19 +136,22 @@ export class DeviceController extends CRUDController {
     return device;
   }
 
-  // @todo to be implemented
-  async update (): Promise<any> {
-    throw new PluginImplementationError('Not available');
+  async update (request: KuzzleRequest) {
+    request.input.args.index = request.getString('engineId');
+
+    return super.update(request);
   }
 
-  // @todo to be implemented
-  async search () {
-    throw new PluginImplementationError('Not available');
+  async search (request: KuzzleRequest) {
+    request.input.args.index = request.getString('engineId');
+
+    return super.search(request);
   }
 
-  // @todo to be implemented
-  async delete (): Promise<any> {
-    throw new PluginImplementationError('Not available');
+  async delete (request: KuzzleRequest) {
+    request.input.args.index = request.getString('engineId');
+
+    return super.delete(request);
   }
 
   /**

--- a/lib/controllers/index.ts
+++ b/lib/controllers/index.ts
@@ -1,3 +1,3 @@
 export * from './AssetController';
 export * from './DeviceController';
-export * from './DecodersController';
+export * from './DecoderController';

--- a/lib/core-classes/AssetService.ts
+++ b/lib/core-classes/AssetService.ts
@@ -48,7 +48,7 @@ export class AssetService {
     assetId: string,
     { size = 25, startAt, endAt }: { size?: number, startAt?: string, endAt?: string },
   ): Promise<KDocument<MeasureContent>[]> {
-    await this.getAsset(engineId, assetId);
+    await this.get(engineId, assetId);
 
     const query = {
       range: {
@@ -118,10 +118,7 @@ export class AssetService {
     return results;
   }
 
-  public async getAsset (
-    engineId: string,
-    assetId: string
-  ): Promise<BaseAsset> {
+  public async get (engineId: string, assetId: string): Promise<BaseAsset> {
     const document = await this.sdk.document.get<BaseAssetContent>(
       engineId,
       InternalCollection.ASSETS,
@@ -136,7 +133,7 @@ export class AssetService {
     assetMeasureNames: string[],
     { strict }: { strict?: boolean }
   ) {
-    const asset = await this.getAsset(engineId, assetId);
+    const asset = await this.get(engineId, assetId);
     const result = asset.removeMeasures(assetMeasureNames);
 
     if (strict && result.notFound.length) {

--- a/lib/core-classes/Decoder.ts
+++ b/lib/core-classes/Decoder.ts
@@ -14,10 +14,10 @@ import { DecoderContent } from '../types';
 /**
  * Array of measures declaration
  */
-export type DecoderMeasures = Array<{
-  type: string;
+export type DecoderMeasures<T = string> = ReadonlyArray<{
+  name: T;
 
-  name: string;
+  type: string;
 }>;
 
 /**
@@ -125,7 +125,7 @@ export abstract class Decoder {
    * @returns Map of `Measurements` by device reference.
    */
   // eslint-disable-next-line no-unused-vars
-  abstract decode (payload: JSONObject, request: KuzzleRequest): Promise<DecodedPayload>;
+  abstract decode (payload: JSONObject, request: KuzzleRequest): Promise<DecodedPayload<Decoder>>;
 
   /**
    * Checks if the provided properties are present in the payload

--- a/lib/core-classes/Decoder.ts
+++ b/lib/core-classes/Decoder.ts
@@ -2,22 +2,23 @@ import {
   HttpRoute,
   JSONObject,
   KuzzleRequest,
-  PluginImplementationError,
   PreconditionError,
 } from 'kuzzle';
 import _ from 'lodash';
 
 import { DecodedPayload } from '../types/DecodedPayload';
 import { DecoderContent } from '../types';
-import { MeasuresRegister } from './registers/MeasuresRegister';
-
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 /**
- * Record<deviceMeasureName, type>
+ * Array of measures declaration
  */
-export type DecoderMeasures = Record<string, string>;
+export type DecoderMeasures = Array<{
+  type: string;
+
+  name: string;
+}>;
 
 /**
  * Base class to implement a decoder for a device model.
@@ -28,14 +29,25 @@ export abstract class Decoder {
   private _http?: HttpRoute[];
 
   /**
-   * Device model name
+   * Device model name.
+   *
+   * Will be infered from the class name if not defined:
+   * `AbeewayGPSDecoder` => `AbeewayGPS`
    */
   public deviceModel: string;
 
   /**
-   * Array of device measure and their type
+   * Declaration of the measures decoded by this decoder.
+   * The name correspond of the measure name for the device.
+   * Measures types should be registered on the plugin beforehand.
+   *
+   * @example
+   *
+   * this.measures = [
+   *   { type: 'temperature', name: 'temperatureExterior' },
+   * ];
    */
-  public decoderMeasures: DecoderMeasures;
+  public measures: DecoderMeasures = [];
 
   /**
    * Custom name for the associated API action in the "payload" controller
@@ -48,6 +60,7 @@ export abstract class Decoder {
    * the device model unique identifier field.
    *
    * @example
+   *
    * this.payloadsMappings = {
    *   device_properties: {
    *     properties: {
@@ -75,27 +88,12 @@ export abstract class Decoder {
     return this._http;
   }
 
-  /**
-   * @param deviceModel Device model for this decoder
-   * @param decoderMeasures Measures created by this decoder
-   *
-   * @example
-   * super('AbeewayGPS', ['position']);
-   */
-  constructor (
-    deviceModel: string,
-    decoderMeasures: DecoderMeasures,
-    measuresRegister: MeasuresRegister,
-  ) {
-    this.deviceModel = deviceModel;
+  get measureNames (): string[] {
+    return this.measures.map(({ name }) => name);
+  }
 
-    for (const [measureName, measureType] of Object.entries(decoderMeasures)) {
-      if (! measuresRegister.has(measureType)) {
-        throw new PluginImplementationError(`Decoder "${this.constructor.name}" cannot register unknown measure type "${measureType}"`);
-      }
-    }
-
-    this.decoderMeasures = decoderMeasures;
+  get measureTypes (): string[] {
+    return this.measures.map(({ type }) => type);
   }
 
   /**
@@ -147,8 +145,8 @@ export abstract class Decoder {
 
   serialize (): DecoderContent {
     return {
-      decoderMeasures: this.decoderMeasures,
       deviceModel: this.deviceModel,
+      measures: this.measures,
     };
   }
 }

--- a/lib/measures/BatteryMeasure.ts
+++ b/lib/measures/BatteryMeasure.ts
@@ -2,11 +2,9 @@ import { Measurement, MeasureDefinition } from '../types';
 
 /* eslint-disable sort-keys */
 
-export interface BatteryMeasurement extends Measurement {
-  values: {
-    battery: number;
-  }
-}
+export type BatteryMeasurement = Measurement<{
+  battery: number;
+}>;
 
 export const batteryMeasure: MeasureDefinition = {
   valuesMappings: { battery: { type: 'integer' } },

--- a/lib/measures/HumidityMeasure.ts
+++ b/lib/measures/HumidityMeasure.ts
@@ -2,11 +2,9 @@ import { Measurement, MeasureDefinition } from '../types';
 
 /* eslint-disable sort-keys */
 
-export interface HumidityMeasurement extends Measurement {
-  values: {
-    humidity: number;
-  }
-}
+export type HumidityMeasurement = Measurement<{
+  humidity: number;
+}>;
 
 export const humidityMeasure: MeasureDefinition = {
   valuesMappings: { humidity: { type: 'float' } },

--- a/lib/measures/MovementMeasure.ts
+++ b/lib/measures/MovementMeasure.ts
@@ -2,11 +2,9 @@ import { Measurement, MeasureDefinition } from '../types';
 
 /* eslint-disable sort-keys */
 
-export interface MovementMeasurement extends Measurement {
-  values: {
-    movement: boolean;
-  }
-}
+export type MovementMeasurement = Measurement<{
+  movement: boolean;
+}>;
 
 export const movementMeasure: MeasureDefinition = {
   valuesMappings: { movement: { type: 'boolean' } },

--- a/lib/measures/PositionMeasure.ts
+++ b/lib/measures/PositionMeasure.ts
@@ -2,16 +2,14 @@ import { Measurement, MeasureDefinition } from '../types';
 
 /* eslint-disable sort-keys */
 
-export interface PositionMeasurement extends Measurement {
-  values: {
-    position: {
-      lat: number;
-      lon: number;
-    };
-    altitude?: number;
-    accuracy?: number;
-  }
-}
+export type PositionMeasurement = Measurement<{
+  position: {
+    lat: number;
+    lon: number;
+  };
+  altitude?: number;
+  accuracy?: number;
+}>;
 
 export const positionMeasure: MeasureDefinition = {
   valuesMappings: {

--- a/lib/measures/TemperatureMeasure.ts
+++ b/lib/measures/TemperatureMeasure.ts
@@ -1,12 +1,10 @@
-import { Measurement, MeasureDefinition } from '../types';
+import { MeasureDefinition, Measurement } from '../types';
 
 /* eslint-disable sort-keys */
 
-export interface TemperatureMeasurement extends Measurement {
-  values: {
-    temperature: number;
-  }
-}
+export type TemperatureMeasurement = Measurement<{
+  temperature: number;
+}>;
 
 export const temperatureMeasure: MeasureDefinition = {
   valuesMappings: { temperature: { type: 'float' } },

--- a/lib/models/BaseAsset.ts
+++ b/lib/models/BaseAsset.ts
@@ -1,7 +1,7 @@
 import { JSONObject } from 'kuzzle';
 import { LinkRequest } from '../types/Request';
 
-import { BaseAssetContent, DeviceLink, MeasureContent } from '../types';
+import { BaseAssetContent, MeasureContent } from '../types';
 import { Device } from './Device';
 
 export class BaseAsset {
@@ -20,6 +20,10 @@ export class BaseAsset {
     if (! Array.isArray(this._source.measures)) {
       this._source.measures = [];
     }
+
+    if (! Array.isArray(this._source.deviceLinks)) {
+      this._source.deviceLinks = [];
+    }
   }
 
   public linkToDevice (linkRequest: LinkRequest) {
@@ -29,8 +33,7 @@ export class BaseAsset {
   public unlinkDevice (device: Device) {
     // TOSEE : Iterate over all or assert there is
     // only one link and remove first match?
-    const linkToKeep = this._source.deviceLinks.filter(
-      (deviceLink: DeviceLink) => deviceLink.deviceId !== device._id);
+    const linkToKeep = this._source.deviceLinks.filter(link => link.deviceId !== device._id);
 
     this._source.deviceLinks = linkToKeep;
   }

--- a/lib/types/DecodedPayload.ts
+++ b/lib/types/DecodedPayload.ts
@@ -7,29 +7,56 @@ import { Measurement } from './measures/MeasureContent';
  *
  * @example
  * const decodedPayload: DecodedPayload = {
- *   'BZH42AZF': [
- *     {
- *       deviceMeasureName: 'battery',
- *       measuredAt: 1655379939496,
- *       type: 'battery',
- *       values: { battery: 32 },
- *     },
- *   ],
- *   'IS7L8HK': [
- *     {
- *       deviceMeasureName: 'internal_temperature',
- *       measuredAt: 1655379939496,
- *       type: 'temperature',
- *       values: { temperature: -3 },
- *     },
- *     {
- *       deviceMeasureName: 'external_temperature',
- *       measuredAt: 1655379939496,
- *       type: 'temperature',
- *       values: { temperature: 39 },
- *     },
- *   ],
+ *   devices: {
+ *     'BZH42AZF': [
+ *       {
+ *         deviceMeasureName: 'battery',
+ *         measuredAt: 1655379939496,
+ *         type: 'battery',
+ *         values: { battery: 32 },
+ *       },
+ *     ],
+ *     'IS7L8HK': [
+ *       {
+ *         deviceMeasureName: 'internal_temperature',
+ *         measuredAt: 1655379939496,
+ *         type: 'temperature',
+ *         values: { temperature: -3 },
+ *       },
+ *       {
+ *         deviceMeasureName: 'external_temperature',
+ *         measuredAt: 1655379939496,
+ *         type: 'temperature',
+ *         values: { temperature: 39 },
+ *       },
+ *     ],
+ *   }
  * };
  */
-export type DecodedPayload = Record<string, Measurement[]>;
-// @todo we should have an intermediary object
+export class DecodedPayload {
+  /**
+   * Measurements per device.
+   *
+   * Record<deviceReference, Measurement[]>
+   */
+  private measurementsByDevice: Record<string, Measurement[]> = {};
+
+  get references () {
+    return Object.keys(this.measurementsByDevice);
+  }
+
+  addMeasurement<TMeasurement extends Measurement = Measurement> (
+    deviceReference: string,
+    measurement: TMeasurement,
+  ) {
+    if (! this.measurementsByDevice[deviceReference]) {
+      this.measurementsByDevice[deviceReference] = [];
+    }
+
+    this.measurementsByDevice[deviceReference].push(measurement);
+  }
+
+  getMeasurements (deviceReference: string): Measurement[] {
+    return this.measurementsByDevice[deviceReference];
+  }
+}

--- a/lib/types/DecodedPayload.ts
+++ b/lib/types/DecodedPayload.ts
@@ -1,15 +1,23 @@
+import { PluginImplementationError } from 'kuzzle';
+import { Decoder } from '../core-classes/Decoder';
 import { Measurement } from './measures/MeasureContent';
 
 /**
  * Class containing the decoded measures.
  */
 export class DecodedPayload {
+  private decoder: Decoder;
+
   /**
    * Measurements per device.
    *
    * Record<deviceReference, Measurement[]>
    */
   private measurementsByDevice: Record<string, Measurement[]> = {};
+
+  constructor (decoder: Decoder) {
+    this.decoder = decoder;
+  }
 
   get references () {
     return Object.keys(this.measurementsByDevice);
@@ -19,15 +27,23 @@ export class DecodedPayload {
    * Add a new measure into the decoded payload
    *
    * @param deviceReference Device reference
+   * @param measureName Name of the decoded measure
    * @param measurement Measurement object
    */
   addMeasurement<TMeasurement extends Measurement = Measurement> (
     deviceReference: string,
+    measureName: string,
     measurement: TMeasurement,
   ) {
+    if (! this.decoder.measureNames.includes(measureName)) {
+      throw new PluginImplementationError(`Decoder "${this.decoder.deviceModel}" has no measure named "${measureName}"`);
+    }
+
     if (! this.measurementsByDevice[deviceReference]) {
       this.measurementsByDevice[deviceReference] = [];
     }
+
+    measurement.deviceMeasureName = measureName;
 
     this.measurementsByDevice[deviceReference].push(measurement);
   }

--- a/lib/types/DecodedPayload.ts
+++ b/lib/types/DecodedPayload.ts
@@ -1,37 +1,7 @@
 import { Measurement } from './measures/MeasureContent';
 
 /**
- * Record containing decoded measurements for each device.
- *
- * Record<deviceReference, Measurement[]>
- *
- * @example
- * const decodedPayload: DecodedPayload = {
- *   devices: {
- *     'BZH42AZF': [
- *       {
- *         deviceMeasureName: 'battery',
- *         measuredAt: 1655379939496,
- *         type: 'battery',
- *         values: { battery: 32 },
- *       },
- *     ],
- *     'IS7L8HK': [
- *       {
- *         deviceMeasureName: 'internal_temperature',
- *         measuredAt: 1655379939496,
- *         type: 'temperature',
- *         values: { temperature: -3 },
- *       },
- *       {
- *         deviceMeasureName: 'external_temperature',
- *         measuredAt: 1655379939496,
- *         type: 'temperature',
- *         values: { temperature: 39 },
- *       },
- *     ],
- *   }
- * };
+ * Class containing the decoded measures.
  */
 export class DecodedPayload {
   /**
@@ -45,6 +15,12 @@ export class DecodedPayload {
     return Object.keys(this.measurementsByDevice);
   }
 
+  /**
+   * Add a new measure into the decoded payload
+   *
+   * @param deviceReference Device reference
+   * @param measurement Measurement object
+   */
   addMeasurement<TMeasurement extends Measurement = Measurement> (
     deviceReference: string,
     measurement: TMeasurement,
@@ -56,6 +32,9 @@ export class DecodedPayload {
     this.measurementsByDevice[deviceReference].push(measurement);
   }
 
+  /**
+   * Gets the measurements decoded for a device
+   */
   getMeasurements (deviceReference: string): Measurement[] {
     return this.measurementsByDevice[deviceReference];
   }

--- a/lib/types/DecodedPayload.ts
+++ b/lib/types/DecodedPayload.ts
@@ -5,8 +5,8 @@ import { Measurement } from './measures/MeasureContent';
 /**
  * Class containing the decoded measures.
  */
-export class DecodedPayload {
-  private decoder: Decoder;
+export class DecodedPayload<TDecoder extends Decoder = Decoder> {
+  public decoder: TDecoder;
 
   /**
    * Measurements per device.
@@ -15,7 +15,7 @@ export class DecodedPayload {
    */
   private measurementsByDevice: Record<string, Measurement[]> = {};
 
-  constructor (decoder: Decoder) {
+  constructor (decoder: TDecoder) {
     this.decoder = decoder;
   }
 
@@ -32,7 +32,7 @@ export class DecodedPayload {
    */
   addMeasurement<TMeasurement extends Measurement = Measurement> (
     deviceReference: string,
-    measureName: string,
+    measureName: TDecoder['measures'][number]['name'],
     measurement: TMeasurement,
   ) {
     if (! this.decoder.measureNames.includes(measureName)) {

--- a/lib/types/DecoderContent.ts
+++ b/lib/types/DecoderContent.ts
@@ -2,5 +2,6 @@ import { DecoderMeasures } from '../core-classes/Decoder';
 
 export interface DecoderContent {
   deviceModel: string,
-  decoderMeasures: DecoderMeasures,
+
+  measures: DecoderMeasures,
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -11,3 +11,7 @@ export * from './DecoderContent';
 export * from './DecodedPayload';
 
 export * from './DeviceManagerConfiguration';
+
+export * from './MetadataContent';
+
+export * from './AssetCategoryContent';

--- a/lib/types/measures/MeasureContent.ts
+++ b/lib/types/measures/MeasureContent.ts
@@ -7,8 +7,10 @@ import { MeasureUnit } from './MeasureDefinition';
  *
  * This interface should be extended and the `values` property specialized
  * to declare new measurement type.
+ *
+ * @todo cannot use type when iterating on measure of the pipe event
  */
-export interface Measurement {
+export interface Measurement<TMeasurementValues extends JSONObject = JSONObject> {
   /**
    * Type of the measure. (e.g. "temperature")
    * The type name is also the name of the sub-property to look at
@@ -21,7 +23,7 @@ export interface Measurement {
    *
    * This should be specialized by child interfaces.
    */
-  values: JSONObject;
+  values: TMeasurementValues;
 
   /**
    * Micro Timestamp of the measurement time.
@@ -32,13 +34,15 @@ export interface Measurement {
    * Name given by the decoder to the measure.
    *
    * By default, it's the type of the measure
+   * @todo device.name
    */
   deviceMeasureName?: string;
 }
 
-export interface AssetMeasurement extends Measurement {
+export interface AssetMeasurement<TMeasurementValues extends JSONObject = JSONObject> extends Measurement<TMeasurementValues> {
   /**
    * Name given by the `deviceLink` of the linked asset.
+   * @todo asset.name
    */
   assetMeasureName: string;
 }
@@ -46,7 +50,7 @@ export interface AssetMeasurement extends Measurement {
 /**
  * Represent the full content of a measure document.
  */
-export interface MeasureContent extends KDocumentContent, AssetMeasurement {
+export interface MeasureContent<TMeasurementValues extends JSONObject = JSONObject> extends KDocumentContent, AssetMeasurement<TMeasurementValues> {
   /**
    * Measurement self-description.
    */
@@ -59,7 +63,7 @@ export interface MeasureContent extends KDocumentContent, AssetMeasurement {
     /**
      * From what the measure has been pushed.
      */
-    type: OriginType;
+    type: 'user' | 'device';
 
     /**
      * Payload uuid that was used to create this measure.
@@ -83,12 +87,4 @@ export interface MeasureContent extends KDocumentContent, AssetMeasurement {
      */
     assetId?: string;
   }
-}
-
-/**
- * From where the measure has been pushed
- */
-export enum OriginType {
-  USER = 'user',
-  DEVICE = 'device',
 }

--- a/lib/types/measures/MeasureDefinition.ts
+++ b/lib/types/measures/MeasureDefinition.ts
@@ -24,7 +24,7 @@ export interface MeasureUnit {
  *
  * @example
  * {
- *   measurementMappings: { temperature: { type: 'float' } },
+ *   valuesMappings: { temperature: { type: 'float' } },
  *   unit: {
  *     name: 'Degree',
  *     sign: '°',
@@ -41,5 +41,5 @@ export interface MeasureDefinition {
   /**
    * Mappings for the measurement values in order to index the fields
    */
-   valuesMappings: JSONObject;
+  valuesMappings: JSONObject;
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the following DX changes for the Decoder class:
 - The constructor does not take any arguments
 - The device model is inferred from the class name (e.g. `AbeewayGPSDecoder` => device model name is `AbeewayGPS`) or use the `deviceModel` property
 - Measures declaration is done in the `measures` property as an array of objects containing a `name` and `type` properties
 - `DecodedPayload` is now a class with a `addMeasurement` method and should be returned from the `Decoder.decode` method

Full example:
```js
class DummyTempDecoder extends Decoder {
  constructor () {
    super();

    this.measures = [
      { name: 'mainBattery', type: 'battery' },
      { name: 'temperature', type: 'temperature' },
    ];

    this.payloadsMappings = {
      deviceEUI: { type: 'keyword' }
    };
  }

  async decode (payload: JSONObject): Promise<DecodedPayload<Decoder>> {
    const decodedPayload = new DecodedPayload<DummyTempDecoder>();

    decodedPayload.addMeasurement<TemperatureMeasurement>(
      payload.deviceEUI,
      'temperature',
      {
        measuredAt: Date.now(),
        type: 'temperature',
        values: {
          temperature: payload.register55,
        },
      });

    decodedPayload.addMeasurement<BatteryMeasurement>(
      payload.deviceEUI,
      'mainBattery',
      {
        measuredAt: Date.now(),
        type: 'battery',
        values: {
          battery: payload.batteryLevel * 100,
        },
      });

    return decodedPayload;
  }
}
```


### Other changes

The `Measurement` type now accepts an optional parameters who will be used to type the `measurement.values`:

```
export type TemperatureMeasurement = Measurement<{
  temperature: number;
}>;

const temperature: TemperatureMeasurement = {
  measuredAt: Date.now(),
  type: 'temperature',
  values: {
    // Trying to put another value here will raise a type error
    temperature: devicePayload.temperature,
  },
};
```
