### PR TITLE
Create a custom search endpoint for assets

### DIFF
--- a/features/AssetCategory.feature
+++ b/features/AssetCategory.feature
@@ -201,7 +201,6 @@ Feature: AssetCategory
     When I successfully execute the action "device-manager/asset":"search" with args:
       | engineId                | "engine-ayse"      |
       | body.query.match.reference | "asset_02" |
-    Then I debug "result"
     Then I should receive a result matching:
       | hits[0]._source.type             | "truck"    |
       | hits[0]._source.model            | "M"        |

--- a/features/AssetCategory.feature
+++ b/features/AssetCategory.feature
@@ -173,7 +173,7 @@ Feature: AssetCategory
       | status | 400 |
 
 
-  Scenario: Create an asset with AssetCategory and present mandatory metadata
+  Scenario: Create an asset with AssetCategory and present mandatory metadata, then verify content given by get and search method
     When I successfully execute the action "device-manager/asset":"create" with args:
       | engineId              | "engine-ayse" |
       | body.type             | "truck"       |
@@ -197,6 +197,17 @@ Feature: AssetCategory
       | reference        | "asset_02" |
       | category.name    | "bigTruck" |
       | metadata.surname | "test"     |
+    Then I refresh the collection "engine-ayse":"assets"
+    When I successfully execute the action "device-manager/asset":"search" with args:
+      | engineId                | "engine-ayse"      |
+      | body.query.match.reference | "asset_02" |
+    Then I debug "result"
+    Then I should receive a result matching:
+      | hits[0]._source.type             | "truck"    |
+      | hits[0]._source.model            | "M"        |
+      | hits[0]._source.reference        | "asset_02" |
+      | hits[0]._source.category.name    | "bigTruck" |
+      | hits[0]._source.metadata.surname | "test"     |
 
   Scenario: Create an assetCategory, a mandatory metadata, link them statically and create an asset with
     When I successfully execute the action "device-manager/assetCategory":"create" with args:

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -1,6 +1,6 @@
 import csv from 'csvtojson';
 import {
-  BadRequestError, 
+  BadRequestError,
   KuzzleRequest,
   Plugin,
 } from 'kuzzle';
@@ -298,12 +298,10 @@ export class AssetController extends RelationalController {
    */
   async search (request: KuzzleRequest) {
     const engineId = request.getString('engineId');
-    request.input.args.index = engineId;
-    const index = request.getIndex();
     const { searchBody } = request.getSearchParams();
     const category = this.getFieldPath(request, 'category', null, 'asset-category');
 
-    const res = await this.sdk.document.search<BaseAssetContent>(index, this.collection, searchBody);
+    const res = await this.sdk.document.search<BaseAssetContent>(engineId, this.collection, searchBody);
     for (const hit of res.hits) {
       const document = await this.esDocumentToFormatted<BaseAssetContent>(engineId, this.collection, hit, [category]);
       this.assetCategoryService.formatDocumentMetadata(document);

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -300,12 +300,7 @@ export class AssetController extends RelationalController {
     const res = await this.sdk.document.search<BaseAssetContent>(index, this.collection, searchBody);
     for (const hit of res.hits) {
       const document = await this.esDocumentToFormatted<BaseAssetContent>(engineId, this.collection, hit, [category]);
-      const metadata = document._source.metadata;
-      const asset = document._source as JSONObject;
-      if (metadata) {
-        asset.metadata = await this.assetCategoryService.formatMetadataForGet(metadata);
-      }
-      hit._source = asset as BaseAssetContent;
+      this.assetCategoryService.formatDocumentMetadata(document);
     }
     return res;
 

--- a/lib/controllers/AssetController.ts
+++ b/lib/controllers/AssetController.ts
@@ -1,6 +1,6 @@
 import csv from 'csvtojson';
 import {
-  BadRequestError, JSONObject,
+  BadRequestError, 
   KuzzleRequest,
   Plugin,
 } from 'kuzzle';

--- a/lib/controllers/RelationalController.ts
+++ b/lib/controllers/RelationalController.ts
@@ -439,6 +439,17 @@ export abstract class RelationalController extends CRUDController {
    */
   protected async genericGet<TKDocumentContent extends KDocumentContent> (index: string, collection : string, documentId : string, nestedFields : FieldPath[] = []): Promise<KDocument<TKDocumentContent>> {
     const document = await this.sdk.document.get<TKDocumentContent>(index, collection, documentId);
+    return this.esDocumentToFormatted(index, collection, document, nestedFields);
+  }
+
+  /**
+   *
+   * @param index
+   * @param collection
+   * @param documentId
+   * @param nestedFields : contain field name in the document to get, collection name and index name of documents that are linked
+   */
+  protected async esDocumentToFormatted<TKDocumentContent extends KDocumentContent> (index: string, collection : string, document : KDocument<TKDocumentContent>, nestedFields : FieldPath[] = []): Promise<KDocument<TKDocumentContent>> {
     const promises : Promise<void>[] = [];
     for (const nestedField of nestedFields) {
       promises.push(this.replaceNestedFieldByContent(document, nestedField));

--- a/lib/controllers/RelationalController.ts
+++ b/lib/controllers/RelationalController.ts
@@ -443,7 +443,6 @@ export abstract class RelationalController extends CRUDController {
   }
 
   /**
-   *
    * @param index
    * @param collection
    * @param documentId

--- a/lib/core-classes/AssetCategoryService.ts
+++ b/lib/core-classes/AssetCategoryService.ts
@@ -1,7 +1,7 @@
 import { MetadataContent } from '../types/MetadataContent';
 import { AssetCategoryContent, FormattedMetadata, FormattedValue } from '../types/AssetCategoryContent';
-import { JSONObject, Plugin, PluginContext } from 'kuzzle';
-import { DeviceManagerConfiguration } from '../types';
+import { JSONObject, KDocument, Plugin, PluginContext } from 'kuzzle';
+import { BaseAssetContent, DeviceManagerConfiguration } from '../types';
 import isEqual from 'lodash.isequal';
 
 export class AssetCategoryService {
@@ -165,6 +165,19 @@ export class AssetCategoryService {
       formattedMetadata.push({ key, value: this.formatValue(value) });
     }
     return formattedMetadata;
+  }
+
+  /**
+   * edit the document to format metadata
+   * @param document
+   */
+  formatDocumentMetadata (document : KDocument<BaseAssetContent>): KDocument<BaseAssetContent> {
+    const metadata = document._source.metadata;
+    const asset = document._source as JSONObject;
+    if (metadata) {
+      asset.metadata = this.formatMetadataForGet(metadata);
+    }
+    return document;
   }
 
   formatMetadataForGet (assetMetadata : FormattedMetadata[]) {

--- a/lib/core-classes/AssetCategoryService.ts
+++ b/lib/core-classes/AssetCategoryService.ts
@@ -173,8 +173,8 @@ export class AssetCategoryService {
    */
   formatDocumentMetadata (document : KDocument<BaseAssetContent>): KDocument<BaseAssetContent> {
     const metadata = document._source.metadata;
-    const asset = document._source as JSONObject;
     if (metadata) {
+      const asset = document._source as JSONObject;
       asset.metadata = this.formatMetadataForGet(metadata);
     }
     return document;

--- a/lib/core-classes/DeviceService.ts
+++ b/lib/core-classes/DeviceService.ts
@@ -303,7 +303,7 @@ export class DeviceService {
           });
     }
 
-    device.linkToAsset({ assetId, deviceLink,engineId });
+    device.linkToAsset({ assetId, deviceLink, engineId });
     asset.linkToDevice({ assetId, deviceLink, engineId });
 
     const response = await this.app.trigger(


### PR DESCRIPTION

## What does this PR do ?

add custom search endpoint for assets, giving preprocessed assets

### How should this be manually tested?

Do POST http request on http://{{kuzzle}}:7512/_/device-manager/{{engineId}}/assets/_search

### Other changes

part of code of assetController go to assetService to have a lighter controller. 
