### PR TITLE
Add code from the guide in the functional test application

### DIFF
--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -5,18 +5,23 @@ import {
   DummyMultiTempDecoder,
   DummyTempDecoder,
   DummyTempPositionDecoder,
+  DummyAccelerometer3dDecoder,
 } from './decoders';
 import { registerTestPipes } from './testPipes'
 import { TreeNodeController } from '../../fakeclasses/TreeNodeController';
 import { InvertTreeNodeController } from '../../fakeclasses/InvertTreeNodeController';
+import { acceleration3dMeasure } from './measures/Acceleration3dMeasure';
 
 const app = new Backend('kuzzle');
 
 const deviceManager = new DeviceManagerPlugin();
 
+deviceManager.measures.register('acceleration3d', acceleration3dMeasure);
+
 deviceManager.decoders.register(new DummyTempDecoder());
 deviceManager.decoders.register(new DummyMultiTempDecoder());
 deviceManager.decoders.register(new DummyTempPositionDecoder());
+deviceManager.decoders.register(new DummyAccelerometer3dDecoder());
 
 deviceManager.devices.registerMetadata({
   group: {

--- a/features/fixtures/application/decoders/DummyAccelerometer3d.ts
+++ b/features/fixtures/application/decoders/DummyAccelerometer3d.ts
@@ -1,0 +1,42 @@
+import { JSONObject } from 'kuzzle';
+
+import {
+    DecodedPayload, Decoder
+} from '../../../../index';
+import { Acceleration3dMeasurement } from '../measures/Acceleration3dMeasure';
+
+export class DummyAccelerometer3dDecoder extends Decoder {
+  public measures = [
+    { name: 'acceleration3d', type: 'acceleration3d' },
+  ] as const;
+
+  constructor () {
+    super();
+
+    this.payloadsMappings = {
+      deviceEUI: { type: 'keyword' }
+    };
+  }
+
+  async validate (payload: JSONObject) {
+    return payload.x && payload.y && payload.z && payload.id;
+  }
+
+  async decode (payload: JSONObject): Promise<DecodedPayload<Decoder>> {
+    const decodedPayload = new DecodedPayload<DummyAccelerometer3dDecoder>(this);
+
+    const measurement: Acceleration3dMeasurement = {
+      measuredAt: Date.now(),
+      type: 'acceleration3d',
+      values: {
+        x: payload.x,
+        y: payload.y,
+        z: payload.z,
+      }
+    }
+
+    decodedPayload.addMeasurement(payload.id, 'acceleration3d', measurement);
+
+    return decodedPayload;
+  }
+}

--- a/features/fixtures/application/decoders/index.ts
+++ b/features/fixtures/application/decoders/index.ts
@@ -3,3 +3,5 @@ export * from './DummyMultiTempDecoder';
 export * from './DummyTempDecoder';
 
 export * from './DummyTempPositionDecoder';
+
+export * from './DummyAccelerometer3d';

--- a/features/fixtures/application/measures/Acceleration3dMeasure.ts
+++ b/features/fixtures/application/measures/Acceleration3dMeasure.ts
@@ -1,0 +1,22 @@
+import { Measurement, MeasureDefinition } from "lib/types";
+
+/* eslint-disable sort-keys */
+
+export type Acceleration3dMeasurement = Measurement<{
+  x: number;
+  y: number;
+  z: number;
+}>;
+
+export const acceleration3dMeasure: MeasureDefinition = {
+  valuesMappings: {
+    x: { type: 'float' },
+    y: { type: 'float' },
+    z: { type: 'float' },
+  },
+  unit: {
+    name: 'Acceleration',
+    sign: 'm/s^2',
+    type: 'number',
+  },
+};

--- a/lib/core-classes/MeasureService.ts
+++ b/lib/core-classes/MeasureService.ts
@@ -404,9 +404,14 @@ export class MeasureService {
     const deviceLink = asset._source.deviceLinks.find(
       link => link.deviceId === device._id);
 
+    // TOSEE Convert to assert ?
+    if (! deviceLink) {
+      throw new PluginImplementationError(`The device "${device._id}" is not linked to the asset "${asset._id}"`);
+    }
+
     const measureLink = deviceLink.measureNamesLinks.find(
       nameLink => nameLink.deviceMeasureName === deviceMeasureName);
 
-    return measureLink.assetMeasureName;
+    return measureLink ? measureLink.assetMeasureName : undefined;
   }
 }

--- a/lib/core-classes/MeasureService.ts
+++ b/lib/core-classes/MeasureService.ts
@@ -404,14 +404,9 @@ export class MeasureService {
     const deviceLink = asset._source.deviceLinks.find(
       link => link.deviceId === device._id);
 
-    // TOSEE Convert to assert ?
-    if (! deviceLink) {
-      throw new PluginImplementationError(`The device "${device._id}" is not linked to the asset "${asset._id}"`);
-    }
-
     const measureLink = deviceLink.measureNamesLinks.find(
       nameLink => nameLink.deviceMeasureName === deviceMeasureName);
 
-    return measureLink ? measureLink.assetMeasureName : undefined;
+    return measureLink.assetMeasureName;
   }
 }


### PR DESCRIPTION
## What does this PR do ?

Implement the example of `MeasureDefinition` and `Decoder` of the guides in the functional test application.

### How should this be manually tested?

Follow the new guide :)