### PR TITLE
correct format geo_point

### DIFF
--- a/lib/modules/asset-category/AssetCategoryService.ts
+++ b/lib/modules/asset-category/AssetCategoryService.ts
@@ -202,10 +202,15 @@ export class AssetCategoryService {
       formattedValue.integer = value;
     } else if (typeof value === "boolean") {
       formattedValue.boolean = value;
-    } else if (value.lat) {
-      formattedValue.geo_point = value;
     } else if (typeof value === "object") {
-      formattedValue.object = this.formatMetadataForES(value);
+      if (
+        Object.prototype.hasOwnProperty.call(value, "lat") &&
+        Object.prototype.hasOwnProperty.call(value, "lon")
+      ) {
+        formattedValue.geo_point = value;
+      } else {
+        formattedValue.object = this.formatMetadataForES(value);
+      }
     } else {
       formattedValue.keyword = value;
     }

--- a/lib/modules/asset-category/AssetCategoryService.ts
+++ b/lib/modules/asset-category/AssetCategoryService.ts
@@ -204,8 +204,8 @@ export class AssetCategoryService {
       formattedValue.boolean = value;
     } else if (typeof value === "object") {
       if (
-        Object.prototype.hasOwnProperty.call(value, "lat") &&
-        Object.prototype.hasOwnProperty.call(value, "lon")
+        typeof value.lat !== "undefined" &&
+        typeof value.lon !== "undefined"
       ) {
         formattedValue.geo_point = value;
       } else {


### PR DESCRIPTION
When send metadata "geolocation" with `geo_point` like:
```json
{
  "geolocation": {
    "lat": 0,
    "lon": 0
  }
}
```

The data are formated in object
```json
{
  "key": "geolocation",
  "value": {
    "object": [
      {
        "key": "lat",
        "value": {
          "integer": 0
        }
      },
      {
        "key": "lon",
        "value": {
          "integer": 0
        }
      }
    ]
  }
}
```

Instead of geo_point like
```json
{
  "key": "geolocation",
  "value": {
    "geo_point": {
      "lat": 0,
      "lon": 0
    }
  }
}
```

It's due to this test:
https://github.com/kuzzleio/kuzzle-device-manager/blob/26d87060eb5a8855737a40f7e78582928b08802b/lib/modules/asset-category/AssetCategoryService.ts#L205

It's not "safe" because value `0` are considered like `falsy` so in this case format in geo_point are ignored and pass in the next condition "format like object" and produce bad metadata.
So In this case prefer test like `typeof value.lat === "undefined"` or test with hasOwnProperty `Object.prototype.hasOwnProperty.call(value, "lat")`