### PR TITLE
Add default roles

### DIFF
--- a/features/Asset/Roles.feature
+++ b/features/Asset/Roles.feature
@@ -1,0 +1,41 @@
+Feature: Default assets roles are registered
+
+  Scenario: Find default assets roles
+    Then The role "assets.reader" should match:
+    """
+      {
+        "controllers": {
+          "device-manager/assets": {
+            "actions": {
+              "get": true,
+              "search": true,
+              "getMeasures": true,
+            },
+          },
+          "device-manager/models": {
+            "actions": {
+              "listAssets": true,
+            },
+          },
+        },
+      }
+    """
+    Then The role "assets.admin" should match:
+    """
+    {
+      "controllers": {
+        "device-manager/assets": {
+          "actions": {
+            "*": true,
+          },
+        },
+        "device-manager/models": {
+          "actions": {
+            "listAssets": true,
+            "writeAsset": true,
+            "deleteAsset": true,
+          },
+        },
+      },
+    }
+    """

--- a/features/Decoder/Roles.feature
+++ b/features/Decoder/Roles.feature
@@ -1,0 +1,15 @@
+Feature: Default decoders roles are registered
+
+  Scenario: Find default decoders roles
+    Then The role "decoders.admin" should match:
+    """
+      {
+        "controllers": {
+          "device-manager/decoders": {
+            "actions": {
+              "*": true,
+            },
+          },
+        },
+      }
+    """

--- a/features/Device/Roles.feature
+++ b/features/Device/Roles.feature
@@ -1,0 +1,46 @@
+Feature: Default devices roles are registered
+
+  Scenario: Find default devices roles
+    Then The role "devices.reader" should match:
+    """
+      {
+        "controllers": {
+          "device-manager/devices": {
+            "actions": {
+              "get": true,
+              "search": true,
+            },
+          },
+          "device-manager/models": {
+            "actions": {
+              "listDevices": true,
+            },
+          },
+        },
+      }
+    """
+    Then The role "devices.admin" should match:
+    """
+      {
+        "controllers": {
+          "device-manager/devices": {
+            "actions": {
+              "create": true,
+              "get": true,
+              "update": true,
+              "search": true,
+              "delete": true,
+              "linkAsset": true,
+              "unlinkAsset": true,
+            },
+          },
+          "device-manager/models": {
+            "actions": {
+              "listDevices": true,
+              "writeDevice": true,
+              "deleteDevice": true,
+            },
+          },
+        },
+      }
+  """

--- a/features/Measure/Roles.feature
+++ b/features/Measure/Roles.feature
@@ -1,0 +1,34 @@
+Feature: Default measures roles are registered
+
+  Scenario: Find default measures roles
+    Then The role "measures.reader" should match:
+    """
+      {
+        "controllers": {
+          "device-manager/models": {
+            "actions": {
+              "listMeasures": true,
+            },
+          },
+        },
+      }
+    """
+    Then The role "measures.admin" should match:
+    """
+      {
+        "controllers": {
+          "device-manager/measures": {
+            "actions": {
+              "*": true,
+            },
+          },
+          "device-manager/models": {
+            "actions": {
+              "listMeasures": true,
+              "writeMeasure": true,
+              "deleteMeasure": true,
+            },
+          },
+        },
+      }
+    """

--- a/features/Model/Controller.feature
+++ b/features/Model/Controller.feature
@@ -27,8 +27,9 @@ Feature: Model Controller
     When I successfully execute the action "device-manager/models":"listAssets" with args:
       | engineGroup | "commons" |
     Then I should receive a result matching:
-      | total         | 3                   |
-      | models[2]._id | "model-asset-plane" |
+      | total         | 3                       |
+      | models[0]._id | "model-asset-container" |
+      | models[1]._id | "model-asset-plane"     |
 
   @models
   Scenario: Create an asset with default metadata values
@@ -109,7 +110,8 @@ Feature: Model Controller
     When I successfully execute the action "device-manager/models":"listMeasures"
     Then I should receive a result matching:
       | total         | 6                        |
-      | models[5]._id | "model-measure-presence" |
+      | models[0]._id | "model-measure-battery"  |
+      | models[4]._id | "model-measure-presence" |
 
   Scenario: Register models from the framework
     Then The document "device-manager":"models":"model-asset-container" content match:

--- a/features/Model/Controller.feature
+++ b/features/Model/Controller.feature
@@ -31,6 +31,32 @@ Feature: Model Controller
       | models[2]._id | "model-asset-plane" |
 
   @models
+  Scenario: Create an asset with default metadata values
+    Given I successfully execute the action "device-manager/models":"writeAsset" with args:
+      | body.engineGroup      | "commons"                                                                               |
+      | body.model            | "plane"                                                                                 |
+      | body.metadataMappings | { size: { type: "integer" }, person: { properties: { company: { type: "keyword" } } } } |
+      | body.defaultValues    | { "person.company": "Firebird" }                                                        |
+    When I successfully execute the action "device-manager/assets":"create" with args:
+      | engineId           | "engine-kuzzle" |
+      | body.model         | "plane"         |
+      | body.reference     | "Dasha31"       |
+      | body.metadata.size | 179             |
+    Then The document "engine-kuzzle":"assets":"plane-Dasha31" content match:
+      | metadata.size           | 179        |
+      | metadata.person.company | "Firebird" |
+
+  @models
+  Scenario: Error if a default value is not a metadata
+    Given I execute the action "device-manager/models":"writeAsset" with args:
+      | body.engineGroup      | "commons"                     |
+      | body.model            | "plane"                       |
+      | body.metadataMappings | { size: { type: "integer" } } |
+      | body.defaultValues    | { "name": "Firebird" }        |
+    Then I should receive an error matching:
+      | message | "The default value \"name\" is not in the metadata mappings." |
+
+  @models
   Scenario: Write and List a Device model
     When I successfully execute the action "device-manager/models":"writeDevice" with args:
       | body.model            | "Zigbee"                         |
@@ -53,7 +79,7 @@ Feature: Model Controller
       | properties.metadata.properties.network2.type | "keyword" |
     When I successfully execute the action "device-manager/models":"listDevices"
     Then I should receive a result matching:
-      | total         | 3                    |
+      | total         | 3                     |
       | models[2]._id | "model-device-Zigbee" |
 
   @models

--- a/features/step_definitions/common/security-steps.js
+++ b/features/step_definitions/common/security-steps.js
@@ -159,14 +159,15 @@ Then("The role {string} should match the default one", async function (roleId) {
   }
 });
 
-Then("The role {string} should match:", async function (roleId, dataTable) {
-  const controllers = this.parseObject(dataTable),
-    role = await this.sdk.security.getRole(roleId);
+Then(
+  "The role {string} should match:",
+  async function (roleId, raw) {
+    const roleDefinition = eval(`let o = ${raw};o`);
+    const role = await this.sdk.security.getRole(roleId);
 
-  for (const [controller, actions] of Object.entries(controllers)) {
-    should(actions).match(role.controllers[controller].actions);
+    should(role).matchObject(roleDefinition);
   }
-});
+);
 
 Then(
   "The profile {string} policies should match:",

--- a/features/step_definitions/common/security-steps.js
+++ b/features/step_definitions/common/security-steps.js
@@ -159,15 +159,12 @@ Then("The role {string} should match the default one", async function (roleId) {
   }
 });
 
-Then(
-  "The role {string} should match:",
-  async function (roleId, raw) {
-    const roleDefinition = eval(`let o = ${raw};o`);
-    const role = await this.sdk.security.getRole(roleId);
+Then("The role {string} should match:", async function (roleId, raw) {
+  const roleDefinition = eval(`let o = ${raw};o`);
+  const role = await this.sdk.security.getRole(roleId);
 
-    should(role).matchObject(roleDefinition);
-  }
-);
+  should(role).matchObject(roleDefinition);
+});
 
 Then(
   "The profile {string} policies should match:",

--- a/lib/core/DeviceManagerConfiguration.ts
+++ b/lib/core/DeviceManagerConfiguration.ts
@@ -1,6 +1,13 @@
 import { JSONObject } from "kuzzle";
 
 export type DeviceManagerConfiguration = {
+  /**
+   * Ignore errors at startup such as wrong mappings update.
+   *
+   * Useful to start the plugin even if the mappings are not up to date.
+   */
+  ignoreStartupErrors: boolean;
+
   engine: {
     /**
      * Auto update collection mappings with models

--- a/lib/core/DeviceManagerPlugin.ts
+++ b/lib/core/DeviceManagerPlugin.ts
@@ -64,8 +64,8 @@ export class DeviceManagerPlugin extends Plugin {
         }: { defaultValues?: JSONObject; engineGroup?: string } = {}
       ) => {
         this.modelsRegister.registerAsset(model, metadataMappings, {
-          engineGroup,
           defaultValues,
+          engineGroup,
         });
       },
 

--- a/lib/core/registers/DecodersRegister.ts
+++ b/lib/core/registers/DecodersRegister.ts
@@ -117,31 +117,15 @@ export class DecodersRegister {
    * This method never returns a rejected promise.
    */
   async createDefaultRights() {
-    try {
-      await this.createDefaultRoles();
-    } catch (error) {
-      this.context.log.error(
-        `Cannot register default decoders roles: ${error}${error.stack}`
-      );
-      return;
-    }
+    await this.createDefaultRoles();
 
-    try {
-      await this.createDefaultProfiles();
-    } catch (error) {
-      this.context.log.error(
-        `Cannot register default decoders profiles: ${error}${error.stack}`
-      );
-      return;
-    }
+    await this.createDefaultProfiles();
 
-    try {
-      await this.createDefaultUsers();
-    } catch (error) {
-      this.context.log.error(
-        `Cannot register default decoders users: ${error}${error.stack}`
-      );
-    }
+    await this.createDefaultUsers();
+
+    this.context.log.info(
+      "Default rights for payload controller has been registered."
+    );
   }
 
   private async createDefaultUsers() {

--- a/lib/core/registers/ModelsRegister.ts
+++ b/lib/core/registers/ModelsRegister.ts
@@ -44,18 +44,25 @@ export class ModelsRegister {
   registerAsset(
     model: string,
     metadataMappings: JSONObject,
-    { engineGroup = "commons" }: { engineGroup?: string } = {}
+    {
+      engineGroup = "commons",
+      defaultValues = {},
+    }: { defaultValues?: JSONObject; engineGroup?: string } = {}
   ) {
     this.assetModels.push({
-      asset: { metadataMappings, model },
+      asset: { defaultValues, metadataMappings, model },
       engineGroup,
       type: "asset",
     });
   }
 
-  registerDevice(model: string, metadataMappings: JSONObject) {
+  registerDevice(
+    model: string,
+    metadataMappings: JSONObject,
+    { defaultValues = {} }: { defaultValues?: JSONObject } = {}
+  ) {
     this.deviceModels.push({
-      device: { metadataMappings, model },
+      device: { defaultValues, metadataMappings, model },
       type: "device",
     });
   }

--- a/lib/modules/asset/AssetModule.ts
+++ b/lib/modules/asset/AssetModule.ts
@@ -2,6 +2,8 @@ import { Module } from "../shared/Module";
 
 import { AssetsController } from "./AssetsController";
 import { AssetService } from "./AssetService";
+import { assetsAdmin } from "./roles/assetsAdmin";
+import { assetsReader } from "./roles/assetsReader";
 
 export class AssetModule extends Module {
   private assetService: AssetService;
@@ -12,5 +14,8 @@ export class AssetModule extends Module {
     this.assetController = new AssetsController(this.assetService);
 
     this.plugin.api["device-manager/assets"] = this.assetController.definition;
+
+    this.plugin.roles["assets.admin"] = assetsAdmin;
+    this.plugin.roles["assets.reader"] = assetsReader;
   }
 }

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import {
   Backend,
   BadRequestError,
@@ -161,6 +162,11 @@ export class AssetService {
         assetModel.asset.metadataMappings
       )) {
         assetMetadata[metadataName] = null;
+      }
+      for (const [metadataName, metadataValue] of Object.entries(
+        assetModel.asset.defaultValues
+      )) {
+        _.set(assetMetadata, metadataName, metadataValue);
       }
 
       const { _source, _id } = await this.sdk.document.create<AssetContent>(

--- a/lib/modules/asset/model/Asset.ts
+++ b/lib/modules/asset/model/Asset.ts
@@ -5,11 +5,11 @@ import { MeasureContent } from "../../measure";
 import { AssetContent } from "../types/AssetContent";
 import { AssetSerializer } from "./AssetSerializer";
 
-export class Asset {
+export class Asset<TAssetContent extends AssetContent = AssetContent> {
   public _id: string;
-  public _source: AssetContent;
+  public _source: TAssetContent;
 
-  constructor(content: AssetContent, _id?: string) {
+  constructor(content: TAssetContent, _id?: string) {
     this._id = _id || AssetSerializer.id(content.model, content.reference);
 
     this._source = content;

--- a/lib/modules/asset/roles/assetsAdmin.ts
+++ b/lib/modules/asset/roles/assetsAdmin.ts
@@ -1,15 +1,15 @@
 export const assetsAdmin = {
-  "controllers": {
+  controllers: {
     "device-manager/assets": {
-      "actions": {
+      actions: {
         "*": true,
       },
     },
     "device-manager/models": {
-      "actions": {
-        "listAssets": true,
-        "writeAsset": true,
-        "deleteAsset": true,
+      actions: {
+        deleteAsset: true,
+        listAssets: true,
+        writeAsset: true,
       },
     },
   },

--- a/lib/modules/asset/roles/assetsAdmin.ts
+++ b/lib/modules/asset/roles/assetsAdmin.ts
@@ -1,0 +1,16 @@
+export const assetsAdmin = {
+  "controllers": {
+    "device-manager/assets": {
+      "actions": {
+        "*": true,
+      },
+    },
+    "device-manager/models": {
+      "actions": {
+        "listAssets": true,
+        "writeAsset": true,
+        "deleteAsset": true,
+      },
+    },
+  },
+};

--- a/lib/modules/asset/roles/assetsReader.ts
+++ b/lib/modules/asset/roles/assetsReader.ts
@@ -1,15 +1,15 @@
 export const assetsReader = {
-  "controllers": {
+  controllers: {
     "device-manager/assets": {
-      "actions": {
-        "get": true,
-        "search": true,
-        "getMeasures": true,
+      actions: {
+        get: true,
+        getMeasures: true,
+        search: true,
       },
     },
     "device-manager/models": {
-      "actions": {
-        "listAssets": true,
+      actions: {
+        listAssets: true,
       },
     },
   },

--- a/lib/modules/asset/roles/assetsReader.ts
+++ b/lib/modules/asset/roles/assetsReader.ts
@@ -1,0 +1,16 @@
+export const assetsReader = {
+  "controllers": {
+    "device-manager/assets": {
+      "actions": {
+        "get": true,
+        "search": true,
+        "getMeasures": true,
+      },
+    },
+    "device-manager/models": {
+      "actions": {
+        "listAssets": true,
+      },
+    },
+  },
+};

--- a/lib/modules/decoder/DecoderModule.ts
+++ b/lib/modules/decoder/DecoderModule.ts
@@ -1,8 +1,10 @@
 import { KuzzleRequest } from "kuzzle";
+
 import { Module } from "../shared/Module";
 
 import { DecodersController } from "./DecodersController";
 import { PayloadService } from "./PayloadService";
+import { decodersAdmin } from "./roles/decodersAdmin";
 
 export class DecoderModule extends Module {
   private payloadService: PayloadService;
@@ -23,12 +25,16 @@ export class DecoderModule extends Module {
 
     this.plugin.api["device-manager/decoders"] =
       this.decoderController.definition;
+
     this.plugin.api["device-manager/payload"] =
       this.decodersRegister.getPayloadController(this.payloadService);
+
     this.plugin.api["device-manager/payload"].actions.generic = {
       handler: this.unknowPayload.bind(this),
       http: [{ path: "device-manager/payload/:device", verb: "post" }],
     };
+
+    this.plugin.roles["decoders.admin"] = decodersAdmin;
   }
 
   async unknowPayload(request: KuzzleRequest) {

--- a/lib/modules/decoder/roles/decodersAdmin.ts
+++ b/lib/modules/decoder/roles/decodersAdmin.ts
@@ -1,0 +1,9 @@
+export const decodersAdmin = {
+  "controllers": {
+    "device-manager/decoders": {
+      "actions": {
+        "*": true,
+      },
+    },
+  },
+};

--- a/lib/modules/decoder/roles/decodersAdmin.ts
+++ b/lib/modules/decoder/roles/decodersAdmin.ts
@@ -1,7 +1,7 @@
 export const decodersAdmin = {
-  "controllers": {
+  controllers: {
     "device-manager/decoders": {
-      "actions": {
+      actions: {
         "*": true,
       },
     },

--- a/lib/modules/device/DeviceModule.ts
+++ b/lib/modules/device/DeviceModule.ts
@@ -2,6 +2,8 @@ import { Module } from "../shared/Module";
 
 import { DevicesController } from "./DevicesController";
 import { DeviceService } from "./DeviceService";
+import { devicesAdmin } from "./roles/devicesAdmin";
+import { devicesReader } from "./roles/devicesReader";
 
 export class DeviceModule extends Module {
   private deviceService: DeviceService;
@@ -13,5 +15,8 @@ export class DeviceModule extends Module {
 
     this.plugin.api["device-manager/devices"] =
       this.deviceController.definition;
+
+    this.plugin.roles["devices.admin"] = devicesAdmin;
+    this.plugin.roles["devices.reader"] = devicesReader;
   }
 }

--- a/lib/modules/device/roles/devicesAdmin.ts
+++ b/lib/modules/device/roles/devicesAdmin.ts
@@ -1,0 +1,22 @@
+export const devicesAdmin = {
+  "controllers": {
+    "device-manager/devices": {
+      "actions": {
+        "create": true,
+        "get": true,
+        "update": true,
+        "search": true,
+        "delete": true,
+        "linkAsset": true,
+        "unlinkAsset": true,
+      },
+    },
+    "device-manager/models": {
+      "actions": {
+        "listDevices": true,
+        "writeDevice": true,
+        "deleteDevice": true,
+      },
+    },
+  },
+};

--- a/lib/modules/device/roles/devicesAdmin.ts
+++ b/lib/modules/device/roles/devicesAdmin.ts
@@ -1,21 +1,21 @@
 export const devicesAdmin = {
-  "controllers": {
+  controllers: {
     "device-manager/devices": {
-      "actions": {
-        "create": true,
-        "get": true,
-        "update": true,
-        "search": true,
-        "delete": true,
-        "linkAsset": true,
-        "unlinkAsset": true,
+      actions: {
+        create: true,
+        delete: true,
+        get: true,
+        linkAsset: true,
+        search: true,
+        unlinkAsset: true,
+        update: true,
       },
     },
     "device-manager/models": {
-      "actions": {
-        "listDevices": true,
-        "writeDevice": true,
-        "deleteDevice": true,
+      actions: {
+        deleteDevice: true,
+        listDevices: true,
+        writeDevice: true,
       },
     },
   },

--- a/lib/modules/device/roles/devicesReader.ts
+++ b/lib/modules/device/roles/devicesReader.ts
@@ -1,0 +1,15 @@
+export const devicesReader = {
+  "controllers": {
+    "device-manager/devices": {
+      "actions": {
+        "get": true,
+        "search": true,
+      },
+    },
+    "device-manager/models": {
+      "actions": {
+        "listDevices": true,
+      },
+    },
+  },
+};

--- a/lib/modules/device/roles/devicesReader.ts
+++ b/lib/modules/device/roles/devicesReader.ts
@@ -1,14 +1,14 @@
 export const devicesReader = {
-  "controllers": {
+  controllers: {
     "device-manager/devices": {
-      "actions": {
-        "get": true,
-        "search": true,
+      actions: {
+        get: true,
+        search: true,
       },
     },
     "device-manager/models": {
-      "actions": {
-        "listDevices": true,
+      actions: {
+        listDevices: true,
       },
     },
   },

--- a/lib/modules/device/types/DeviceContent.ts
+++ b/lib/modules/device/types/DeviceContent.ts
@@ -1,10 +1,13 @@
+import { JSONObject } from "kuzzle-sdk";
 import { DigitalTwinContent, Metadata } from "../../shared";
 
 /**
  * Device document content
  */
-export interface DeviceContent<TMetadata extends Metadata = Metadata>
-  extends DigitalTwinContent<TMetadata> {
+export interface DeviceContent<
+  TMeasurementValues extends JSONObject = JSONObject,
+  TMetadata extends Metadata = Metadata
+> extends DigitalTwinContent<TMeasurementValues, TMetadata> {
   /**
    * Linked asset unique identifier
    */

--- a/lib/modules/measure/MeasureModule.ts
+++ b/lib/modules/measure/MeasureModule.ts
@@ -2,6 +2,8 @@ import { Module } from "../shared/Module";
 
 import { MeasuresController } from "./MeasuresController";
 import { MeasureService } from "./MeasureService";
+import { measuresAdmin } from "./roles/measuresAdmin";
+import { measuresReader } from "./roles/measuresReader";
 
 export class MeasureModule extends Module {
   private measureService: MeasureService;
@@ -19,5 +21,8 @@ export class MeasureModule extends Module {
 
     this.plugin.api["device-manager/measures"] =
       this.measureController.definition;
+
+    this.plugin.roles["measures.admin"] = measuresAdmin;
+    this.plugin.roles["measures.reader"] = measuresReader;
   }
 }

--- a/lib/modules/measure/roles/measuresAdmin.ts
+++ b/lib/modules/measure/roles/measuresAdmin.ts
@@ -1,15 +1,15 @@
 export const measuresAdmin = {
-  "controllers": {
+  controllers: {
     "device-manager/measures": {
-      "actions": {
+      actions: {
         "*": true,
       },
     },
     "device-manager/models": {
-      "actions": {
-        "listMeasures": true,
-        "writeMeasure": true,
-        "deleteMeasure": true,
+      actions: {
+        deleteMeasure: true,
+        listMeasures: true,
+        writeMeasure: true,
       },
     },
   },

--- a/lib/modules/measure/roles/measuresAdmin.ts
+++ b/lib/modules/measure/roles/measuresAdmin.ts
@@ -1,0 +1,16 @@
+export const measuresAdmin = {
+  "controllers": {
+    "device-manager/measures": {
+      "actions": {
+        "*": true,
+      },
+    },
+    "device-manager/models": {
+      "actions": {
+        "listMeasures": true,
+        "writeMeasure": true,
+        "deleteMeasure": true,
+      },
+    },
+  },
+};

--- a/lib/modules/measure/roles/measuresReader.ts
+++ b/lib/modules/measure/roles/measuresReader.ts
@@ -1,0 +1,9 @@
+export const measuresReader = {
+  "controllers": {
+    "device-manager/models": {
+      "actions": {
+        "listMeasures": true,
+      },
+    },
+  },
+};

--- a/lib/modules/measure/roles/measuresReader.ts
+++ b/lib/modules/measure/roles/measuresReader.ts
@@ -1,8 +1,8 @@
 export const measuresReader = {
-  "controllers": {
+  controllers: {
     "device-manager/models": {
-      "actions": {
-        "listMeasures": true,
+      actions: {
+        listMeasures: true,
       },
     },
   },

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -179,11 +179,12 @@ export class ModelService {
     const query = {
       and: [{ equals: { type: "asset" } }, { equals: { engineGroup } }],
     };
+    const sort = { "asset.model": "asc" };
 
     const result = await this.sdk.document.search<AssetModelContent>(
       this.config.adminIndex,
       InternalCollection.MODELS,
-      { query },
+      { query, sort },
       { lang: "koncorde", size: 100 }
     );
 
@@ -194,11 +195,12 @@ export class ModelService {
     const query = {
       and: [{ equals: { type: "device" } }],
     };
+    const sort = { "device.model": "asc" };
 
     const result = await this.sdk.document.search<DeviceModelContent>(
       this.config.adminIndex,
       InternalCollection.MODELS,
-      { query },
+      { query, sort },
       { lang: "koncorde", size: 100 }
     );
 
@@ -209,11 +211,12 @@ export class ModelService {
     const query = {
       and: [{ equals: { type: "measure" } }],
     };
+    const sort = { "measure.name": "asc" };
 
     const result = await this.sdk.document.search<MeasureModelContent>(
       this.config.adminIndex,
       InternalCollection.MODELS,
-      { query },
+      { query, sort },
       { lang: "koncorde", size: 100 }
     );
 

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -70,13 +70,13 @@ export class ModelsController {
     const engineGroup = request.getBodyString("engineGroup");
     const model = request.getBodyString("model");
     const metadataMappings = request.getBodyObject("metadataMappings");
+    const defaultValues = request.getBodyObject("defaultValues", {});
 
     const assetModel = await this.modelService.writeAsset(
+      engineGroup,
       model,
       metadataMappings,
-      {
-        engineGroup,
-      }
+      defaultValues
     );
 
     return assetModel;
@@ -87,10 +87,12 @@ export class ModelsController {
   ): Promise<ApiModelCreateDeviceResult> {
     const model = request.getBodyString("model");
     const metadataMappings = request.getBodyObject("metadataMappings");
+    const defaultValues = request.getBodyObject("defaultValues", {});
 
     const deviceModel = await this.modelService.writeDevice(
       model,
-      metadataMappings
+      metadataMappings,
+      defaultValues
     );
 
     return deviceModel;

--- a/lib/modules/model/collections/modelsMappings.ts
+++ b/lib/modules/model/collections/modelsMappings.ts
@@ -32,6 +32,10 @@ export const modelsMappings: CollectionMappings = {
           dynamic: "false",
           properties: {},
         },
+        defaultValues: {
+          dynamic: "false",
+          properties: {},
+        },
       },
     },
 
@@ -39,6 +43,10 @@ export const modelsMappings: CollectionMappings = {
       properties: {
         model: { type: "keyword" },
         metadataMappings: {
+          dynamic: "false",
+          properties: {},
+        },
+        defaultValues: {
           dynamic: "false",
           properties: {},
         },

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -11,28 +11,30 @@ interface ModelsControllerRequest {
 }
 
 export interface ApiModelCreateAssetRequest extends ModelsControllerRequest {
-  action: "createAsset";
+  action: "writeAsset";
 
   body: {
     engineGroup: string;
     model: string;
     metadataMappings: JSONObject;
+    defaultValues: JSONObject;
   };
 }
 export type ApiModelCreateAssetResult = KDocument<AssetModelContent>;
 
 export interface ApiModelCreateDeviceRequest extends ModelsControllerRequest {
-  action: "createDevice";
+  action: "writeDevice";
 
   body: {
     model: string;
     metadataMappings: JSONObject;
+    defaultValues: JSONObject;
   };
 }
 export type ApiModelCreateDeviceResult = KDocument<DeviceModelContent>;
 
 export interface ApiModelCreateMeasureRequest extends ModelsControllerRequest {
-  action: "createMeasure";
+  action: "writeMeasure";
 
   body: {
     name: string;

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -16,8 +16,34 @@ export interface AssetModelContent extends KDocumentContent {
   engineGroup: string;
 
   asset: {
+    /**
+     * Name of the model
+     */
     model: string;
+
+    /**
+     * Metadata mappings.
+     *
+     * @example
+     * {
+     *   "company": {
+     *     "properties": {
+     *        "name": { "type": "keyword" },
+     *      }
+     *   }
+     * }
+     */
     metadataMappings: JSONObject;
+
+    /**
+     * Default values for metadata.
+     *
+     * @example
+     * {
+     *    "company.name": "Firebird"
+     * }
+     */
+    defaultValues: JSONObject;
   };
 }
 
@@ -25,8 +51,34 @@ export interface DeviceModelContent extends KDocumentContent {
   type: "device";
 
   device: {
+    /**
+     * Name of the model
+     */
     model: string;
+
+    /**
+     * Metadata mappings.
+     *
+     * @example
+     * {
+     *   "company": {
+     *     "properties": {
+     *        "name": { "type": "keyword" },
+     *      }
+     *   }
+     * }
+     */
     metadataMappings: JSONObject;
+
+    /**
+     * Default values for metadata.
+     *
+     * @example
+     * {
+     *    "company.name": "Firebird"
+     * }
+     */
+    defaultValues: JSONObject;
   };
 }
 

--- a/lib/modules/shared/utils/flattenObject.ts
+++ b/lib/modules/shared/utils/flattenObject.ts
@@ -1,0 +1,51 @@
+import { JSONObject } from "kuzzle-sdk";
+
+/**
+ * Flatten an object transform:
+ *
+ * {
+ *  title: "kuzzle",
+ *  info : {
+ *    tag: "news"
+ *  }
+ * }
+ *
+ * Into an object like:
+ * {
+ *  title: "kuzzle",
+ *  info.tag: news
+ * }
+ *
+ * @todo does not support correctly arrays
+ *
+ * @param target the object we have to flatten
+ *
+ * @returns the flattened object
+ */
+export function flattenObject(target: JSONObject): JSONObject {
+  const output = {};
+
+  flattenStep(output, target);
+
+  return output;
+}
+
+function flattenStep(
+  output: JSONObject,
+  object: JSONObject,
+  prev: string = null
+): void {
+  const keys = Object.keys(object);
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = object[key];
+    const newKey = prev ? prev + "." + key : key;
+
+    if (Object.prototype.toString.call(value) === "[object Object]") {
+      flattenStep(output, value, newKey);
+    } else {
+      output[newKey] = value;
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do ?

Add default roles to manage plugin ressources. Admins roles can do everything and reader can only read.
 - `assets.admin`
 - `assets.reader`
 - `device.admin`: this role cannot attach and detach devices from engines
 - `device.reader`
 - `decoders.admin`
 - `measures.reader`
 - `measures.admin` 
 