### PR TITLE
Ensure unix timestamp for measuredAt

### DIFF
--- a/features/Decoder/PayloadController.feature
+++ b/features/Decoder/PayloadController.feature
@@ -14,6 +14,13 @@ Feature: Payloads Controller
       | engineId                                | null          |
       | assetId                                 | null          |
 
+  Scenario: Reject if measuredAt is not unix timestamp
+    Given I try to send the following "dummy-temp" payloads:
+      | deviceEUI | temperature | measuredAt |
+      | "12345"   | 21          | 1671007889 |
+    Then I should receive an error matching:
+      | message | "Invalid payload: \"measuredAt\" should be a timestamp in milliseconds" |
+
   Scenario: Reject with error a DummyTemp payload
     Given I try to send the following "dummy-temp" payloads:
       | deviceEUI | temperature |
@@ -61,12 +68,12 @@ Feature: Payloads Controller
     And I should receive a result matching:
       | hits[0]._source.type                  | "temperature"       |
       | hits[0]._source.measuredAt            | "_DATE_NOW_"        |
-      | hits[0]._source.origin._id             | "DummyTemp-linked1" |
+      | hits[0]._source.origin._id            | "DummyTemp-linked1" |
       | hits[0]._source.origin.type           | "device"            |
       | hits[0]._source.origin.measureName    | "temperature"       |
       | hits[0]._source.origin.deviceModel    | "DummyTemp"         |
       | hits[0]._source.origin.reference      | "linked1"           |
-      | hits[0]._source.asset._id              | "container-linked1" |
+      | hits[0]._source.asset._id             | "container-linked1" |
       | hits[0]._source.asset.measureName     | "temperatureExt"    |
       | hits[0]._source.asset.metadata.weight | 10                  |
       | hits[0]._source.asset.metadata.height | 11                  |

--- a/features/fixtures/application/decoders/DummyTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempDecoder.ts
@@ -42,7 +42,7 @@ export class DummyTempDecoder extends Decoder {
       payload.deviceEUI,
       "temperature",
       {
-        measuredAt: Date.now(),
+        measuredAt: payload.measuredAt || Date.now(),
         type: "temperature",
         values: {
           temperature: payload.temperature,

--- a/lib/modules/decoder/DecodedPayload.ts
+++ b/lib/modules/decoder/DecodedPayload.ts
@@ -48,9 +48,12 @@ export class DecodedPayload<TDecoder extends Decoder = Decoder> {
       );
     }
 
+    this.validateMeasurement(measurement);
+
     if (!this.measurementsByDevice[deviceReference]) {
       this.measurementsByDevice[deviceReference] = [];
     }
+
     const decodedMeasurement: DecodedMeasurement<TMeasureValues> = {
       measureName,
       ...measurement,
@@ -90,5 +93,15 @@ export class DecodedPayload<TDecoder extends Decoder = Decoder> {
    */
   getMetadata(deviceReference: string): JSONObject {
     return this.metadataByDevice[deviceReference];
+  }
+
+  private validateMeasurement<TMeasureValues>(
+    measurement: Omit<DecodedMeasurement<TMeasureValues>, "measureName">,
+  ) {
+    if (measurement.measuredAt / 1000000000000 < 1) {
+      throw new BadRequestError(
+        `Invalid payload: "measuredAt" should be a timestamp in milliseconds`
+      );
+    }
   }
 }

--- a/lib/modules/decoder/DecodedPayload.ts
+++ b/lib/modules/decoder/DecodedPayload.ts
@@ -98,7 +98,7 @@ export class DecodedPayload<TDecoder extends Decoder = Decoder> {
   private validateMeasurement<TMeasureValues>(
     measurement: Omit<DecodedMeasurement<TMeasureValues>, "measureName">
   ) {
-    if (measurement.measuredAt / 1000000000000 < 1) {
+    if (measurement.measuredAt.toString().length !== 13) {
       throw new BadRequestError(
         `Invalid payload: "measuredAt" should be a timestamp in milliseconds`
       );

--- a/lib/modules/decoder/DecodedPayload.ts
+++ b/lib/modules/decoder/DecodedPayload.ts
@@ -96,7 +96,7 @@ export class DecodedPayload<TDecoder extends Decoder = Decoder> {
   }
 
   private validateMeasurement<TMeasureValues>(
-    measurement: Omit<DecodedMeasurement<TMeasureValues>, "measureName">,
+    measurement: Omit<DecodedMeasurement<TMeasureValues>, "measureName">
   ) {
     if (measurement.measuredAt / 1000000000000 < 1) {
       throw new BadRequestError(


### PR DESCRIPTION
## What does this PR do ?

Ensure the `measuredAt` timestamp is an Unix Timestamp (milliseconds)