### PR TITLE
Skip permissions creation when no decoder are registered

### DIFF
--- a/lib/core/registers/DecodersRegister.ts
+++ b/lib/core/registers/DecodersRegister.ts
@@ -93,6 +93,10 @@ export class DecodersRegister {
    * This method never returns a rejected promise.
    */
   async createDefaultRights() {
+    if (this.decoders.length === 0) {
+      return;
+    }
+
     await this.createDefaultRoles();
 
     await this.createDefaultProfiles();


### PR DESCRIPTION
## What does this PR do ?

Do not try to create permissions when no decoder are registered.

