### PR TITLE
[breaking] Pass decodedPayload to Decoder.decode method

### DIFF
--- a/features/fixtures/application/decoders/DummyTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempDecoder.ts
@@ -29,9 +29,10 @@ export class DummyTempDecoder extends Decoder {
     return true;
   }
 
-  async decode(payload: JSONObject): Promise<DecodedPayload<Decoder>> {
-    const decodedPayload = new DecodedPayload<DummyTempDecoder>(this);
-
+  async decode(
+    decodedPayload: DecodedPayload<DummyTempDecoder>,
+    payload: JSONObject,
+  ): Promise<DecodedPayload<DummyTempDecoder>> {
     if (payload?.metadata?.color) {
       decodedPayload.addMetadata(payload.deviceEUI, {
         color: payload.metadata.color,

--- a/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
@@ -23,9 +23,10 @@ export class DummyTempPositionDecoder extends Decoder {
     return true;
   }
 
-  async decode(payload: JSONObject): Promise<DecodedPayload<Decoder>> {
-    const decodedPayload = new DecodedPayload<DummyTempPositionDecoder>(this);
-
+  async decode(
+    decodedPayload: DecodedPayload<DummyTempPositionDecoder>,
+    payload: JSONObject,
+  ): Promise<DecodedPayload<DummyTempPositionDecoder>> {
     decodedPayload.addMeasurement<TemperatureMeasurement>(
       payload.deviceEUI,
       "temperature",

--- a/lib/modules/decoder/Decoder.ts
+++ b/lib/modules/decoder/Decoder.ts
@@ -147,9 +147,10 @@ export abstract class Decoder {
    */
   // eslint-disable-next-line no-unused-vars
   abstract decode(
+    decodedPayload: DecodedPayload<any>,
     payload: JSONObject,
     request: KuzzleRequest
-  ): Promise<DecodedPayload<Decoder>>;
+  ): Promise<DecodedPayload<any>>;
 
   /**
    * Checks if the provided properties are present in the payload

--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -14,6 +14,7 @@ import {
 } from "../../core";
 import { DeviceContent, DeviceSerializer } from "../device";
 import { EventMeasureIngest } from "../measure";
+import { DecodedPayload } from "./DecodedPayload";
 
 import { Decoder } from "./Decoder";
 
@@ -63,7 +64,9 @@ export class PayloadService {
       await this.savePayload(decoder.deviceModel, uuid, valid, payload);
     }
 
-    const decodedPayload = await decoder.decode(payload, request);
+    let decodedPayload = new DecodedPayload<any>(decoder);
+
+    decodedPayload = await decoder.decode(decodedPayload, payload, request);
 
     const devices = await this.retrieveDevices(
       decoder.deviceModel,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc33",
+  "version": "2.0.0-rc34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.0.0-rc33",
+      "version": "2.0.0-rc34",
       "license": "Apache-2.0",
       "dependencies": {
         "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.5.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc33",
+  "version": "2.0.0-rc34",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {


### PR DESCRIPTION
## What does this PR do ?

Instantiate the `DecoderPayload` and pass it directly to the `Decoder.decode` method.

Before
```
  async decode(
    payload: JSONObject,
  ): Promise<DecodedPayload<DummyTempDecoder>> {
    const decodedPayload = new DecodedPayload<DummyTempDecoder>(this);
    // decode measurements..
    return decodedPayload;
  }
```

After
```
  async decode(
    decodedPayload: DecodedPayload<DummyTempDecoder>,
    payload: JSONObject,
  ): Promise<DecodedPayload<DummyTempDecoder>> {
    // decode measurements..
    return decodedPayload;
  }
```
