### PR TITLE
[breaking] Change the `measures` property in API and data model to be more intuitive

### DIFF
--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -8,12 +8,12 @@ Feature: Asset Controller
       | body.reference       | "A1"            |
       | body.metadata.height | 5               |
     Then The document "engine-kuzzle":"assets":"Container-A1" content match:
-      | metadata.height              | 5             |
-      | metadata.weight              | null          |
-      | measures.temperatureExt.type | "temperature" |
-      | measures.temperatureInt.type | "temperature" |
-      | measures.position.type       | "position"    |
-      | linkedDevices                | []            |
+      | metadata.height         | 5    |
+      | metadata.weight         | null |
+      | measures.temperatureExt | null |
+      | measures.temperatureInt | null |
+      | measures.position       | null |
+      | linkedDevices           | []   |
     When I successfully execute the action "device-manager/assets":"update" with args:
       | engineId             | "engine-kuzzle" |
       | _id                  | "Container-A1"  |

--- a/features/Device/Controller/LinkAsset.feature
+++ b/features/Device/Controller/LinkAsset.feature
@@ -2,69 +2,78 @@ Feature: LinkAsset
 
   Scenario: Link devices to an asset
     When I successfully execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-unlinked1" |
-      | assetId                       | "Container-unlinked1" |
-      | engineId                      | "engine-ayse"         |
-      | body.measureNames.temperature | "temperatureExt"      |
+      | _id                         | "DummyTemp-unlinked1" |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
     Then The document "device-manager":"devices":"DummyTemp-unlinked1" content match:
       | assetId | "Container-unlinked1" |
     And The document "engine-ayse":"devices":"DummyTemp-unlinked1" content match:
       | assetId | "Container-unlinked1" |
     And The document "engine-ayse":"assets":"Container-unlinked1" content match:
-      | linkedDevices[0]._id                   | "DummyTemp-unlinked1" |
-      | linkedDevices[0].measures.temperature | "temperatureExt"      |
+      | linkedDevices[0]._id                    | "DummyTemp-unlinked1" |
+      | linkedDevices[0].measureNames[0].asset  | "temperatureExt"      |
+      | linkedDevices[0].measureNames[0].device | "temperature"         |
     When I successfully execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-unlinked2" |
-      | assetId                       | "Container-unlinked1" |
-      | engineId                      | "engine-ayse"         |
-      | body.measureNames.temperature | "temperatureInt"      |
+      | _id                         | "DummyTemp-unlinked2" |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureInt"      |
     And The document "engine-ayse":"assets":"Container-unlinked1" content match:
-      | linkedDevices[0]._id                   | "DummyTemp-unlinked1" |
-      | linkedDevices[0].measures.temperature | "temperatureExt"      |
-      | linkedDevices[1]._id                   | "DummyTemp-unlinked2" |
-      | linkedDevices[1].measures.temperature | "temperatureInt"      |
+      | linkedDevices[0]._id                    | "DummyTemp-unlinked1" |
+      | linkedDevices[0].measureNames[0].asset  | "temperatureExt"      |
+      | linkedDevices[0].measureNames[0].device | "temperature"         |
+      | linkedDevices[1]._id                    | "DummyTemp-unlinked2" |
+      | linkedDevices[1].measureNames[0].asset  | "temperatureInt"      |
 
   Scenario: Error when device is already linked
     When I execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-linked1"   |
-      | assetId                       | "Container-unlinked1" |
-      | engineId                      | "engine-ayse"         |
-      | body.measureNames.temperature | "temperatureExt"      |
+      | _id                         | "DummyTemp-linked1"   |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
     Then I should receive an error matching:
       | message | "Device \"DummyTemp-linked1\" is already linked to an asset." |
 
   Scenario: Error when linking a device and using an already used measure name
     When I execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-unlinked1" |
-      | assetId                       | "Container-linked1"   |
-      | engineId                      | "engine-ayse"         |
-      | body.measureNames.temperature | "temperatureExt"      |
+      | _id                         | "DummyTemp-unlinked1" |
+      | assetId                     | "Container-linked1"   |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
     Then I should receive an error matching:
-      | message | "Measure name \"temperatureExt\" is already used by another device." |
+      | message | "Measure name \"temperatureExt\" is already used by another device on this asset." |
 
   Scenario: Error when device is not attached to an engine
     When I execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-detached1" |
-      | assetId                       | "Container-unlinked1" |
-      | engineId                      | "engine-ayse"         |
-      | body.measureNames.temperature | "temperatureExt"      |
+      | _id                         | "DummyTemp-detached1" |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
     Then I should receive an error matching:
       | message | "Device \"DummyTemp-detached1\" is not attached to an engine." |
 
   Scenario: Error when device is attached to wrong engine
     When I execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-unlinked1" |
-      | assetId                       | "Container-unlinked1" |
-      | engineId                      | "engine-kuzzle"       |
-      | body.measureNames.temperature | "temperatureExt"      |
+      | _id                         | "DummyTemp-unlinked1" |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-kuzzle"       |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
     Then I should receive an error matching:
       | message | "Device \"DummyTemp-unlinked1\" is not attached to the specified engine." |
 
   Scenario: Error when device is linked to non-existing asset
     When I execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-unlinked1"   |
-      | assetId                       | "Container-nonexisting" |
-      | engineId                      | "engine-ayse"           |
-      | body.measureNames.temperature | "temperatureExt"        |
+      | _id                         | "DummyTemp-unlinked1"   |
+      | assetId                     | "Container-nonexisting" |
+      | engineId                    | "engine-ayse"           |
+      | body.measureNames[0].device | "temperature"           |
+      | body.measureNames[0].asset  | "temperatureExt"        |
     Then I should receive an error matching:
       | message | "Document \"Container-nonexisting\" not found in \"engine-ayse\":\"assets\"." |

--- a/features/Measure/IngestionPipeline.feature
+++ b/features/Measure/IngestionPipeline.feature
@@ -14,6 +14,7 @@ Feature: Ingestion Pipeline Events
       | body.measureNames[0].asset  | "temperatureExt"             |
     Given I send the following "dummy-temp" payloads:
       | deviceEUI          | temperature |
+      | "enrich_me_master" | 18          |
       | "enrich_me_master" | 21          |
     And I refresh the collection "engine-ayse":"measures"
     Then When I successfully execute the action "document":"search" with args:
@@ -22,8 +23,8 @@ Feature: Ingestion Pipeline Events
       | body       | { query: { term:{"asset._id":"Container-unlinked1"}}} |
     # temperature has been multiplied by 2
     And I should receive a result matching:
-      | hits[0]._source.type               | "temperature" |
-      | hits[0]._source.values.temperature | 42            |
+      | hits[1]._source.type               | "temperature" |
+      | hits[1]._source.values.temperature | 42            |
     Then The document "device-manager":"devices":"DummyTemp-enrich_me_master" content match:
       | measures.temperature.values.temperature | 42 |
     Then The document "engine-ayse":"devices":"DummyTemp-enrich_me_master" content match:

--- a/features/Measure/IngestionPipeline.feature
+++ b/features/Measure/IngestionPipeline.feature
@@ -7,17 +7,18 @@ Feature: Ingestion Pipeline Events
       | body.model     | "DummyTemp"        |
       | body.reference | "enrich_me_master" |
     Given I successfully execute the action "device-manager/devices":"linkAsset" with args:
-      | _id                           | "DummyTemp-enrich_me_master" |
-      | assetId                       | "Container-unlinked1"        |
-      | engineId                      | "engine-ayse"                |
-      | body.measureNames.temperature | "temperatureExt"             |
+      | _id                         | "DummyTemp-enrich_me_master" |
+      | assetId                     | "Container-unlinked1"        |
+      | engineId                    | "engine-ayse"                |
+      | body.measureNames[0].device | "temperature"                |
+      | body.measureNames[0].asset  | "temperatureExt"             |
     Given I send the following "dummy-temp" payloads:
       | deviceEUI          | temperature |
       | "enrich_me_master" | 21          |
     And I refresh the collection "engine-ayse":"measures"
     Then When I successfully execute the action "document":"search" with args:
-      | index      | "engine-ayse"                                        |
-      | collection | "measures"                                           |
+      | index      | "engine-ayse"                                         |
+      | collection | "measures"                                            |
       | body       | { query: { term:{"asset._id":"Container-unlinked1"}}} |
     # temperature has been multiplied by 2
     And I should receive a result matching:

--- a/features/Model/Controller.feature
+++ b/features/Model/Controller.feature
@@ -187,11 +187,11 @@ Feature: Model Controller
   Scenario: Error if the model name is not PascalCase
     Given I execute the action "device-manager/models":"writeAsset" with args:
       | body.engineGroup      | "commons"                     |
-      | body.model            | "Plane"                       |
+      | body.model            | "plane"                       |
       | body.metadataMappings | { size: { type: "integer" } } |
       | body.defaultValues    | { "name": "Firebird" }        |
     Then I should receive an error matching:
-      | message | "The default value \"name\" is not in the metadata mappings." |
+      | message | "Asset model \"plane\" must be PascalCase." |
 
   @models
   Scenario: Error if a default value is not a metadata
@@ -228,43 +228,54 @@ Feature: Model Controller
     Then The collection "engine-ayse":"devices" mappings match:
       """
       {
-        "metadata": {
-          "properties": {
-            "color": {
-              "type": "keyword"
-            },
-            "network": {
-              "type": "keyword"
-            },
-            "network2": {
-              "type": "keyword"
-            }
-          }
-        },
+      "metadata": {
+      "properties": {
+      "color": {
+      "type": "keyword"
+      },
+      "network": {
+      "type": "keyword"
+      },
+      "network2": {
+      "type": "keyword"
+      }
+      }
+      },
       }
       """
     Then The collection "device-manager":"devices" mappings match:
       """
       {
-        "metadata": {
-          "properties": {
-            "color": {
-              "type": "keyword"
-            },
-            "network": {
-              "type": "keyword"
-            },
-            "network2": {
-              "type": "keyword"
-            }
-          }
-        },
+      "metadata": {
+      "properties": {
+      "color": {
+      "type": "keyword"
+      },
+      "network": {
+      "type": "keyword"
+      },
+      "network2": {
+      "type": "keyword"
+      }
+      }
+      },
       }
       """
     When I successfully execute the action "device-manager/models":"listDevices"
     Then I should receive a result matching:
       | total         | 3                     |
       | models[2]._id | "model-device-Zigbee" |
+
+  @models
+  Scenario: Error if the model name is not PascalCase
+    Given I execute the action "device-manager/models":"writeDevice" with args:
+      | body.engineGroup          | "commons"                     |
+      | body.model                | "plane"                       |
+      | body.metadataMappings     | { size: { type: "integer" } } |
+      | body.defaultValues        | { "name": "Firebird" }        |
+      | body.measures.temperature | "temperature"                 |
+    Then I should receive an error matching:
+      | message | "Device model \"plane\" must be PascalCase." |
 
   @models
   Scenario: Write and List a Measure model
@@ -327,65 +338,65 @@ Feature: Model Controller
     Then The collection "engine-ayse":"devices" mappings match:
       """
       {
-        "measures": {
-          "properties": {
-            "presence": {
-              "properties": {
-                "measuredAt": {
-                  "type": "date"
-                },
-                "payloadUuids": {
-                  "type": "keyword"
-                },
-                "type": {
-                  "type": "keyword"
-                },
-                "values": {
-                  "properties": {
-                    "presence": {
-                      "type": "boolean"
-                    },
-                    "presence2": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            },
-          }
-        },
+      "measures": {
+      "properties": {
+      "presence": {
+      "properties": {
+      "measuredAt": {
+      "type": "date"
+      },
+      "payloadUuids": {
+      "type": "keyword"
+      },
+      "type": {
+      "type": "keyword"
+      },
+      "values": {
+      "properties": {
+      "presence": {
+      "type": "boolean"
+      },
+      "presence2": {
+      "type": "boolean"
+      }
+      }
+      }
+      }
+      },
+      }
+      },
       }
       """
     Then The collection "device-manager":"devices" mappings match:
       """
       {
-        "measures": {
-          "properties": {
-            "presence": {
-              "properties": {
-                "measuredAt": {
-                  "type": "date"
-                },
-                "payloadUuids": {
-                  "type": "keyword"
-                },
-                "type": {
-                  "type": "keyword"
-                },
-                "values": {
-                  "properties": {
-                    "presence": {
-                      "type": "boolean"
-                    },
-                    "presence2": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            },
-          }
-        },
+      "measures": {
+      "properties": {
+      "presence": {
+      "properties": {
+      "measuredAt": {
+      "type": "date"
+      },
+      "payloadUuids": {
+      "type": "keyword"
+      },
+      "type": {
+      "type": "keyword"
+      },
+      "values": {
+      "properties": {
+      "presence": {
+      "type": "boolean"
+      },
+      "presence2": {
+      "type": "boolean"
+      }
+      }
+      }
+      }
+      },
+      }
+      },
       }
       """
     When I successfully execute the action "device-manager/models":"listMeasures"

--- a/features/Model/Controller.feature
+++ b/features/Model/Controller.feature
@@ -4,30 +4,37 @@ Feature: Model Controller
   Scenario: Write and List an Asset model
     # Create model
     When I successfully execute the action "device-manager/models":"writeAsset" with args:
-      | body.engineGroup             | "commons"                        |
-      | body.model                   | "Plane"                          |
-      | body.metadataMappings        | { company: { type: "keyword" } } |
-      | body.measures.temperatureExt | "temperature"                    |
+      | body.engineGroup      | "commons"                        |
+      | body.model            | "Plane"                          |
+      | body.metadataMappings | { company: { type: "keyword" } } |
+      | body.measures[0].name | "temperatureExt"                 |
+      | body.measures[0].type | "temperature"                    |
     Then The document "device-manager":"models":"model-asset-Plane" content match:
-      | type                                | "asset"       |
-      | engineGroup                         | "commons"     |
-      | asset.model                         | "Plane"       |
-      | asset.metadataMappings.company.type | "keyword"     |
-      | asset.measures.temperatureExt       | "temperature" |
+      | type                                | "asset"          |
+      | engineGroup                         | "commons"        |
+      | asset.model                         | "Plane"          |
+      | asset.metadataMappings.company.type | "keyword"        |
+      | asset.measures[0].name              | "temperatureExt" |
+      | asset.measures[0].type              | "temperature"    |
     # Update model
     When I successfully execute the action "device-manager/models":"writeAsset" with args:
-      | body.engineGroup       | "commons"                         |
-      | body.model             | "Plane"                           |
-      | body.metadataMappings  | { company2: { type: "keyword" } } |
-      | body.measures.position | "position"                        |
+      | body.engineGroup      | "commons"                         |
+      | body.model            | "Plane"                           |
+      | body.metadataMappings | { company2: { type: "keyword" } } |
+      | body.measures[0].name | "temperatureExt"                  |
+      | body.measures[0].type | "temperature"                     |
+      | body.measures[1].name | "position"                        |
+      | body.measures[1].type | "position"                        |
     Then The document "device-manager":"models":"model-asset-Plane" content match:
-      | type                                 | "asset"       |
-      | engineGroup                          | "commons"     |
-      | asset.model                          | "Plane"       |
-      | asset.metadataMappings.company.type  | "keyword"     |
-      | asset.metadataMappings.company2.type | "keyword"     |
-      | asset.measures.temperatureExt        | "temperature" |
-      | asset.measures.position              | "position"    |
+      | type                                 | "asset"          |
+      | engineGroup                          | "commons"        |
+      | asset.model                          | "Plane"          |
+      | asset.metadataMappings.company.type  | "keyword"        |
+      | asset.metadataMappings.company2.type | "keyword"        |
+      | asset.measures[0].name               | "temperatureExt" |
+      | asset.measures[0].type               | "temperature"    |
+      | asset.measures[1].name               | "position"       |
+      | asset.measures[1].type               | "position"       |
     # This test fail when run with all the other but success when run individually
     # Then The collection "engine-ayse":"assets" mappings match:
     #   """
@@ -207,23 +214,29 @@ Feature: Model Controller
   Scenario: Write and List a Device model
     When I successfully execute the action "device-manager/models":"writeDevice" with args:
       | body.model            | "Zigbee"                         |
-      | body.measures.battery | "battery"                        |
+      | body.measures[0].type | "battery"                        |
+      | body.measures[0].name | "battery"                        |
       | body.metadataMappings | { network: { type: "keyword" } } |
     Then The document "device-manager":"models":"model-device-Zigbee" content match:
       | type                                 | "device"  |
       | device.model                         | "Zigbee"  |
       | device.metadataMappings.network.type | "keyword" |
     When I successfully execute the action "device-manager/models":"writeDevice" with args:
-      | body.model                | "Zigbee"                          |
-      | body.measures.temperature | "temperature"                     |
-      | body.metadataMappings     | { network2: { type: "keyword" } } |
+      | body.model            | "Zigbee"                          |
+      | body.measures[0].type | "battery"                         |
+      | body.measures[0].name | "battery"                         |
+      | body.measures[1].type | "temperature"                     |
+      | body.measures[1].name | "temperature"                     |
+      | body.metadataMappings | { network2: { type: "keyword" } } |
     Then The document "device-manager":"models":"model-device-Zigbee" content match:
       | type                                  | "device"      |
       | device.model                          | "Zigbee"      |
       | device.metadataMappings.network.type  | "keyword"     |
       | device.metadataMappings.network2.type | "keyword"     |
-      | device.measures.battery               | "battery"     |
-      | device.measures.temperature           | "temperature" |
+      | device.measures[0].type               | "battery"     |
+      | device.measures[0].name               | "battery"     |
+      | device.measures[1].type               | "temperature" |
+      | device.measures[1].name               | "temperature" |
     And I refresh the collection "device-manager":"models"
     Then The collection "engine-ayse":"devices" mappings match:
       """
@@ -269,11 +282,12 @@ Feature: Model Controller
   @models
   Scenario: Error if the model name is not PascalCase
     Given I execute the action "device-manager/models":"writeDevice" with args:
-      | body.engineGroup          | "commons"                     |
-      | body.model                | "plane"                       |
-      | body.metadataMappings     | { size: { type: "integer" } } |
-      | body.defaultValues        | { "name": "Firebird" }        |
-      | body.measures.temperature | "temperature"                 |
+      | body.engineGroup      | "commons"                     |
+      | body.model            | "plane"                       |
+      | body.metadataMappings | { size: { type: "integer" } } |
+      | body.defaultValues    | { "name": "Firebird" }        |
+      | body.measures[0].type | "temperature"                 |
+      | body.measures[0].name | "temperature"                 |
     Then I should receive an error matching:
       | message | "Device model \"plane\" must be PascalCase." |
 
@@ -332,71 +346,72 @@ Feature: Model Controller
       }
       """
     When I successfully execute the action "device-manager/models":"writeDevice" with args:
-      | body.model             | "Zigbee"   |
-      | body.metadataMappings  | {}         |
-      | body.measures.presence | "presence" |
+      | body.model            | "Zigbee"   |
+      | body.metadataMappings | {}         |
+      | body.measures[0].type | "presence" |
+      | body.measures[0].name | "presence" |
     Then The collection "engine-ayse":"devices" mappings match:
       """
       {
-      "measures": {
-      "properties": {
-      "presence": {
-      "properties": {
-      "measuredAt": {
-      "type": "date"
-      },
-      "payloadUuids": {
-      "type": "keyword"
-      },
-      "type": {
-      "type": "keyword"
-      },
-      "values": {
-      "properties": {
-      "presence": {
-      "type": "boolean"
-      },
-      "presence2": {
-      "type": "boolean"
-      }
-      }
-      }
-      }
-      },
-      }
-      },
+        "measures": {
+          "properties": {
+            "presence": {
+              "properties": {
+                "measuredAt": {
+                  "type": "date"
+                },
+                "payloadUuids": {
+                  "type": "keyword"
+                },
+                "type": {
+                  "type": "keyword"
+                },
+                "values": {
+                  "properties": {
+                    "presence": {
+                      "type": "boolean"
+                    },
+                    "presence2": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
       """
     Then The collection "device-manager":"devices" mappings match:
       """
       {
-      "measures": {
-      "properties": {
-      "presence": {
-      "properties": {
-      "measuredAt": {
-      "type": "date"
-      },
-      "payloadUuids": {
-      "type": "keyword"
-      },
-      "type": {
-      "type": "keyword"
-      },
-      "values": {
-      "properties": {
-      "presence": {
-      "type": "boolean"
-      },
-      "presence2": {
-      "type": "boolean"
-      }
-      }
-      }
-      }
-      },
-      }
-      },
+        "measures": {
+          "properties": {
+            "presence": {
+              "properties": {
+                "measuredAt": {
+                  "type": "date"
+                },
+                "payloadUuids": {
+                  "type": "keyword"
+                },
+                "type": {
+                  "type": "keyword"
+                },
+                "values": {
+                  "properties": {
+                    "presence": {
+                      "type": "boolean"
+                    },
+                    "presence2": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
       """
     When I successfully execute the action "device-manager/models":"listMeasures"
@@ -407,20 +422,30 @@ Feature: Model Controller
 
   Scenario: Register models from the framework
     Then The document "device-manager":"models":"model-asset-Container" content match:
-      | type                               | "asset"     |
-      | engineGroup                        | "commons"   |
-      | asset.model                        | "Container" |
-      | asset.metadataMappings.weight.type | "integer"   |
-      | asset.metadataMappings.height.type | "integer"   |
+      | type                               | "asset"          |
+      | engineGroup                        | "commons"        |
+      | asset.model                        | "Container"      |
+      | asset.metadataMappings.weight.type | "integer"        |
+      | asset.metadataMappings.height.type | "integer"        |
+      | asset.measures[0].name             | "temperatureExt" |
+      | asset.measures[0].type             | "temperature"    |
+      | asset.measures[1].name             | "temperatureInt" |
+      | asset.measures[1].type             | "temperature"    |
+      | asset.measures[2].name             | "position"       |
+      | asset.measures[2].type             | "position"       |
     Then The document "device-manager":"models":"model-asset-Warehouse" content match:
       | type                                | "asset"     |
       | engineGroup                         | "commons"   |
       | asset.model                         | "Warehouse" |
       | asset.metadataMappings.surface.type | "integer"   |
+      | asset.measures[0].name              | "position"  |
+      | asset.measures[0].type              | "position"  |
     Then The document "device-manager":"models":"model-device-DummyTemp" content match:
-      | type                               | "device"    |
-      | device.model                       | "DummyTemp" |
-      | device.metadataMappings.color.type | "keyword"   |
+      | type                               | "device"      |
+      | device.model                       | "DummyTemp"   |
+      | device.metadataMappings.color.type | "keyword"     |
+      | device.measures[0].name            | "temperature" |
+      | device.measures[0].type            | "temperature" |
     Then The document "device-manager":"models":"model-measure-temperature" content match:
       | type                                    | "measure"     |
       | measure.type                            | "temperature" |

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -27,7 +27,7 @@ deviceManager.models.registerDevice("DummyTemp", {
 // Register an asset for the "commons" group
 
 deviceManager.models.registerAsset("commons", "Container", {
-  measuresNames: [
+  measures: [
     { name: "temperatureExt", type: "temperature" },
     { name: "temperatureInt", type: "temperature" },
     { name: "position", type: "position" },
@@ -42,7 +42,7 @@ deviceManager.models.registerAsset("commons", "Container", {
 });
 
 deviceManager.models.registerAsset("commons", "Warehouse", {
-  measuresNames: [{ name: "position", type: "position" }],
+  measures: [{ name: "position", type: "position" }],
   metadataMappings: {
     surface: { type: "integer" },
   },

--- a/features/fixtures/application/testPipes.ts
+++ b/features/fixtures/application/testPipes.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import { Backend, KDocument } from "kuzzle";
+import should from "should";
 
 import {
   MeasureContent,
@@ -36,6 +37,13 @@ export function registerTestPipes(app: Backend) {
 
       for (const measure of measures) {
         if (measure.values.temperature) {
+          if (device._source.measures.temperature) {
+            // Ensure the measure has not been integrated to the device yet
+            should(measure.measuredAt).be.greaterThan(
+              device._source.measures.temperature.measuredAt
+            );
+          }
+
           measure.values.temperature *= 2;
         }
       }

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -45,9 +45,9 @@ const assetAyseLinked = {
   },
   linkedDevices: [
     {
-      measures: {
-        temperature: "temperatureExt",
-      },
+      measureNames: [
+        { asset: "temperatureExt", device: "temperature" }
+      ],
       _id: "DummyTemp-linked1",
     },
   ],

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -45,9 +45,7 @@ const assetAyseLinked = {
   },
   linkedDevices: [
     {
-      measureNames: [
-        { asset: "temperatureExt", device: "temperature" }
-      ],
+      measureNames: [{ asset: "temperatureExt", device: "temperature" }],
       _id: "DummyTemp-linked1",
     },
   ],

--- a/lib/core/DeviceManagerEngine.ts
+++ b/lib/core/DeviceManagerEngine.ts
@@ -15,6 +15,7 @@ import { onAsk } from "../modules/shared";
 import { DeviceManagerConfiguration } from "./DeviceManagerConfiguration";
 import { DeviceManagerPlugin } from "./DeviceManagerPlugin";
 import { InternalCollection } from "./InternalCollection";
+import { NamedMeasures } from "lib/modules/decoder";
 
 const digitalTwinMappings = {
   asset: assetsMappings,
@@ -170,9 +171,9 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
         model._source[digitalTwinType].metadataMappings
       );
 
-      for (const [measureName, measureType] of Object.entries(
-        model._source[digitalTwinType].measures
-      )) {
+      for (const { name: measureName, type: measureType } of model._source[
+        digitalTwinType
+      ].measures as NamedMeasures) {
         const measureModel = measureModels.find(
           (m) => m._source.measure.type === measureType
         );

--- a/lib/core/DeviceManagerPlugin.ts
+++ b/lib/core/DeviceManagerPlugin.ts
@@ -65,7 +65,7 @@ export class DeviceManagerPlugin extends Plugin {
        *
        * @param engineGroup Engine group name
        * @param model Name of the asset model
-       * @param definition.measuresNames Array describing measures names and types
+       * @param definition.measures Array describing measures names and types
        * @param definition.metadataMappings Metadata mappings definition
        * @param definition.defaultMetadata Default metadata values
        *
@@ -73,9 +73,9 @@ export class DeviceManagerPlugin extends Plugin {
        * ```
        * deviceManager.models.registerAsset(
        *   "logistic",
-       *   "container",
+       *   "Container",
        *   {
-       *     measuresNames: [
+       *     measures: [
        *       { name: "temperatureExt", type: "temperature" },
        *       { name: "temperatureInt", type: "temperature" },
        *       { name: "position", type: "position" },
@@ -96,17 +96,11 @@ export class DeviceManagerPlugin extends Plugin {
         model: string,
         definition: AssetModelDefinition
       ) => {
-        const measures: Record<string, string> = {};
-
-        for (const measure of definition.measuresNames) {
-          measures[measure.name] = measure.type;
-        }
-
         this.modelsRegister.registerAsset(
           engineGroup,
           model,
+          definition.measures,
           definition.metadataMappings,
-          measures,
           definition.defaultMetadata
         );
       },
@@ -135,15 +129,9 @@ export class DeviceManagerPlugin extends Plugin {
       registerDevice: (model: string, definition: DeviceModelDefinition) => {
         this.decodersRegister.register(definition.decoder);
 
-        const measures: Record<string, string> = {};
-
-        for (const measure of definition.decoder.measures) {
-          measures[measure.name] = measure.type;
-        }
-
         this.modelsRegister.registerDevice(
           model,
-          measures,
+          definition.decoder.measures,
           definition.metadataMappings,
           definition.defaultMetadata
         );

--- a/lib/core/registers/ModelsRegister.ts
+++ b/lib/core/registers/ModelsRegister.ts
@@ -4,6 +4,7 @@ import {
   PluginContext,
   PluginImplementationError,
 } from "kuzzle";
+import { NamedMeasures } from "lib/modules/decoder";
 import { MeasureDefinition } from "../../modules/measure";
 
 import { ModelSerializer } from "../../modules/model";
@@ -49,8 +50,8 @@ export class ModelsRegister {
   registerAsset(
     engineGroup: string,
     model: string,
-    metadataMappings: JSONObject,
-    measures: Record<string, string>,
+    measures: NamedMeasures,
+    metadataMappings: JSONObject = {},
     defaultMetadata: JSONObject = {}
   ) {
     if (Inflector.pascalCase(model) !== model) {
@@ -68,7 +69,7 @@ export class ModelsRegister {
 
   registerDevice(
     model: string,
-    measures: Record<string, string>,
+    measures: NamedMeasures,
     metadataMappings: JSONObject = {},
     defaultMetadata: JSONObject = {}
   ) {

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -171,14 +171,8 @@ export class AssetService {
 
       const measures: Record<string, EmbeddedMeasure> = {};
 
-      for (const { name, type } of assetModel.asset.measures) {
-        measures[name] = {
-          measuredAt: null,
-          name,
-          payloadUuids: null,
-          type,
-          values: {},
-        };
+      for (const { name } of assetModel.asset.measures) {
+        measures[name] = null;
       }
 
       const asset = await this.sdk.document.create<AssetContent>(

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -12,7 +12,7 @@ import {
 import { MeasureContent } from "../measure/";
 import { ApiDeviceUnlinkAssetRequest } from "../device/types/DeviceApi";
 import { lock } from "../shared/utils/lock";
-import { Metadata } from "../shared";
+import { EmbeddedMeasure, Metadata } from "../shared";
 import {
   DeviceManagerConfiguration,
   InternalCollection,
@@ -169,11 +169,13 @@ export class AssetService {
         _.set(assetMetadata, metadataName, metadataValue);
       }
 
-      const measures = {};
+      const measures: Record<string, EmbeddedMeasure> = {};
 
-      for (const [name, type] of Object.entries(assetModel.asset.measures)) {
+      for (const { name, type } of assetModel.asset.measures) {
         measures[name] = {
+          measuredAt: null,
           name,
+          payloadUuids: null,
           type,
           values: {},
         };

--- a/lib/modules/asset/collections/assetsMappings.ts
+++ b/lib/modules/asset/collections/assetsMappings.ts
@@ -28,7 +28,7 @@ export const assetsMappings = {
         measureNames: {
           properties: {
             asset: { type: "keyword" },
-            device: { type: "keyword" }
+            device: { type: "keyword" },
           },
         },
       },

--- a/lib/modules/asset/collections/assetsMappings.ts
+++ b/lib/modules/asset/collections/assetsMappings.ts
@@ -25,9 +25,11 @@ export const assetsMappings = {
     linkedDevices: {
       properties: {
         _id: { type: "keyword" },
-        measures: {
-          dynamic: "false",
-          properties: {},
+        measureNames: {
+          properties: {
+            asset: { type: "keyword" },
+            device: { type: "keyword" }
+          },
         },
       },
     },

--- a/lib/modules/asset/types/AssetContent.ts
+++ b/lib/modules/asset/types/AssetContent.ts
@@ -19,17 +19,17 @@ export interface AssetContent<
     _id: string;
 
     /**
-     * Names lookup table for measures
+     * Names of the linked measures
      *
-     * Record<deviceName, assetName>
+     * Array<{ asset: string, device: string }>
      *
      * @example
      *
-     * {
-     *   "temperature": "externalTemperature",
-     * }
+     * [
+     *   { asset: "externalTemperature", device: "temperature" }
+     * ]
      */
-    measures: Record<string, string>;
+    measureNames: Array<{ asset: string, device: string }>;
   }>;
 }
 

--- a/lib/modules/asset/types/AssetContent.ts
+++ b/lib/modules/asset/types/AssetContent.ts
@@ -29,7 +29,7 @@ export interface AssetContent<
      *   { asset: "externalTemperature", device: "temperature" }
      * ]
      */
-    measureNames: Array<{ asset: string, device: string }>;
+    measureNames: Array<{ asset: string; device: string }>;
   }>;
 }
 

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -455,12 +455,12 @@ export class DeviceService {
    */
   private checkAssetMeasureNamesAvailability(
     asset: KDocument<AssetContent>,
-    measureNames: ApiDeviceLinkAssetRequest["body"]["measureNames"],
+    measureNames: ApiDeviceLinkAssetRequest["body"]["measureNames"]
   ) {
-    const requestedMeasuresNames = measureNames.map(m => m.asset);
+    const requestedMeasuresNames = measureNames.map((m) => m.asset);
 
     for (const link of asset._source.linkedDevices) {
-      const existingMeasureNames = link.measureNames.map(m => m.asset);
+      const existingMeasureNames = link.measureNames.map((m) => m.asset);
 
       for (const requestedMeasuresName of requestedMeasuresNames) {
         if (existingMeasureNames.includes(requestedMeasuresName)) {
@@ -471,7 +471,6 @@ export class DeviceService {
       }
     }
   }
-
 
   /**
    * Unlink a device of an asset

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -10,6 +10,7 @@ import {
   ApiDeviceDeleteResult,
   ApiDeviceDetachEngineResult,
   ApiDeviceGetResult,
+  ApiDeviceLinkAssetRequest,
   ApiDeviceLinkAssetResult,
   ApiDeviceSearchResult,
   ApiDeviceUnlinkAssetResult,
@@ -203,7 +204,7 @@ export class DevicesController {
     const deviceId = request.getId();
     const engineId = request.getString("engineId");
     const assetId = request.getString("assetId");
-    const measureNames = request.getBodyObject("measureNames");
+    const measureNames = request.getBodyArray("measureNames") as ApiDeviceLinkAssetRequest["body"]["measureNames"];
     const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.linkAsset(

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -204,7 +204,9 @@ export class DevicesController {
     const deviceId = request.getId();
     const engineId = request.getString("engineId");
     const assetId = request.getString("assetId");
-    const measureNames = request.getBodyArray("measureNames") as ApiDeviceLinkAssetRequest["body"]["measureNames"];
+    const measureNames = request.getBodyArray(
+      "measureNames"
+    ) as ApiDeviceLinkAssetRequest["body"]["measureNames"];
     const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.linkAsset(

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -123,7 +123,7 @@ export interface ApiDeviceLinkAssetRequest extends DevicesControllerRequest {
      *   { asset: "externalTemperature", device: "temperature" }
      * ]
      */
-    measureNames: Array<{ asset: string, device: string }>;
+    measureNames: Array<{ asset: string; device: string }>;
   };
 }
 export type ApiDeviceLinkAssetResult = {

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -113,17 +113,17 @@ export interface ApiDeviceLinkAssetRequest extends DevicesControllerRequest {
 
   body?: {
     /**
-     * Names lookup table for measures
+     * Names of the linked measures
      *
-     * Record<deviceName, assetName>
+     * Array<{ asset: string, device: string }>
      *
      * @example
      *
-     * {
-     *   "temperature": "externalTemperature",
-     * }
+     * [
+     *   { asset: "externalTemperature", device: "temperature" }
+     * ]
      */
-    measureNames: Record<string, string>;
+    measureNames: Array<{ asset: string, device: string }>;
   };
 }
 export type ApiDeviceLinkAssetResult = {

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -429,8 +429,10 @@ export class MeasureService {
         `Device "${device._id}" is not linked to asset "${asset._id}"`
       );
     }
-    console.log({deviceLink})
-    const measureName = deviceLink.measureNames.find(m => m.device === deviceMeasureName);
+
+    const measureName = deviceLink.measureNames.find(
+      (m) => m.device === deviceMeasureName
+    );
     if (!measureName) {
       throw new BadRequestError(
         `Measure "${deviceMeasureName}" from device "${device._id}" does not have a name in asset "${asset._id}"`

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -429,13 +429,14 @@ export class MeasureService {
         `Device "${device._id}" is not linked to asset "${asset._id}"`
       );
     }
-
-    if (!deviceLink.measures[deviceMeasureName]) {
+    console.log({deviceLink})
+    const measureName = deviceLink.measureNames.find(m => m.device === deviceMeasureName);
+    if (!measureName) {
       throw new BadRequestError(
         `Measure "${deviceMeasureName}" from device "${device._id}" does not have a name in asset "${asset._id}"`
       );
     }
 
-    return deviceLink.measures[deviceMeasureName];
+    return measureName.asset;
   }
 }

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -102,11 +102,6 @@ export class MeasureService {
         payloadUuids
       );
 
-      this.updateEmbeddedMeasures("device", device, measures);
-      if (asset) {
-        this.updateEmbeddedMeasures("asset", asset, measures);
-      }
-
       /**
        * Event before starting to process new measures.
        *

--- a/lib/modules/measure/types/MeasureEvents.ts
+++ b/lib/modules/measure/types/MeasureEvents.ts
@@ -22,6 +22,13 @@ export type EventMeasureIngest = {
   ];
 };
 
+/**
+ * Event before starting to process new measures.
+ *
+ * Useful to enrich measures before they are saved.
+ *
+ * Only measures documents can be modified
+ */
 export type EventMeasureProcessBefore = {
   name: "device-manager:measures:process:before";
 

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -54,12 +54,10 @@ export class ModelService {
     model: string,
     metadataMappings: JSONObject,
     defaultMetadata: JSONObject,
-    measures: JSONObject
+    measures: AssetModelContent["asset"]["measures"]
   ): Promise<KDocument<AssetModelContent>> {
     if (Inflector.pascalCase(model) !== model) {
-      throw new BadRequestError(
-        `Asset model "${model}" must be PascalCase.`
-      );
+      throw new BadRequestError(`Asset model "${model}" must be PascalCase.`);
     }
 
     const modelContent: AssetModelContent = {
@@ -113,12 +111,10 @@ export class ModelService {
     model: string,
     metadataMappings: JSONObject,
     defaultMetadata: JSONObject,
-    measures: JSONObject
+    measures: DeviceModelContent["device"]["measures"]
   ): Promise<KDocument<DeviceModelContent>> {
     if (Inflector.pascalCase(model) !== model) {
-      throw new BadRequestError(
-        `Device model "${model}" must be PascalCase.`
-      );
+      throw new BadRequestError(`Device model "${model}" must be PascalCase.`);
     }
 
     const modelContent: DeviceModelContent = {

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -4,7 +4,6 @@ import {
   JSONObject,
   KDocument,
   PluginContext,
-  PluginImplementationError,
 } from "kuzzle";
 
 import {
@@ -58,8 +57,8 @@ export class ModelService {
     measures: JSONObject
   ): Promise<KDocument<AssetModelContent>> {
     if (Inflector.pascalCase(model) !== model) {
-      throw new PluginImplementationError(
-        `Asset model "${model}" must be PascalCase`
+      throw new BadRequestError(
+        `Asset model "${model}" must be PascalCase.`
       );
     }
 
@@ -117,8 +116,8 @@ export class ModelService {
     measures: JSONObject
   ): Promise<KDocument<DeviceModelContent>> {
     if (Inflector.pascalCase(model) !== model) {
-      throw new PluginImplementationError(
-        `Device model "${model}" must be PascalCase`
+      throw new BadRequestError(
+        `Device model "${model}" must be PascalCase.`
       );
     }
 

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -2,9 +2,9 @@ import { ControllerDefinition, KuzzleRequest } from "kuzzle";
 
 import { ModelService } from "./ModelService";
 import {
-  ApiModelCreateAssetResult,
-  ApiModelCreateDeviceResult,
-  ApiModelCreateMeasureResult,
+  ApiModelWriteAssetResult,
+  ApiModelWriteDeviceResult,
+  ApiModelWriteMeasureResult,
   ApiModelDeleteAssetResult,
   ApiModelDeleteDeviceResult,
   ApiModelDeleteMeasureResult,
@@ -65,7 +65,7 @@ export class ModelsController {
     };
   }
 
-  async writeAsset(request: KuzzleRequest): Promise<ApiModelCreateAssetResult> {
+  async writeAsset(request: KuzzleRequest): Promise<ApiModelWriteAssetResult> {
     const engineGroup = request.getBodyString("engineGroup");
     const model = request.getBodyString("model");
     const metadataMappings = request.getBodyObject("metadataMappings");
@@ -85,7 +85,7 @@ export class ModelsController {
 
   async writeDevice(
     request: KuzzleRequest
-  ): Promise<ApiModelCreateDeviceResult> {
+  ): Promise<ApiModelWriteDeviceResult> {
     const model = request.getBodyString("model");
     const metadataMappings = request.getBodyObject("metadataMappings");
     const defaultValues = request.getBodyObject("defaultValues", {});
@@ -103,7 +103,7 @@ export class ModelsController {
 
   async writeMeasure(
     request: KuzzleRequest
-  ): Promise<ApiModelCreateMeasureResult> {
+  ): Promise<ApiModelWriteMeasureResult> {
     const type = request.getBodyString("type");
     const valuesMappings = request.getBodyObject("valuesMappings");
 

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -68,9 +68,9 @@ export class ModelsController {
   async writeAsset(request: KuzzleRequest): Promise<ApiModelWriteAssetResult> {
     const engineGroup = request.getBodyString("engineGroup");
     const model = request.getBodyString("model");
-    const metadataMappings = request.getBodyObject("metadataMappings");
+    const metadataMappings = request.getBodyObject("metadataMappings", {});
     const defaultValues = request.getBodyObject("defaultValues", {});
-    const measures = request.getBodyObject("measures", {});
+    const measures = request.getBodyArray("measures", []);
 
     const assetModel = await this.modelService.writeAsset(
       engineGroup,
@@ -87,9 +87,9 @@ export class ModelsController {
     request: KuzzleRequest
   ): Promise<ApiModelWriteDeviceResult> {
     const model = request.getBodyString("model");
-    const metadataMappings = request.getBodyObject("metadataMappings");
+    const metadataMappings = request.getBodyObject("metadataMappings", {});
     const defaultValues = request.getBodyObject("defaultValues", {});
-    const measures = request.getBodyObject("measures");
+    const measures = request.getBodyArray("measures");
 
     const deviceModel = await this.modelService.writeDevice(
       model,

--- a/lib/modules/model/collections/modelsMappings.ts
+++ b/lib/modules/model/collections/modelsMappings.ts
@@ -8,6 +8,9 @@ export const modelsMappings: CollectionMappings = {
     type: { type: "keyword" },
     engineGroup: { type: "keyword" },
 
+    /**
+     * Measure model
+     */
     measure: {
       properties: {
         type: { type: "keyword" },
@@ -18,6 +21,9 @@ export const modelsMappings: CollectionMappings = {
       },
     },
 
+    /**
+     * Asset model
+     */
     asset: {
       properties: {
         model: { type: "keyword" },
@@ -30,12 +36,17 @@ export const modelsMappings: CollectionMappings = {
           properties: {},
         },
         measures: {
-          dynamic: "false",
-          properties: {},
+          properties: {
+            type: { type: "keyword" },
+            name: { type: "keyword" },
+          },
         },
       },
     },
 
+    /**
+     * Device model
+     */
     device: {
       properties: {
         model: { type: "keyword" },
@@ -48,8 +59,10 @@ export const modelsMappings: CollectionMappings = {
           properties: {},
         },
         measures: {
-          dynamic: "false",
-          properties: {},
+          properties: {
+            type: { type: "keyword" },
+            name: { type: "keyword" },
+          },
         },
       },
     },

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -10,7 +10,7 @@ interface ModelsControllerRequest {
   controller: "device-manager/models";
 }
 
-export interface ApiModelCreateAssetRequest extends ModelsControllerRequest {
+export interface ApiModelWriteAssetRequest extends ModelsControllerRequest {
   action: "writeAsset";
 
   body: {
@@ -20,20 +20,21 @@ export interface ApiModelCreateAssetRequest extends ModelsControllerRequest {
     defaultValues: JSONObject;
   };
 }
-export type ApiModelCreateAssetResult = KDocument<AssetModelContent>;
+export type ApiModelWriteAssetResult = KDocument<AssetModelContent>;
 
-export interface ApiModelCreateDeviceRequest extends ModelsControllerRequest {
+export interface ApiModelWriteDeviceRequest extends ModelsControllerRequest {
   action: "writeDevice";
 
   body: {
     model: string;
     metadataMappings: JSONObject;
     defaultValues: JSONObject;
+    measures: Record<string, string>
   };
 }
-export type ApiModelCreateDeviceResult = KDocument<DeviceModelContent>;
+export type ApiModelWriteDeviceResult = KDocument<DeviceModelContent>;
 
-export interface ApiModelCreateMeasureRequest extends ModelsControllerRequest {
+export interface ApiModelWriteMeasureRequest extends ModelsControllerRequest {
   action: "writeMeasure";
 
   body: {
@@ -46,7 +47,7 @@ export interface ApiModelCreateMeasureRequest extends ModelsControllerRequest {
     valuesMappings: JSONObject;
   };
 }
-export type ApiModelCreateMeasureResult = KDocument<MeasureModelContent>;
+export type ApiModelWriteMeasureResult = KDocument<MeasureModelContent>;
 
 export interface ApiModelDeleteAssetRequest extends ModelsControllerRequest {
   action: "deleteAsset";

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -16,8 +16,9 @@ export interface ApiModelWriteAssetRequest extends ModelsControllerRequest {
   body: {
     engineGroup: string;
     model: string;
-    metadataMappings: JSONObject;
-    defaultValues: JSONObject;
+    metadataMappings?: JSONObject;
+    defaultValues?: JSONObject;
+    measures?: AssetModelContent["asset"]["measures"];
   };
 }
 export type ApiModelWriteAssetResult = KDocument<AssetModelContent>;
@@ -27,9 +28,9 @@ export interface ApiModelWriteDeviceRequest extends ModelsControllerRequest {
 
   body: {
     model: string;
-    metadataMappings: JSONObject;
-    defaultValues: JSONObject;
-    measures: Record<string, string>
+    metadataMappings?: JSONObject;
+    defaultValues?: JSONObject;
+    measures: DeviceModelContent["device"]["measures"];
   };
 }
 export type ApiModelWriteDeviceResult = KDocument<DeviceModelContent>;
@@ -39,11 +40,6 @@ export interface ApiModelWriteMeasureRequest extends ModelsControllerRequest {
 
   body: {
     type: string;
-    unit: {
-      name: string;
-      sign: string;
-      type: string;
-    };
     valuesMappings: JSONObject;
   };
 }

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -1,4 +1,5 @@
 import { JSONObject, KDocumentContent } from "kuzzle";
+import { NamedMeasures } from "lib/modules/decoder";
 
 import { MeasureDefinition } from "../../measure";
 
@@ -48,15 +49,15 @@ export interface AssetModelContent extends KDocumentContent {
     /**
      * List of accepted measures for this model
      *
-     * Record<name, type>
+     * Array<{ type: string, name: string }>
      *
      * @example
      *
-     * {
-     *   "externalTemperature": "temperature",
-     * }
+     * [
+     *   { type: "temperature", name: "externalTemperature" }
+     * ]
      */
-    measures: Record<string, string>;
+    measures: NamedMeasures;
   };
 }
 
@@ -96,15 +97,15 @@ export interface DeviceModelContent extends KDocumentContent {
     /**
      * List of decoded measures for this model
      *
-     * Record<name, type>
+     * Array<{ type: string, name: string }>
      *
      * @example
      *
-     * {
-     *   "temperature1": "temperature",
-     * }
+     * [
+     *   { type: "temperature", name: "externalTemperature" }
+     * ]
      */
-    measures: Record<string, string>;
+    measures: NamedMeasures;
   };
 }
 

--- a/lib/modules/model/types/ModelDefinition.ts
+++ b/lib/modules/model/types/ModelDefinition.ts
@@ -7,7 +7,7 @@ import { Decoder, NamedMeasures } from "../../../modules/decoder";
  *
  * @example
  *   {
- *     measuresNames: [
+ *     measures: [
  *       { name: "temperatureExt", type: "temperature" },
  *       { name: "temperatureInt", type: "temperature" },
  *       { name: "position", type: "position" },
@@ -26,12 +26,12 @@ export type AssetModelDefinition = {
   /**
    * Array describing measures names and types
    */
-  measuresNames: NamedMeasures;
+  measures: NamedMeasures;
 
   /**
    * Metadata mappings definition
    */
-  metadataMappings: JSONObject;
+  metadataMappings?: JSONObject;
 
   /**
    * Default metadata values

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc38",
+  "version": "2.0.0-rc37",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.0.0-rc38",
+      "version": "2.0.0-rc37",
       "license": "Apache-2.0",
       "dependencies": {
         "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.5.tar.gz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc37",
+  "version": "2.0.0-rc38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.0.0-rc37",
+      "version": "2.0.0-rc38",
       "license": "Apache-2.0",
       "dependencies": {
         "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.5.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc38",
+  "version": "2.0.0-rc37",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.0-rc37",
+  "version": "2.0.0-rc38",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager-types",
-  "version": "2.0.0-rc36",
+  "version": "2.0.0-rc38",
   "description": "Shared types for Kuzzle Device Manager",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "types": "dist/index.d.ts",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager-types",
-  "version": "2.0.0-rc38",
+  "version": "2.0.0-rc37",
   "description": "Shared types for Kuzzle Device Manager",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What does this PR do ?

Change `device-manager/devices:linkAsset` API action. The new format is specified in the type `ApiDeviceLinkAssetRequest`. The `measures` is not a table anymore but an array which each element describe a measure with it's `name` and `type` to avoid confusion between key/value.

```
  action: "linkAsset";

  _id: string;

  refresh?: string;

  assetId: string;

  body?: {
    /**
     * Names of the linked measures
     *
     * Array<{ asset: string, device: string }>
     *
     * @example
     *
     * [
     *   { asset: "externalTemperature", device: "temperature" }
     * ]
     */
    measureNames: Array<{ asset: string; device: string }>;
  };
```

The method to register default devices and array also changed accordingly (`Plugin.registerAsset` and `Plugin.registerDevice`).

The `assets` collection changed as well. `measures` become `measureNames` and have the same format as the parameter in the API action

The `models` collection mappings also changed, the `measures` property now have the same format as the parameter in the API action