### PR TITLE
Add asset historization

### DIFF
--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -14,14 +14,16 @@ Feature: Asset Controller
       | measures.temperatureInt | null |
       | measures.position       | null |
       | linkedDevices           | []   |
+      | _kuzzle_info.author     | "-1" |
     # Update metadata
     When I successfully execute the action "device-manager/assets":"update" with args:
       | engineId             | "engine-kuzzle" |
       | _id                  | "Container-A1"  |
       | body.metadata.weight | 1250            |
     Then The document "engine-kuzzle":"assets":"Container-A1" content match:
-      | metadata.height | 5    |
-      | metadata.weight | 1250 |
+      | metadata.height      | 5    |
+      | metadata.weight      | 1250 |
+      | _kuzzle_info.updater | "-1" |
     # Get
     When I successfully execute the action "device-manager/assets":"get" with args:
       | engineId | "engine-kuzzle" |
@@ -43,11 +45,11 @@ Feature: Asset Controller
     Then I should receive a "hits" array of objects matching:
       | _id            |
       | "Container-A1" |
-    # Delete
-    When I successfully execute the action "device-manager/assets":"delete" with args:
-      | engineId | "engine-kuzzle" |
-      | _id      | "Container-A1"  |
-    Then The document "engine-kuzzle":"assets":"Container-A1" does not exists
+  # Delete
+  When I successfully execute the action "device-manager/assets":"delete" with args:
+    | engineId | "engine-kuzzle" |
+    | _id      | "Container-A1"  |
+  Then The document "engine-kuzzle":"assets":"Container-A1" does not exists
 
   Scenario: Error when creating Asset from unknown model
     When I execute the action "device-manager/assets":"create" with args:

--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -14,6 +14,7 @@ Feature: Asset Controller
       | measures.temperatureInt | null |
       | measures.position       | null |
       | linkedDevices           | []   |
+    # Update metadata
     When I successfully execute the action "device-manager/assets":"update" with args:
       | engineId             | "engine-kuzzle" |
       | _id                  | "Container-A1"  |

--- a/features/Asset/History.feature
+++ b/features/Asset/History.feature
@@ -18,13 +18,11 @@ Feature: Asset Historization
     And I should receive a result matching:
       | hits.length                           | 2                    |
       | hits[0]._source.id                    | "Container-A1"       |
-      | hits[0]._source.type                  | "asset"              |
       | hits[0]._source.event.name            | "metadata"           |
       | hits[0]._source.event.metadata.names  | ["weight"]           |
       | hits[0]._source.asset.metadata.height | 5                    |
       | hits[0]._source.asset.metadata.weight | 1250                 |
       | hits[1]._source.id                    | "Container-A1"       |
-      | hits[1]._source.type                  | "asset"              |
       | hits[1]._source.event.name            | "metadata"           |
       | hits[1]._source.event.metadata.names  | ["weight", "height"] |
       | hits[1]._source.asset.metadata.height | 5                    |
@@ -48,12 +46,10 @@ Feature: Asset Historization
     And I should receive a result matching:
       | hits.length                                | 2                     |
       | hits[0]._source.id                         | "Container-unlinked1" |
-      | hits[0]._source.type                       | "asset"               |
       | hits[0]._source.event.name                 | "unlink"              |
       | hits[0]._source.event.unlink.deviceId      | "DummyTemp-unlinked1" |
       | hits[0]._source.asset.linkedDevices        | []                    |
       | hits[1]._source.id                         | "Container-unlinked1" |
-      | hits[1]._source.type                       | "asset"               |
       | hits[1]._source.event.name                 | "link"                |
       | hits[1]._source.event.link.deviceId        | "DummyTemp-unlinked1" |
       | hits[1]._source.asset.linkedDevices[0]._id | "DummyTemp-unlinked1" |
@@ -70,7 +66,6 @@ Feature: Asset Historization
     And I should receive a result matching:
       | hits.length                                                      | 1                   |
       | hits[0]._source.id                                               | "Container-linked1" |
-      | hits[0]._source.type                                             | "asset"             |
       | hits[0]._source.event.name                                       | "measure"           |
       | hits[0]._source.event.measure.names                              | ["temperatureExt"]  |
       | hits[0]._source.event.metadata                                   | "_UNDEFINED_"       |
@@ -89,7 +84,6 @@ Feature: Asset Historization
     And I should receive a result matching:
       | hits.length                                                      | 1                   |
       | hits[0]._source.id                                               | "Container-linked1" |
-      | hits[0]._source.type                                             | "asset"             |
       | hits[0]._source.event.name                                       | "measure"           |
       | hits[0]._source.event.measure.names                              | ["temperatureExt"]  |
       | hits[0]._source.event.metadata.names                             | ["weight"]          |

--- a/features/Asset/History.feature
+++ b/features/Asset/History.feature
@@ -12,21 +12,23 @@ Feature: Asset Historization
       | body.metadata.weight | 1250            |
     And I refresh the collection "engine-kuzzle":"assets-history"
     Then I successfully execute the action "document":"search" with args:
-      | index      | "engine-kuzzle"  |
-      | collection | "assets-history" |
-      | body       | {}               |
+      | index      | "engine-kuzzle"                    |
+      | collection | "assets-history"                   |
+      | body.sort  | {"_kuzzle_info.createdAt": "desc"} |
     And I should receive a result matching:
-      | hits.length                           | 2              |
-      | hits[0]._source.id                    | "Container-A1" |
-      | hits[0]._source.type                  | "asset"        |
-      | hits[0]._source.events                | ["metadata"]   |
-      | hits[0]._source.asset.metadata.height | 5              |
-      | hits[0]._source.asset.metadata.weight | null           |
-      | hits[1]._source.id                    | "Container-A1" |
-      | hits[1]._source.type                  | "asset"        |
-      | hits[1]._source.events                | ["metadata"]   |
-      | hits[1]._source.asset.metadata.height | 5              |
-      | hits[1]._source.asset.metadata.weight | 1250           |
+      | hits.length                           | 2                    |
+      | hits[0]._source.id                    | "Container-A1"       |
+      | hits[0]._source.type                  | "asset"              |
+      | hits[0]._source.event.name            | "metadata"           |
+      | hits[0]._source.event.metadata.names  | ["weight"]           |
+      | hits[0]._source.asset.metadata.height | 5                    |
+      | hits[0]._source.asset.metadata.weight | 1250                 |
+      | hits[1]._source.id                    | "Container-A1"       |
+      | hits[1]._source.type                  | "asset"              |
+      | hits[1]._source.event.name            | "metadata"           |
+      | hits[1]._source.event.metadata.names  | ["weight", "height"] |
+      | hits[1]._source.asset.metadata.height | 5                    |
+      | hits[1]._source.asset.metadata.weight | null                 |
 
   Scenario: Historize asset after being linked and unlinked
     When I successfully execute the action "device-manager/devices":"linkAsset" with args:
@@ -40,33 +42,56 @@ Feature: Asset Historization
       | _id      | "DummyTemp-unlinked1" |
     And I refresh the collection "engine-ayse":"assets-history"
     Then I successfully execute the action "document":"search" with args:
-      | index      | "engine-ayse"    |
-      | collection | "assets-history" |
-      | body       | {}               |
+      | index      | "engine-ayse"                      |
+      | collection | "assets-history"                   |
+      | body.sort  | {"_kuzzle_info.createdAt": "desc"} |
     And I should receive a result matching:
       | hits.length                                | 2                     |
       | hits[0]._source.id                         | "Container-unlinked1" |
       | hits[0]._source.type                       | "asset"               |
-      | hits[0]._source.events                     | ["link"]              |
-      | hits[0]._source.asset.linkedDevices[0]._id | "DummyTemp-unlinked1" |
+      | hits[0]._source.event.name                 | "unlink"              |
+      | hits[0]._source.event.unlink.deviceId      | "DummyTemp-unlinked1" |
+      | hits[0]._source.asset.linkedDevices        | []                    |
       | hits[1]._source.id                         | "Container-unlinked1" |
       | hits[1]._source.type                       | "asset"               |
-      | hits[1]._source.events                     | ["link"]              |
-      | hits[1]._source.asset.linkedDevices        | []                    |
+      | hits[1]._source.event.name                 | "link"                |
+      | hits[1]._source.event.link.deviceId        | "DummyTemp-unlinked1" |
+      | hits[1]._source.asset.linkedDevices[0]._id | "DummyTemp-unlinked1" |
 
-  #
   Scenario: Historize asset after receiving a new measure
     When I send the following "dummy-temp" payloads:
       | deviceEUI | temperature |
       | "linked1" | 42.2        |
     And I refresh the collection "engine-ayse":"assets-history"
     Then I successfully execute the action "document":"search" with args:
-      | index      | "engine-ayse"    |
-      | collection | "assets-history" |
-      | body       | {}               |
+      | index      | "engine-ayse"                      |
+      | collection | "assets-history"                   |
+      | body.sort  | {"_kuzzle_info.createdAt": "desc"} |
     And I should receive a result matching:
       | hits.length                                                      | 1                   |
       | hits[0]._source.id                                               | "Container-linked1" |
       | hits[0]._source.type                                             | "asset"             |
-      | hits[0]._source.events                                           | ["measure"]         |
+      | hits[0]._source.event.name                                       | "measure"           |
+      | hits[0]._source.event.measure.names                              | ["temperatureExt"]  |
+      | hits[0]._source.event.metadata                                   | "_UNDEFINED_"       |
       | hits[0]._source.asset.measures.temperatureExt.values.temperature | 42.2                |
+
+  Scenario: Historize asset when metadata have been updated when receiving a measure
+    # A pipe will set the asset "weight" metadata to 42042
+    When I send the following "dummy-temp" payloads:
+      | deviceEUI | temperature | metadata.color                       |
+      | "linked1" | 42.2        | "test-metadata-history-with-measure" |
+    And I refresh the collection "engine-ayse":"assets-history"
+    Then I successfully execute the action "document":"search" with args:
+      | index      | "engine-ayse"                      |
+      | collection | "assets-history"                   |
+      | body.sort  | {"_kuzzle_info.createdAt": "desc"} |
+    And I should receive a result matching:
+      | hits.length                                                      | 1                   |
+      | hits[0]._source.id                                               | "Container-linked1" |
+      | hits[0]._source.type                                             | "asset"             |
+      | hits[0]._source.event.name                                       | "measure"           |
+      | hits[0]._source.event.measure.names                              | ["temperatureExt"]  |
+      | hits[0]._source.event.metadata.names                             | ["weight"]          |
+      | hits[0]._source.asset.measures.temperatureExt.values.temperature | 42.2                |
+      | hits[0]._source.asset.metadata.weight                            | 42042               |

--- a/features/Asset/History.feature
+++ b/features/Asset/History.feature
@@ -1,0 +1,72 @@
+Feature: Asset Historization
+
+  Scenario: Historize asset after creation and metadata update
+    When I successfully execute the action "device-manager/assets":"create" with args:
+      | engineId             | "engine-kuzzle" |
+      | body.model           | "Container"     |
+      | body.reference       | "A1"            |
+      | body.metadata.height | 5               |
+    And I successfully execute the action "device-manager/assets":"update" with args:
+      | engineId             | "engine-kuzzle" |
+      | _id                  | "Container-A1"  |
+      | body.metadata.weight | 1250            |
+    And I refresh the collection "engine-kuzzle":"assets-history"
+    Then I successfully execute the action "document":"search" with args:
+      | index      | "engine-kuzzle"  |
+      | collection | "assets-history" |
+      | body       | {}               |
+    And I should receive a result matching:
+      | hits.length                           | 2              |
+      | hits[0]._source.id                    | "Container-A1" |
+      | hits[0]._source.type                  | "asset"        |
+      | hits[0]._source.events                | ["metadata"]   |
+      | hits[0]._source.asset.metadata.height | 5              |
+      | hits[0]._source.asset.metadata.weight | null           |
+      | hits[1]._source.id                    | "Container-A1" |
+      | hits[1]._source.type                  | "asset"        |
+      | hits[1]._source.events                | ["metadata"]   |
+      | hits[1]._source.asset.metadata.height | 5              |
+      | hits[1]._source.asset.metadata.weight | 1250           |
+
+  Scenario: Historize asset after being linked and unlinked
+    When I successfully execute the action "device-manager/devices":"linkAsset" with args:
+      | _id                         | "DummyTemp-unlinked1" |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
+    And I execute the action "device-manager/devices":"unlinkAsset" with args:
+      | engineId | "engine-ayse"         |
+      | _id      | "DummyTemp-unlinked1" |
+    And I refresh the collection "engine-ayse":"assets-history"
+    Then I successfully execute the action "document":"search" with args:
+      | index      | "engine-ayse"    |
+      | collection | "assets-history" |
+      | body       | {}               |
+    And I should receive a result matching:
+      | hits.length                                | 2                     |
+      | hits[0]._source.id                         | "Container-unlinked1" |
+      | hits[0]._source.type                       | "asset"               |
+      | hits[0]._source.events                     | ["link"]              |
+      | hits[0]._source.asset.linkedDevices[0]._id | "DummyTemp-unlinked1" |
+      | hits[1]._source.id                         | "Container-unlinked1" |
+      | hits[1]._source.type                       | "asset"               |
+      | hits[1]._source.events                     | ["link"]              |
+      | hits[1]._source.asset.linkedDevices        | []                    |
+
+  #
+  Scenario: Historize asset after receiving a new measure
+    When I send the following "dummy-temp" payloads:
+      | deviceEUI | temperature |
+      | "linked1" | 42.2        |
+    And I refresh the collection "engine-ayse":"assets-history"
+    Then I successfully execute the action "document":"search" with args:
+      | index      | "engine-ayse"    |
+      | collection | "assets-history" |
+      | body       | {}               |
+    And I should receive a result matching:
+      | hits.length                                                      | 1                   |
+      | hits[0]._source.id                                               | "Container-linked1" |
+      | hits[0]._source.type                                             | "asset"             |
+      | hits[0]._source.events                                           | ["measure"]         |
+      | hits[0]._source.asset.measures.temperatureExt.values.temperature | 42.2                |

--- a/features/Decoder/PayloadController.feature
+++ b/features/Decoder/PayloadController.feature
@@ -36,12 +36,12 @@ Feature: Payloads Controller
       | valid | false |
     And The document "device-manager":"devices":"DummyTemp-12345" does not exists
 
-  Scenario: Receive a payload with 3 measures
+  Scenario: Receive a payload with 3 measures but only 2 are propagated to the asset
     Given I send the following "dummy-temp-position" payloads:
       | deviceEUI | temperature | location.lat | location.lon | location.accuracy | battery |
-      | "12345"   | 21          | 42.2         | 2.42         | 2100              | 0.8     |
-    Then The document "device-manager":"devices":"DummyTempPosition-12345" content match:
-      | reference                               | "12345"             |
+      | "linked2" | 21          | 42.2         | 2.42         | 2100              | 0.8     |
+    Then The document "device-manager":"devices":"DummyTempPosition-linked2" content match:
+      | reference                               | "linked2"           |
       | model                                   | "DummyTempPosition" |
       | measures.temperature.type               | "temperature"       |
       | measures.temperature.measuredAt         | "_DATE_NOW_"        |
@@ -54,8 +54,24 @@ Feature: Payloads Controller
       | measures.battery.type                   | "battery"           |
       | measures.battery.measuredAt             | "_DATE_NOW_"        |
       | measures.battery.values.battery         | 80                  |
-      | engineId                                | null                |
-      | assetId                                 | null                |
+      | engineId                                | "engine-ayse"       |
+      | assetId                                 | "Container-linked2" |
+    Then The document "engine-ayse":"assets":"Container-linked2" content match:
+      | measures.temperatureExt.values.temperature | 21            |
+      | measures.position.values.position.lat      | 42.2          |
+      | measures.position.values.position.lon      | 2.42          |
+      | measures.battery                           | "_UNDEFINED_" |
+    And I refresh the collection "engine-ayse":"assets-history"
+    Then I successfully execute the action "document":"search" with args:
+      | index      | "engine-ayse"                      |
+      | collection | "assets-history"                   |
+      | body.sort  | {"_kuzzle_info.createdAt": "desc"} |
+    And I should receive a result matching:
+      | hits.length                         | 1                              |
+      | hits[0]._source.id                  | "Container-linked2"            |
+      | hits[0]._source.event.name          | "measure"                      |
+      | hits[0]._source.event.measure.names | ["temperatureExt", "position"] |
+
 
   Scenario: Historize the measures with device and asset context
     Given I send the following "dummy-temp" payloads:

--- a/features/Decoder/PayloadController.feature
+++ b/features/Decoder/PayloadController.feature
@@ -59,14 +59,15 @@ Feature: Payloads Controller
 
   Scenario: Historize the measures with device and asset context
     Given I send the following "dummy-temp" payloads:
-      | deviceEUI | "12345" |
-      | "linked1" | 42.2    |
+      | deviceEUI | temperature |
+      | "linked1" | 42.2        |
     And I refresh the collection "engine-ayse":"measures"
     Then When I successfully execute the action "document":"search" with args:
       | index      | "engine-ayse" |
       | collection | "measures"    |
     And I should receive a result matching:
       | hits[0]._source.type                  | "temperature"       |
+      | hits[0]._source.values.temperature    | 42.2                |
       | hits[0]._source.measuredAt            | "_DATE_NOW_"        |
       | hits[0]._source.origin._id            | "DummyTemp-linked1" |
       | hits[0]._source.origin.type           | "device"            |

--- a/features/Device/Controller/AttachEngine.feature
+++ b/features/Device/Controller/AttachEngine.feature
@@ -5,9 +5,11 @@ Feature: Attach device to engine
       | _id      | "DummyTemp-detached1" |
       | engineId | "engine-kuzzle"       |
     Then The document "device-manager":"devices":"DummyTemp-detached1" content match:
-      | engineId | "engine-kuzzle" |
+      | engineId             | "engine-kuzzle" |
+      | _kuzzle_info.updater | "-1"            |
     Then The document "engine-kuzzle":"devices":"DummyTemp-detached1" content match:
-      | engineId | "engine-kuzzle" |
+      | engineId            | "engine-kuzzle" |
+      | _kuzzle_info.author | "-1"            |
     When I send the following "dummy-temp" payloads:
       | deviceEUI   | temperature |
       | "detached1" | 21          |

--- a/features/Device/Controller/DetachEngine.feature
+++ b/features/Device/Controller/DetachEngine.feature
@@ -8,7 +8,8 @@ Feature: Detach device from engine
       | engineId | "engine-kuzzle"       |
       | _id      | "DummyTemp-detached1" |
     Then The document "device-manager":"devices":"DummyTemp-detached1" content match:
-      | engineId | null |
+      | engineId             | null |
+      | _kuzzle_info.updater | "-1" |
     And The document "engine-kuzzle":"devices":"DummyTemp-detached1" does not exists
 
   Scenario: Error if device is not attached

--- a/features/Device/Controller/LinkAsset.feature
+++ b/features/Device/Controller/LinkAsset.feature
@@ -8,13 +8,16 @@ Feature: LinkAsset
       | body.measureNames[0].device | "temperature"         |
       | body.measureNames[0].asset  | "temperatureExt"      |
     Then The document "device-manager":"devices":"DummyTemp-unlinked1" content match:
-      | assetId | "Container-unlinked1" |
+      | assetId              | "Container-unlinked1" |
+      | _kuzzle_info.updater | "-1"                  |
     And The document "engine-ayse":"devices":"DummyTemp-unlinked1" content match:
-      | assetId | "Container-unlinked1" |
+      | assetId              | "Container-unlinked1" |
+      | _kuzzle_info.updater | "-1"                  |
     And The document "engine-ayse":"assets":"Container-unlinked1" content match:
       | linkedDevices[0]._id                    | "DummyTemp-unlinked1" |
       | linkedDevices[0].measureNames[0].asset  | "temperatureExt"      |
       | linkedDevices[0].measureNames[0].device | "temperature"         |
+      | _kuzzle_info.updater                    | "-1"                  |
     When I successfully execute the action "device-manager/devices":"linkAsset" with args:
       | _id                         | "DummyTemp-unlinked2" |
       | assetId                     | "Container-unlinked1" |

--- a/features/Device/Controller/SCRUD.feature
+++ b/features/Device/Controller/SCRUD.feature
@@ -17,6 +17,8 @@ Feature: Device SCRUD
       | _source.model          | "DummyTemp" |
       | _source.reference      | "scrudme"   |
       | _source.metadata.color | "RED"       |
+      | _source._kuzzle_info.author     | "-1" |
+      | _source._kuzzle_info.updater     | "-1" |
     Given I refresh the collection "device-manager":"devices"
     When I successfully execute the action "device-manager/devices":"search" with args:
       | engineId | "device-manager"                                |

--- a/features/Device/Controller/UnlinkAsset.feature
+++ b/features/Device/Controller/UnlinkAsset.feature
@@ -31,7 +31,6 @@ Feature: UnlinkAsset
     And I should receive a result matching:
       | hits.length                                | 1                     |
       | hits[0]._source.id                         | "Container-linked1" |
-      | hits[0]._source.type                       | "asset"               |
       | hits[0]._source.event.name                 | "unlink"              |
       | hits[0]._source.event.unlink.deviceId      | "DummyTemp-linked1" |
       | hits[0]._source.asset.linkedDevices        | []                    |

--- a/features/Device/Controller/UnlinkAsset.feature
+++ b/features/Device/Controller/UnlinkAsset.feature
@@ -16,3 +16,23 @@ Feature: UnlinkAsset
       | _id | "DummyTemp-unlinked1" |
     Then I should receive an error matching:
       | message | "Device \"DummyTemp-unlinked1\" is not linked to an asset." |
+
+  Scenario: Unlink asset when deleting device
+    When I execute the action "device-manager/devices":"delete" with args:
+      | engineId | "engine-ayse"       |
+      | _id      | "DummyTemp-linked1" |
+    Then The document "engine-ayse":"assets":"Container-linked1" content match:
+      | linkedDevices.length | 0 |
+    And I refresh the collection "engine-ayse":"assets-history"
+    Then I successfully execute the action "document":"search" with args:
+      | index      | "engine-ayse"                      |
+      | collection | "assets-history"                   |
+      | body.sort  | {"_kuzzle_info.createdAt": "desc"} |
+    And I should receive a result matching:
+      | hits.length                                | 1                     |
+      | hits[0]._source.id                         | "Container-linked1" |
+      | hits[0]._source.type                       | "asset"               |
+      | hits[0]._source.event.name                 | "unlink"              |
+      | hits[0]._source.event.unlink.deviceId      | "DummyTemp-linked1" |
+      | hits[0]._source.asset.linkedDevices        | []                    |
+

--- a/features/Engine.feature
+++ b/features/Engine.feature
@@ -3,10 +3,6 @@ Feature: Engine Controller
   @reset-engines
   Scenario: Create and delete an engine
     Given an existing index "engine-kuzzle"
-    When I successfully execute the action "collection":"list" with args:
-      | index | "engine-kuzzle" |
-    Then I should receive a result matching:
-      | collections | [{"name":"assets","type":"stored"}, {"name":"config","type":"stored"},{"name":"devices","type":"stored"},{"name":"measures","type":"stored"}] |
     When I successfully execute the action "device-manager/engine":"delete" with args:
       | index | "engine-kuzzle" |
     And I successfully execute the action "collection":"list" with args:

--- a/features/fixtures/application/testPipes.ts
+++ b/features/fixtures/application/testPipes.ts
@@ -31,22 +31,25 @@ export function registerTestPipes(app: Backend) {
       device: KDocument<DeviceContent>;
       measures: MeasureContent[];
     }) => {
-      if (device._id !== "DummyTemp-enrich_me_master") {
-        return { asset, device, measures };
-      }
+      if (device._id === "DummyTemp-enrich_me_master") {
+        for (const measure of measures) {
+          if (measure.values.temperature) {
+            if (device._source.measures.temperature) {
+              // Ensure the measure has not been integrated to the device yet
+              should(measure.measuredAt).be.greaterThan(
+                device._source.measures.temperature.measuredAt
+              );
+            }
 
-      for (const measure of measures) {
-        if (measure.values.temperature) {
-          if (device._source.measures.temperature) {
-            // Ensure the measure has not been integrated to the device yet
-            should(measure.measuredAt).be.greaterThan(
-              device._source.measures.temperature.measuredAt
-            );
+            measure.values.temperature *= 2;
           }
-
-          measure.values.temperature *= 2;
         }
       }
+
+      if (device._source.metadata.color === 'test-metadata-history-with-measure') {
+        asset._source.metadata.weight = 42042;
+      }
+
 
       return { asset, device, measures };
     }

--- a/features/fixtures/application/testPipes.ts
+++ b/features/fixtures/application/testPipes.ts
@@ -46,10 +46,11 @@ export function registerTestPipes(app: Backend) {
         }
       }
 
-      if (device._source.metadata.color === 'test-metadata-history-with-measure') {
+      if (
+        device._source.metadata.color === "test-metadata-history-with-measure"
+      ) {
         asset._source.metadata.weight = 42042;
       }
-
 
       return { asset, device, measures };
     }

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -16,6 +16,16 @@ const deviceAyseLinked1 = {
 };
 const deviceAyseLinked1Id = `${deviceAyseLinked1.model}-${deviceAyseLinked1.reference}`;
 
+const deviceAyseLinked2 = {
+  model: "DummyTempPosition",
+  reference: "linked2",
+  metadata: {},
+  measures: {},
+  engineId: "engine-ayse",
+  assetId: "Container-linked2",
+};
+const deviceAyseLinked2Id = `${deviceAyseLinked2.model}-${deviceAyseLinked2.reference}`;
+
 const deviceAyseUnlinked1 = {
   model: "DummyTemp",
   reference: "unlinked1",
@@ -36,7 +46,7 @@ const deviceAyseUnlinked2 = {
 };
 const deviceAyseUnlinked2Id = `${deviceAyseUnlinked2.model}-${deviceAyseUnlinked2.reference}`;
 
-const assetAyseLinked = {
+const assetAyseLinked1 = {
   model: "Container",
   reference: "linked1",
   metadata: {
@@ -50,7 +60,26 @@ const assetAyseLinked = {
     },
   ],
 };
-const assetAyseLinkedId = `${assetAyseLinked.model}-${assetAyseLinked.reference}`;
+const assetAyseLinked1Id = `${assetAyseLinked1.model}-${assetAyseLinked1.reference}`;
+
+const assetAyseLinked2 = {
+  model: "Container",
+  reference: "linked2",
+  metadata: {
+    weight: 42,
+    height: 21,
+  },
+  linkedDevices: [
+    {
+      measureNames: [
+        { asset: "temperatureExt", device: "temperature" },
+        { asset: "position", device: "position" },
+      ],
+      _id: "DummyTempPosition-linked2",
+    },
+  ],
+};
+const assetAyseLinked2Id = `${assetAyseLinked2.model}-${assetAyseLinked2.reference}`;
 
 const assetAyseUnlinked = {
   model: "Container",
@@ -68,6 +97,8 @@ module.exports = {
     devices: [
       { index: { _id: deviceAyseLinked1Id } },
       deviceAyseLinked1,
+      { index: { _id: deviceAyseLinked2Id } },
+      deviceAyseLinked2,
       { index: { _id: deviceDetached1Id } },
       deviceDetached1,
       { index: { _id: deviceAyseUnlinked1Id } },
@@ -82,14 +113,18 @@ module.exports = {
     devices: [
       { index: { _id: deviceAyseLinked1Id } },
       deviceAyseLinked1,
+      { index: { _id: deviceAyseLinked2Id } },
+      deviceAyseLinked2,
       { index: { _id: deviceAyseUnlinked1Id } },
       deviceAyseUnlinked1,
       { index: { _id: deviceAyseUnlinked2Id } },
       deviceAyseUnlinked2,
     ],
     assets: [
-      { index: { _id: assetAyseLinkedId } },
-      assetAyseLinked,
+      { index: { _id: assetAyseLinked1Id } },
+      assetAyseLinked1,
+      { index: { _id: assetAyseLinked2Id } },
+      assetAyseLinked2,
       { index: { _id: assetAyseUnlinkedId } },
       assetAyseUnlinked,
     ],

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -84,10 +84,12 @@ Before({ timeout: 30 * 1000 }, async function () {
     truncateCollection(this.sdk, "device-manager", "payloads"),
 
     truncateCollection(this.sdk, "engine-kuzzle", "assets"),
+    truncateCollection(this.sdk, "engine-kuzzle", "assets-history"),
     truncateCollection(this.sdk, "engine-kuzzle", "measures"),
     truncateCollection(this.sdk, "engine-kuzzle", "devices"),
 
     truncateCollection(this.sdk, "engine-ayse", "assets"),
+    truncateCollection(this.sdk, "engine-ayse", "assets-history"),
     truncateCollection(this.sdk, "engine-ayse", "measures"),
     truncateCollection(this.sdk, "engine-ayse", "devices"),
 

--- a/lib/core/DeviceManagerEngine.ts
+++ b/lib/core/DeviceManagerEngine.ts
@@ -100,10 +100,10 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
     return {
       collections: [
-        "assets",
+        InternalCollection.ASSETS,
         this.engineConfigManager.collection,
-        "devices",
-        "measures",
+        InternalCollection.DEVICES,
+        InternalCollection.MEASURES,
       ],
     };
   }
@@ -127,13 +127,27 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   async onDelete(index: string) {
     const promises = [];
 
-    promises.push(this.sdk.collection.delete(index, "assets"));
-    promises.push(this.sdk.collection.delete(index, "devices"));
-    promises.push(this.sdk.collection.delete(index, "measures"));
+    promises.push(this.sdk.collection.delete(index, InternalCollection.ASSETS));
+    promises.push(
+      this.sdk.collection.delete(index, InternalCollection.ASSETS_HISTORY)
+    );
+    promises.push(
+      this.sdk.collection.delete(index, InternalCollection.DEVICES)
+    );
+    promises.push(
+      this.sdk.collection.delete(index, InternalCollection.MEASURES)
+    );
 
     await Promise.all(promises);
 
-    return { collections: ["assets", "devices", "measures"] };
+    return {
+      collections: [
+        InternalCollection.ASSETS,
+        InternalCollection.ASSETS_HISTORY,
+        InternalCollection.DEVICES,
+        InternalCollection.MEASURES,
+      ],
+    };
   }
 
   async createAssetsCollection(engineId: string, engineGroup: string) {

--- a/lib/core/DeviceManagerEngine.ts
+++ b/lib/core/DeviceManagerEngine.ts
@@ -151,17 +151,22 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
     return InternalCollection.ASSETS;
   }
 
-  async createAssetsHistoryCollection (engineId: string, engineGroup: string) {
-    const assetsMappings = await this.getDigitalTwinMappings<AssetModelContent>("asset", engineGroup);
+  async createAssetsHistoryCollection(engineId: string, engineGroup: string) {
+    const assetsCollectionMappings =
+      await this.getDigitalTwinMappings<AssetModelContent>(
+        "asset",
+        engineGroup
+      );
 
     const mappings = JSON.parse(JSON.stringify(assetsHistoryMappings));
 
-    _.merge(mappings.properties.asset, assetsMappings);
+    _.merge(mappings.properties.asset, assetsCollectionMappings);
 
     await this.sdk.collection.create(
       engineId,
       InternalCollection.ASSETS_HISTORY,
-      mappings);
+      mappings
+    );
 
     return InternalCollection.ASSETS_HISTORY;
   }

--- a/lib/core/InternalCollection.ts
+++ b/lib/core/InternalCollection.ts
@@ -1,5 +1,6 @@
 export enum InternalCollection {
   ASSETS = "assets",
+  ASSETS_HISTORY = "assets-history",
   DEVICES = "devices",
   MEASURES = "measures",
   MODELS = "models",

--- a/lib/core/registers/ModelsRegister.ts
+++ b/lib/core/registers/ModelsRegister.ts
@@ -4,9 +4,9 @@ import {
   PluginContext,
   PluginImplementationError,
 } from "kuzzle";
-import { NamedMeasures } from "lib/modules/decoder";
-import { MeasureDefinition } from "../../modules/measure";
 
+import { NamedMeasures } from "../../modules/decoder";
+import { MeasureDefinition } from "../../modules/measure";
 import { ModelSerializer } from "../../modules/model";
 import {
   AssetModelContent,
@@ -14,6 +14,7 @@ import {
   ModelContent,
   DeviceModelContent,
 } from "../../modules/model";
+
 import { DeviceManagerConfiguration } from "../DeviceManagerConfiguration";
 import { DeviceManagerPlugin } from "../DeviceManagerPlugin";
 import { InternalCollection } from "../InternalCollection";

--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -1,9 +1,20 @@
 import { KDocument, PluginContext } from "kuzzle";
 
-import { DeviceManagerConfiguration, DeviceManagerPlugin, InternalCollection } from "../../core";
+import {
+  DeviceManagerConfiguration,
+  DeviceManagerPlugin,
+  InternalCollection,
+} from "../../core";
 import { onAsk } from "../shared";
 
-import { AssetHistoryContent, AssetHistoryEvent, AssetHistoryEventLink, AssetHistoryEventMeasure, AssetHistoryEventMetadata, AssetHistoryEventUnlink } from "./types/AssetHistoryContent";
+import {
+  AssetHistoryContent,
+  AssetHistoryEvent,
+  AssetHistoryEventLink,
+  AssetHistoryEventMeasure,
+  AssetHistoryEventMetadata,
+  AssetHistoryEventUnlink,
+} from "./types/AssetHistoryContent";
 import { AssetContent } from "./types/AssetContent";
 import { AskAssetHistoryAdd } from "./types/AssetEvents";
 
@@ -21,106 +32,106 @@ export class AssetHistoryService {
 
     onAsk<AskAssetHistoryAdd<AssetHistoryEvent>>(
       "ask:device-manager:asset:history:add",
-      async ({ engineId, event, asset }) => this.add(engineId, event, asset));
+      async ({ engineId, event, asset }) => this.add(engineId, event, asset)
+    );
   }
 
-  async add<TAssetHistoryEvent extends AssetHistoryEvent> (
+  async add<TAssetHistoryEvent extends AssetHistoryEvent>(
     engineId: string,
     event: TAssetHistoryEvent,
-    asset: KDocument<AssetContent>,
+    asset: KDocument<AssetContent>
   ) {
     await this.sdk.document.create<AssetHistoryContent<TAssetHistoryEvent>>(
       engineId,
       InternalCollection.ASSETS_HISTORY,
       {
-        type: "asset",
+        asset: asset._source,
         event,
         id: asset._id,
-        asset: asset._source
-      });
-  }
-
-  async eventMeasure (
-    engineId: string,
-    asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventMeasure["measure"],
-  ) {
-    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventMeasure>>(
-      engineId,
-      InternalCollection.ASSETS_HISTORY,
-      {
         type: "asset",
-        event: {
-          name: 'measure',
-          measure: {
-            names: eventContent.names,
-          }
-        },
-        id: asset._id,
-        asset: asset._source
-      });
+      }
+    );
   }
 
-  async eventMetadata (
+  async eventMeasure(
     engineId: string,
     asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventMetadata["metadata"],
+    eventContent: AssetHistoryEventMeasure["measure"]
   ) {
-    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventMetadata>>(
-      engineId,
-      InternalCollection.ASSETS_HISTORY,
-      {
-        type: "asset",
-        event: {
-          name: 'metadata',
-          metadata: {
-            names: eventContent.names,
-          }
+    await this.sdk.document.create<
+      AssetHistoryContent<AssetHistoryEventMeasure>
+    >(engineId, InternalCollection.ASSETS_HISTORY, {
+      asset: asset._source,
+      event: {
+        measure: {
+          names: eventContent.names,
         },
-        id: asset._id,
-        asset: asset._source
-      });
+        name: "measure",
+      },
+      id: asset._id,
+      type: "asset",
+    });
   }
 
-  async eventLink (
+  async eventMetadata(
     engineId: string,
     asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventLink["link"],
+    eventContent: AssetHistoryEventMetadata["metadata"]
+  ) {
+    await this.sdk.document.create<
+      AssetHistoryContent<AssetHistoryEventMetadata>
+    >(engineId, InternalCollection.ASSETS_HISTORY, {
+      asset: asset._source,
+      event: {
+        metadata: {
+          names: eventContent.names,
+        },
+        name: "metadata",
+      },
+      id: asset._id,
+      type: "asset",
+    });
+  }
+
+  async eventLink(
+    engineId: string,
+    asset: KDocument<AssetContent>,
+    eventContent: AssetHistoryEventLink["link"]
   ) {
     await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventLink>>(
       engineId,
       InternalCollection.ASSETS_HISTORY,
       {
-        type: "asset",
+        asset: asset._source,
         event: {
-          name: 'link',
           link: {
             deviceId: eventContent.deviceId,
-          }
+          },
+          name: "link",
         },
         id: asset._id,
-        asset: asset._source
-      });
+        type: "asset",
+      }
+    );
   }
 
-  async eventUnlink (
+  async eventUnlink(
     engineId: string,
     asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventUnlink["unlink"],
+    eventContent: AssetHistoryEventUnlink["unlink"]
   ) {
-    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventUnlink>>(
-      engineId,
-      InternalCollection.ASSETS_HISTORY,
-      {
-        type: "asset",
-        event: {
-          name: 'unlink',
-          unlink: {
-            deviceId: eventContent.deviceId,
-          }
+    await this.sdk.document.create<
+      AssetHistoryContent<AssetHistoryEventUnlink>
+    >(engineId, InternalCollection.ASSETS_HISTORY, {
+      asset: asset._source,
+      event: {
+        name: "unlink",
+        unlink: {
+          deviceId: eventContent.deviceId,
         },
-        id: asset._id,
-        asset: asset._source
-      });
+      },
+      id: asset._id,
+      type: "asset",
+    });
   }
 }

--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -3,7 +3,7 @@ import { KDocument, PluginContext } from "kuzzle";
 import { DeviceManagerConfiguration, DeviceManagerPlugin, InternalCollection } from "../../core";
 import { onAsk } from "../shared";
 
-import { AssetHistoryContent } from "./types/AssetHistoryContent";
+import { AssetHistoryContent, AssetHistoryEvent, AssetHistoryEventLink, AssetHistoryEventMeasure, AssetHistoryEventMetadata, AssetHistoryEventUnlink } from "./types/AssetHistoryContent";
 import { AssetContent } from "./types/AssetContent";
 import { AskAssetHistoryAdd } from "./types/AssetEvents";
 
@@ -19,22 +19,106 @@ export class AssetHistoryService {
     this.context = plugin.context;
     this.config = plugin.config;
 
-    onAsk<AskAssetHistoryAdd>(
+    onAsk<AskAssetHistoryAdd<AssetHistoryEvent>>(
       "ask:device-manager:asset:history:add",
-      async ({ engineId, events, asset }) => this.add(engineId, events, asset));
+      async ({ engineId, event, asset }) => this.add(engineId, event, asset));
   }
 
-  async add (
+  async add<TAssetHistoryEvent extends AssetHistoryEvent> (
     engineId: string,
-    events: AssetHistoryContent["events"],
-    asset: KDocument<AssetContent>
+    event: TAssetHistoryEvent,
+    asset: KDocument<AssetContent>,
   ) {
-    await this.sdk.document.create<AssetHistoryContent>(
+    await this.sdk.document.create<AssetHistoryContent<TAssetHistoryEvent>>(
       engineId,
       InternalCollection.ASSETS_HISTORY,
       {
         type: "asset",
-        events,
+        event,
+        id: asset._id,
+        asset: asset._source
+      });
+  }
+
+  async eventMeasure (
+    engineId: string,
+    asset: KDocument<AssetContent>,
+    eventContent: AssetHistoryEventMeasure["measure"],
+  ) {
+    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventMeasure>>(
+      engineId,
+      InternalCollection.ASSETS_HISTORY,
+      {
+        type: "asset",
+        event: {
+          name: 'measure',
+          measure: {
+            names: eventContent.names,
+          }
+        },
+        id: asset._id,
+        asset: asset._source
+      });
+  }
+
+  async eventMetadata (
+    engineId: string,
+    asset: KDocument<AssetContent>,
+    eventContent: AssetHistoryEventMetadata["metadata"],
+  ) {
+    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventMetadata>>(
+      engineId,
+      InternalCollection.ASSETS_HISTORY,
+      {
+        type: "asset",
+        event: {
+          name: 'metadata',
+          metadata: {
+            names: eventContent.names,
+          }
+        },
+        id: asset._id,
+        asset: asset._source
+      });
+  }
+
+  async eventLink (
+    engineId: string,
+    asset: KDocument<AssetContent>,
+    eventContent: AssetHistoryEventLink["link"],
+  ) {
+    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventLink>>(
+      engineId,
+      InternalCollection.ASSETS_HISTORY,
+      {
+        type: "asset",
+        event: {
+          name: 'link',
+          link: {
+            deviceId: eventContent.deviceId,
+          }
+        },
+        id: asset._id,
+        asset: asset._source
+      });
+  }
+
+  async eventUnlink (
+    engineId: string,
+    asset: KDocument<AssetContent>,
+    eventContent: AssetHistoryEventUnlink["unlink"],
+  ) {
+    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventUnlink>>(
+      engineId,
+      InternalCollection.ASSETS_HISTORY,
+      {
+        type: "asset",
+        event: {
+          name: 'unlink',
+          unlink: {
+            deviceId: eventContent.deviceId,
+          }
+        },
         id: asset._id,
         asset: asset._source
       });

--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -44,7 +44,6 @@ export class AssetHistoryService {
         asset: asset._source,
         event,
         id: asset._id,
-        type: "asset",
       }
     );
   }

--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -1,0 +1,42 @@
+import { KDocument, PluginContext } from "kuzzle";
+
+import { DeviceManagerConfiguration, DeviceManagerPlugin, InternalCollection } from "../../core";
+import { onAsk } from "../shared";
+
+import { AssetHistoryContent } from "./types/AssetHistoryContent";
+import { AssetContent } from "./types/AssetContent";
+import { AskAssetHistoryAdd } from "./types/AssetEvents";
+
+export class AssetHistoryService {
+  private context: PluginContext;
+  private config: DeviceManagerConfiguration;
+
+  private get sdk() {
+    return this.context.accessors.sdk;
+  }
+
+  constructor(plugin: DeviceManagerPlugin) {
+    this.context = plugin.context;
+    this.config = plugin.config;
+
+    onAsk<AskAssetHistoryAdd>(
+      "ask:device-manager:asset:history:add",
+      async ({ engineId, events, asset }) => this.add(engineId, events, asset));
+  }
+
+  async add (
+    engineId: string,
+    events: AssetHistoryContent["events"],
+    asset: KDocument<AssetContent>
+  ) {
+    await this.sdk.document.create<AssetHistoryContent>(
+      engineId,
+      InternalCollection.ASSETS_HISTORY,
+      {
+        type: "asset",
+        events,
+        id: asset._id,
+        asset: asset._source
+      });
+  }
+}

--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -10,10 +10,6 @@ import { onAsk } from "../shared";
 import {
   AssetHistoryContent,
   AssetHistoryEvent,
-  AssetHistoryEventLink,
-  AssetHistoryEventMeasure,
-  AssetHistoryEventMetadata,
-  AssetHistoryEventUnlink,
 } from "./types/AssetHistoryContent";
 import { AssetContent } from "./types/AssetContent";
 import { AskAssetHistoryAdd } from "./types/AssetEvents";
@@ -51,87 +47,5 @@ export class AssetHistoryService {
         type: "asset",
       }
     );
-  }
-
-  async eventMeasure(
-    engineId: string,
-    asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventMeasure["measure"]
-  ) {
-    await this.sdk.document.create<
-      AssetHistoryContent<AssetHistoryEventMeasure>
-    >(engineId, InternalCollection.ASSETS_HISTORY, {
-      asset: asset._source,
-      event: {
-        measure: {
-          names: eventContent.names,
-        },
-        name: "measure",
-      },
-      id: asset._id,
-      type: "asset",
-    });
-  }
-
-  async eventMetadata(
-    engineId: string,
-    asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventMetadata["metadata"]
-  ) {
-    await this.sdk.document.create<
-      AssetHistoryContent<AssetHistoryEventMetadata>
-    >(engineId, InternalCollection.ASSETS_HISTORY, {
-      asset: asset._source,
-      event: {
-        metadata: {
-          names: eventContent.names,
-        },
-        name: "metadata",
-      },
-      id: asset._id,
-      type: "asset",
-    });
-  }
-
-  async eventLink(
-    engineId: string,
-    asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventLink["link"]
-  ) {
-    await this.sdk.document.create<AssetHistoryContent<AssetHistoryEventLink>>(
-      engineId,
-      InternalCollection.ASSETS_HISTORY,
-      {
-        asset: asset._source,
-        event: {
-          link: {
-            deviceId: eventContent.deviceId,
-          },
-          name: "link",
-        },
-        id: asset._id,
-        type: "asset",
-      }
-    );
-  }
-
-  async eventUnlink(
-    engineId: string,
-    asset: KDocument<AssetContent>,
-    eventContent: AssetHistoryEventUnlink["unlink"]
-  ) {
-    await this.sdk.document.create<
-      AssetHistoryContent<AssetHistoryEventUnlink>
-    >(engineId, InternalCollection.ASSETS_HISTORY, {
-      asset: asset._source,
-      event: {
-        name: "unlink",
-        unlink: {
-          deviceId: eventContent.deviceId,
-        },
-      },
-      id: asset._id,
-      type: "asset",
-    });
   }
 }

--- a/lib/modules/asset/AssetModule.ts
+++ b/lib/modules/asset/AssetModule.ts
@@ -1,5 +1,6 @@
 import { Module } from "../shared/Module";
 
+import { AssetHistoryService } from "./AssetHistoryService";
 import { AssetsController } from "./AssetsController";
 import { AssetService } from "./AssetService";
 import { RoleAssetsAdmin } from "./roles/RoleAssetsAdmin";
@@ -7,10 +8,12 @@ import { RoleAssetsReader } from "./roles/RoleAssetsReader";
 
 export class AssetModule extends Module {
   private assetService: AssetService;
+  private assetHistoryService: AssetHistoryService;
   private assetController: AssetsController;
 
   public async init(): Promise<void> {
-    this.assetService = new AssetService(this.plugin);
+    this.assetHistoryService = new AssetHistoryService(this.plugin);
+    this.assetService = new AssetService(this.plugin, this.assetHistoryService);
     this.assetController = new AssetsController(this.assetService);
 
     this.plugin.api["device-manager/assets"] = this.assetController.definition;

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -41,7 +41,10 @@ export class AssetService {
     return global.app;
   }
 
-  constructor(plugin: DeviceManagerPlugin, assetHistoryService: AssetHistoryService) {
+  constructor(
+    plugin: DeviceManagerPlugin,
+    assetHistoryService: AssetHistoryService
+  ) {
     this.context = plugin.context;
     this.config = plugin.config;
     this.assetHistoryService = assetHistoryService;
@@ -139,12 +142,13 @@ export class AssetService {
       await this.assetHistoryService.add<AssetHistoryEventMetadata>(
         engineId,
         {
-          name: 'metadata',
           metadata: {
-            names: Object.keys(updatedPayload.metadata)
-          }
+            names: Object.keys(updatedPayload.metadata),
+          },
+          name: "metadata",
         },
-        updatedAsset);
+        updatedAsset
+      );
 
       await this.app.trigger<EventAssetUpdateAfter>(
         "device-manager:asset:update:after",
@@ -209,12 +213,13 @@ export class AssetService {
       await this.assetHistoryService.add<AssetHistoryEventMetadata>(
         engineId,
         {
-          name: 'metadata',
           metadata: {
-            names: Object.keys(asset._source.metadata)
-          }
+            names: Object.keys(asset._source.metadata),
+          },
+          name: "metadata",
         },
-        asset);
+        asset
+      );
 
       return asset;
     });

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -78,6 +78,7 @@ export class AssetsController {
     const refresh = request.getRefresh();
 
     const updatedAsset = await this.assetService.update(
+      request.getUser(),
       engineId,
       assetId,
       metadata,
@@ -97,6 +98,7 @@ export class AssetsController {
     const refresh = request.getRefresh();
 
     const asset = await this.assetService.create(
+      request.getUser(),
       engineId,
       model,
       reference,
@@ -115,7 +117,7 @@ export class AssetsController {
     const refresh = request.getRefresh();
     const strict = request.getBoolean("strict");
 
-    await this.assetService.delete(engineId, assetId, {
+    await this.assetService.delete(request.getUser(), engineId, assetId, {
       refresh,
       strict,
     });

--- a/lib/modules/asset/collections/assetsHistoryMappings.ts
+++ b/lib/modules/asset/collections/assetsHistoryMappings.ts
@@ -4,7 +4,7 @@ export const assetsHistoryMappings = {
     type: { type: "keyword" },
     event: {
       properties: {
-        names: { type: "keyword" },
+        name: { type: "keyword" },
         measure: {
           properties: {
             names: { type: "keyword" },

--- a/lib/modules/asset/collections/assetsHistoryMappings.ts
+++ b/lib/modules/asset/collections/assetsHistoryMappings.ts
@@ -1,7 +1,6 @@
 export const assetsHistoryMappings = {
   dynamic: "strict",
   properties: {
-    type: { type: "keyword" },
     event: {
       properties: {
         name: { type: "keyword" },

--- a/lib/modules/asset/collections/assetsHistoryMappings.ts
+++ b/lib/modules/asset/collections/assetsHistoryMappings.ts
@@ -1,0 +1,22 @@
+export const assetsHistoryMappings = {
+  dynamic: "strict",
+  properties: {
+    type: { type: "keyword" },
+    events: { type: "keyword" },
+    id: { type: "keyword" },
+    asset: {
+      // populated with generated assets mappings
+
+      properties: {
+        _kuzzle_info: {
+          properties: {
+            author: { type: "keyword" },
+            createdAt: { type: "date" },
+            updatedAt: { type: "date" },
+            updater: { type: "keyword" },
+          }
+        }
+      }
+     }
+  }
+};

--- a/lib/modules/asset/collections/assetsHistoryMappings.ts
+++ b/lib/modules/asset/collections/assetsHistoryMappings.ts
@@ -2,7 +2,31 @@ export const assetsHistoryMappings = {
   dynamic: "strict",
   properties: {
     type: { type: "keyword" },
-    events: { type: "keyword" },
+    event: {
+      properties: {
+        names: { type: "keyword" },
+        measure: {
+          properties: {
+            names: { type: 'keyword' },
+          }
+        },
+        metadata: {
+          properties: {
+            names: { type: 'keyword' },
+          }
+        },
+        link: {
+          properties: {
+            deviceId: { type: 'keyword' },
+          }
+        },
+        unlink: {
+          properties: {
+            deviceId: { type: 'keyword' },
+          }
+        },
+      }
+    },
     id: { type: "keyword" },
     asset: {
       // populated with generated assets mappings

--- a/lib/modules/asset/collections/assetsHistoryMappings.ts
+++ b/lib/modules/asset/collections/assetsHistoryMappings.ts
@@ -7,25 +7,25 @@ export const assetsHistoryMappings = {
         names: { type: "keyword" },
         measure: {
           properties: {
-            names: { type: 'keyword' },
-          }
+            names: { type: "keyword" },
+          },
         },
         metadata: {
           properties: {
-            names: { type: 'keyword' },
-          }
+            names: { type: "keyword" },
+          },
         },
         link: {
           properties: {
-            deviceId: { type: 'keyword' },
-          }
+            deviceId: { type: "keyword" },
+          },
         },
         unlink: {
           properties: {
-            deviceId: { type: 'keyword' },
-          }
+            deviceId: { type: "keyword" },
+          },
         },
-      }
+      },
     },
     id: { type: "keyword" },
     asset: {
@@ -38,9 +38,9 @@ export const assetsHistoryMappings = {
             createdAt: { type: "date" },
             updatedAt: { type: "date" },
             updater: { type: "keyword" },
-          }
-        }
-      }
-     }
-  }
+          },
+        },
+      },
+    },
+  },
 };

--- a/lib/modules/asset/exports.ts
+++ b/lib/modules/asset/exports.ts
@@ -1,4 +1,5 @@
 export * from "./types/AssetContent";
+export * from "./types/AssetHistoryContent";
 export * from "./types/AssetEvents";
 export * from "./types/AssetApi";
 export * from "./roles/RoleAssetsAdmin";

--- a/lib/modules/asset/index.ts
+++ b/lib/modules/asset/index.ts
@@ -1,5 +1,7 @@
 export * from "./collections/assetsMappings";
+export * from "./collections/assetsHistoryMappings";
 export * from "./types/AssetContent";
+export * from "./types/AssetHistoryContent";
 export * from "./types/AssetEvents";
 export * from "./types/AssetApi";
 export * from "./model/AssetSerializer";

--- a/lib/modules/asset/model/AssetSerializer.ts
+++ b/lib/modules/asset/model/AssetSerializer.ts
@@ -25,10 +25,6 @@ export class AssetSerializer {
     asset: KDocument<AssetContent>,
     measureName: string
   ): AssetMeasureContext {
-    if (!asset) {
-      return undefined;
-    }
-
     return {
       _id: asset._id,
       measureName,

--- a/lib/modules/asset/types/AssetEvents.ts
+++ b/lib/modules/asset/types/AssetEvents.ts
@@ -3,6 +3,7 @@ import { KDocument } from "kuzzle";
 import { Metadata } from "../../../modules/shared";
 
 import { AssetContent } from "./AssetContent";
+import { AssetHistoryContent } from "./AssetHistoryContent";
 
 export type EventAssetUpdateBefore = {
   name: "device-manager:asset:update:before";
@@ -14,4 +15,19 @@ export type EventAssetUpdateAfter = {
   name: "device-manager:asset:update:after";
 
   args: [{ asset: KDocument<AssetContent>; metadata: Metadata }];
+};
+
+/**
+ * @internal
+ */
+ export type AskAssetHistoryAdd = {
+  name: "ask:device-manager:asset:history:add";
+
+  payload: {
+    engineId: string;
+    events: AssetHistoryContent["events"];
+    asset: KDocument<AssetContent>;
+  };
+
+  result: void;
 };

--- a/lib/modules/asset/types/AssetEvents.ts
+++ b/lib/modules/asset/types/AssetEvents.ts
@@ -3,7 +3,7 @@ import { KDocument } from "kuzzle";
 import { Metadata } from "../../../modules/shared";
 
 import { AssetContent } from "./AssetContent";
-import { AssetHistoryContent } from "./AssetHistoryContent";
+import { AssetHistoryEvent } from "./AssetHistoryContent";
 
 export type EventAssetUpdateBefore = {
   name: "device-manager:asset:update:before";
@@ -20,12 +20,12 @@ export type EventAssetUpdateAfter = {
 /**
  * @internal
  */
- export type AskAssetHistoryAdd = {
+ export type AskAssetHistoryAdd<TAssetHistoryEvent extends AssetHistoryEvent> = {
   name: "ask:device-manager:asset:history:add";
 
   payload: {
     engineId: string;
-    events: AssetHistoryContent["events"];
+    event: TAssetHistoryEvent;
     asset: KDocument<AssetContent>;
   };
 

--- a/lib/modules/asset/types/AssetEvents.ts
+++ b/lib/modules/asset/types/AssetEvents.ts
@@ -20,7 +20,7 @@ export type EventAssetUpdateAfter = {
 /**
  * @internal
  */
- export type AskAssetHistoryAdd<TAssetHistoryEvent extends AssetHistoryEvent> = {
+export type AskAssetHistoryAdd<TAssetHistoryEvent extends AssetHistoryEvent> = {
   name: "ask:device-manager:asset:history:add";
 
   payload: {

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -1,0 +1,35 @@
+import { JSONObject, KDocumentContent } from "kuzzle";
+
+import { Metadata } from "../../shared";
+import { AssetContent } from "./AssetContent";
+
+/**
+ * Asset History document content
+ */
+export interface AssetHistoryContent<
+  TMeasures extends JSONObject = any,
+  TMetadata extends Metadata = any
+> extends KDocumentContent {
+  /**
+   * Type of the history document
+   *
+   * (reserved for futur use)
+   */
+  type: string;
+
+  /**
+   * ID of the historized asset
+   */
+  id: string;
+
+  /**
+   * Name of the changes who caused the historization
+   *
+   *  - `measure` a new measure has been received
+   *  - `metadata` the asset metadata has been updated
+   *  - `link` a device has been linked or unlinked to the asset
+   */
+  events: Array<'measure' | 'metadata' | 'link'>;
+
+  asset: AssetContent<TMeasures, TMetadata>;
+}

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -5,37 +5,38 @@ import { Metadata } from "../../shared";
 import { AssetContent } from "./AssetContent";
 
 export type AssetHistoryEventMeasure = {
-  name: 'measure';
+  name: "measure";
   measure: {
     names: string[];
   };
-}
+};
 
 export type AssetHistoryEventMetadata = {
-  name: 'metadata';
+  name: "metadata";
   metadata: {
     names: string[];
   };
-}
+};
 
 export type AssetHistoryEventLink = {
-  name: 'link';
+  name: "link";
   link: {
     deviceId: string;
   };
-}
+};
 
 export type AssetHistoryEventUnlink = {
-  name: 'unlink';
+  name: "unlink";
   unlink: {
     deviceId: string;
   };
-}
+};
 
-export type AssetHistoryEvent = AssetHistoryEventMeasure |
-  AssetHistoryEventMetadata |
-  AssetHistoryEventLink |
-  AssetHistoryEventUnlink;
+export type AssetHistoryEvent =
+  | AssetHistoryEventMeasure
+  | AssetHistoryEventMetadata
+  | AssetHistoryEventLink
+  | AssetHistoryEventUnlink;
 
 /**
  * Asset History document content

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -47,13 +47,6 @@ export interface AssetHistoryContent<
   TMetadata extends Metadata = any
 > extends KDocumentContent {
   /**
-   * Type of the history document.
-   *
-   * (reserved for futur use)
-   */
-  type: string;
-
-  /**
    * Name of the event who caused the historization
    *
    *  - `measure` a new measure has been received

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -1,21 +1,66 @@
 import { JSONObject, KDocumentContent } from "kuzzle";
 
 import { Metadata } from "../../shared";
+
 import { AssetContent } from "./AssetContent";
+
+export type AssetHistoryEventMeasure = {
+  name: 'measure';
+  measure: {
+    names: string[];
+  };
+}
+
+export type AssetHistoryEventMetadata = {
+  name: 'metadata';
+  metadata: {
+    names: string[];
+  };
+}
+
+export type AssetHistoryEventLink = {
+  name: 'link';
+  link: {
+    deviceId: string;
+  };
+}
+
+export type AssetHistoryEventUnlink = {
+  name: 'unlink';
+  unlink: {
+    deviceId: string;
+  };
+}
+
+export type AssetHistoryEvent = AssetHistoryEventMeasure |
+  AssetHistoryEventMetadata |
+  AssetHistoryEventLink |
+  AssetHistoryEventUnlink;
 
 /**
  * Asset History document content
  */
 export interface AssetHistoryContent<
+  TAssetHistoryEvent extends AssetHistoryEvent = any,
   TMeasures extends JSONObject = any,
   TMetadata extends Metadata = any
 > extends KDocumentContent {
   /**
-   * Type of the history document
+   * Type of the history document.
    *
    * (reserved for futur use)
    */
   type: string;
+
+  /**
+   * Name of the event who caused the historization
+   *
+   *  - `measure` a new measure has been received
+   *  - `metadata` the asset metadata has been updated
+   *  - `link` a device has been linked or unlinked to the asset
+   *  - `unlink` a device has been unlinked from the asset
+   */
+  event: TAssetHistoryEvent;
 
   /**
    * ID of the historized asset
@@ -23,13 +68,7 @@ export interface AssetHistoryContent<
   id: string;
 
   /**
-   * Name of the changes who caused the historization
-   *
-   *  - `measure` a new measure has been received
-   *  - `metadata` the asset metadata has been updated
-   *  - `link` a device has been linked or unlinked to the asset
+   * Asset content after the event
    */
-  events: Array<'measure' | 'metadata' | 'link'>;
-
   asset: AssetContent<TMeasures, TMetadata>;
 }

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -9,12 +9,10 @@ import {
   SearchResult,
 } from "kuzzle";
 
-import { AskAssetHistoryAdd, AssetContent } from "./../asset";
+import { AskAssetHistoryAdd, AssetContent, AssetHistoryEventLink, AssetHistoryEventUnlink } from "./../asset";
 import { InternalCollection, DeviceManagerConfiguration } from "../../core";
-import { lock } from "../shared/utils/lock";
-import { Metadata } from "../shared";
-import { ask } from "../shared/utils/ask";
-import { AskModelDeviceGet } from "../model/types/ModelEvents";
+import { Metadata, lock, ask } from "../shared";
+import { AskModelDeviceGet } from "../model";
 
 import { DeviceContent } from "./types/DeviceContent";
 import { DeviceSerializer } from "./model/DeviceSerializer";
@@ -428,9 +426,15 @@ export class DeviceService {
         ),
       ]);
 
-      await ask<AskAssetHistoryAdd>(
+      const event: AssetHistoryEventLink = {
+        name: "link",
+        link: {
+          deviceId: device._id
+        }
+      };
+      await ask<AskAssetHistoryAdd<AssetHistoryEventLink>>(
         "ask:device-manager:asset:history:add",
-        { engineId, events: ["link"], asset: updatedAsset });
+        { engineId, event, asset: updatedAsset });
 
       if (refresh) {
         await Promise.all([
@@ -536,9 +540,15 @@ export class DeviceService {
         ),
       ]);
 
-      await ask<AskAssetHistoryAdd>(
+      const event: AssetHistoryEventUnlink = {
+        name: "unlink",
+        unlink: {
+          deviceId
+        }
+      };
+      await ask<AskAssetHistoryAdd<AssetHistoryEventUnlink>>(
         "ask:device-manager:asset:history:add",
-        { engineId, events: ["link"], asset: updatedAsset });
+        { engineId, event, asset: updatedAsset });
 
       if (refresh) {
         await Promise.all([

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -9,7 +9,12 @@ import {
   SearchResult,
 } from "kuzzle";
 
-import { AskAssetHistoryAdd, AssetContent, AssetHistoryEventLink, AssetHistoryEventUnlink } from "./../asset";
+import {
+  AskAssetHistoryAdd,
+  AssetContent,
+  AssetHistoryEventLink,
+  AssetHistoryEventUnlink,
+} from "./../asset";
 import { InternalCollection, DeviceManagerConfiguration } from "../../core";
 import { Metadata, lock, ask } from "../shared";
 import { AskModelDeviceGet } from "../model";
@@ -427,14 +432,15 @@ export class DeviceService {
       ]);
 
       const event: AssetHistoryEventLink = {
-        name: "link",
         link: {
-          deviceId: device._id
-        }
+          deviceId: device._id,
+        },
+        name: "link",
       };
       await ask<AskAssetHistoryAdd<AssetHistoryEventLink>>(
         "ask:device-manager:asset:history:add",
-        { engineId, event, asset: updatedAsset });
+        { asset: updatedAsset, engineId, event }
+      );
 
       if (refresh) {
         await Promise.all([
@@ -543,12 +549,13 @@ export class DeviceService {
       const event: AssetHistoryEventUnlink = {
         name: "unlink",
         unlink: {
-          deviceId
-        }
+          deviceId,
+        },
       };
       await ask<AskAssetHistoryAdd<AssetHistoryEventUnlink>>(
         "ask:device-manager:asset:history:add",
-        { engineId, event, asset: updatedAsset });
+        { asset: updatedAsset, engineId, event }
+      );
 
       if (refresh) {
         await Promise.all([
@@ -556,14 +563,8 @@ export class DeviceService {
             this.config.adminIndex,
             InternalCollection.DEVICES
           ),
-          this.sdk.collection.refresh(
-            engineId,
-            InternalCollection.DEVICES
-          ),
-          this.sdk.collection.refresh(
-            engineId,
-            InternalCollection.ASSETS
-          ),
+          this.sdk.collection.refresh(engineId, InternalCollection.DEVICES),
+          this.sdk.collection.refresh(engineId, InternalCollection.ASSETS),
         ]);
       }
 

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -113,6 +113,7 @@ export class DevicesController {
     const refresh = request.getRefresh();
 
     const updatedDevice = await this.deviceService.update(
+      request.getUser(),
       engineId,
       deviceId,
       metadata,
@@ -129,7 +130,9 @@ export class DevicesController {
     const deviceId = request.getId();
     const refresh = request.getRefresh();
 
-    await this.deviceService.delete(engineId, deviceId, { refresh });
+    await this.deviceService.delete(request.getUser(), engineId, deviceId, {
+      refresh,
+    });
   }
 
   async search(request: KuzzleRequest): Promise<ApiDeviceSearchResult> {
@@ -162,10 +165,16 @@ export class DevicesController {
     const metadata = request.getBodyObject("metadata", {});
     const refresh = request.getRefresh();
 
-    const device = await this.deviceService.create(model, reference, metadata, {
-      engineId,
-      refresh,
-    });
+    const device = await this.deviceService.create(
+      request.getUser(),
+      model,
+      reference,
+      metadata,
+      {
+        engineId,
+        refresh,
+      }
+    );
 
     return DeviceSerializer.serialize(device);
   }
@@ -180,9 +189,14 @@ export class DevicesController {
     const deviceId = request.getId();
     const refresh = request.getRefresh();
 
-    await this.deviceService.attachEngine(engineId, deviceId, {
-      refresh,
-    });
+    await this.deviceService.attachEngine(
+      request.getUser(),
+      engineId,
+      deviceId,
+      {
+        refresh,
+      }
+    );
   }
 
   /**
@@ -194,7 +208,9 @@ export class DevicesController {
     const deviceId = request.getId();
     const refresh = request.getRefresh();
 
-    await this.deviceService.detachEngine(deviceId, { refresh });
+    await this.deviceService.detachEngine(request.getUser(), deviceId, {
+      refresh,
+    });
   }
 
   /**
@@ -210,6 +226,7 @@ export class DevicesController {
     const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.linkAsset(
+      request.getUser(),
       engineId,
       deviceId,
       assetId,
@@ -232,9 +249,13 @@ export class DevicesController {
     const deviceId = request.getId();
     const refresh = request.getRefresh();
 
-    const { asset, device } = await this.deviceService.unlinkAsset(deviceId, {
-      refresh,
-    });
+    const { asset, device } = await this.deviceService.unlinkAsset(
+      request.getUser(),
+      deviceId,
+      {
+        refresh,
+      }
+    );
 
     return {
       asset: AssetSerializer.serialize(asset),

--- a/lib/modules/device/types/DeviceEvents.ts
+++ b/lib/modules/device/types/DeviceEvents.ts
@@ -1,4 +1,4 @@
-import { KDocument } from "kuzzle";
+import { KDocument, User } from "kuzzle";
 
 import { Metadata } from "../../../modules/shared";
 
@@ -14,4 +14,18 @@ export type EventDeviceUpdateAfter = {
   name: "device-manager:device:update:after";
 
   args: [{ device: KDocument<DeviceContent>; metadata: Metadata }];
+};
+
+/**
+ * @internal
+ */
+export type AskDeviceUnlinkAsset = {
+  name: "ask:device-manager:device:unlink-asset";
+
+  payload: {
+    deviceId: string;
+    user: User;
+  };
+
+  result: void;
 };

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -14,7 +14,12 @@ import {
   InternalCollection,
 } from "../../core";
 import { DeviceContent } from "./../device";
-import { AskAssetHistoryAdd, AssetContent, AssetHistoryEventMeasure, AssetHistoryEventMetadata } from "../asset";
+import {
+  AskAssetHistoryAdd,
+  AssetContent,
+  AssetHistoryEventMeasure,
+  AssetHistoryEventMetadata,
+} from "../asset";
 import { DigitalTwinContent, Metadata, lock, ask } from "../shared";
 import { AssetSerializer } from "../asset";
 
@@ -93,7 +98,9 @@ export class MeasureService {
         engineId,
         device._source.assetId
       );
-      const originalAssetMetadata = JSON.parse(JSON.stringify(asset._source.metadata));
+      const originalAssetMetadata = JSON.parse(
+        JSON.stringify(asset._source.metadata)
+      );
 
       _.merge(device._source.metadata, metadata);
 
@@ -190,24 +197,30 @@ export class MeasureService {
                 asset._id,
                 asset._source
               )
-              .then(async updatedAsset => {
+              .then(async (updatedAsset) => {
                 const event: AssetHistoryEventMeasure = {
-                  name: 'measure',
                   measure: {
-                    names: afterEnrichment.measures.map(m => m.asset.measureName)
-                  }
-                }
+                    names: afterEnrichment.measures.map(
+                      (m) => m.asset.measureName
+                    ),
+                  },
+                  name: "measure",
+                };
 
-                const metadataDiff = this.compareMetadata(originalAssetMetadata, updatedAsset._source.metadata);
+                const metadataDiff = this.compareMetadata(
+                  originalAssetMetadata,
+                  updatedAsset._source.metadata
+                );
                 if (metadataDiff.length !== 0) {
                   (event as unknown as AssetHistoryEventMetadata).metadata = {
-                    names: metadataDiff
+                    names: metadataDiff,
                   };
                 }
 
                 await ask<AskAssetHistoryAdd<AssetHistoryEventMeasure>>(
                   "ask:device-manager:asset:history:add",
-                  { engineId, event, asset: updatedAsset });
+                  { asset: updatedAsset, engineId, event }
+                );
               })
               .catch((error) => {
                 throw new BadRequestError(
@@ -245,7 +258,7 @@ export class MeasureService {
     });
   }
 
-  private compareMetadata (before: JSONObject, after: JSONObject): string[] {
+  private compareMetadata(before: JSONObject, after: JSONObject): string[] {
     const names: string[] = [];
 
     for (const [key, value] of Object.entries(before)) {

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -98,9 +98,10 @@ export class MeasureService {
         engineId,
         device._source.assetId
       );
-      const originalAssetMetadata = JSON.parse(
-        JSON.stringify(asset._source.metadata)
-      );
+      const originalAssetMetadata =
+        asset === null
+          ? {}
+          : JSON.parse(JSON.stringify(asset._source.metadata));
 
       _.merge(device._source.metadata, metadata);
 

--- a/lib/modules/model/index.ts
+++ b/lib/modules/model/index.ts
@@ -2,5 +2,7 @@ export * from "./collections/modelsMappings";
 export * from "./types/ModelApi";
 export * from "./types/ModelContent";
 export * from "./types/ModelDefinition";
+export * from "./types/ModelEvents";
 export * from "./ModelModule";
 export * from "./ModelSerializer";
+

--- a/lib/modules/model/index.ts
+++ b/lib/modules/model/index.ts
@@ -5,4 +5,3 @@ export * from "./types/ModelDefinition";
 export * from "./types/ModelEvents";
 export * from "./ModelModule";
 export * from "./ModelSerializer";
-

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -1,5 +1,6 @@
 import { JSONObject, KDocumentContent } from "kuzzle";
-import { NamedMeasures } from "lib/modules/decoder";
+
+import { NamedMeasures } from "../../../modules/decoder";
 
 import { MeasureDefinition } from "../../measure";
 


### PR DESCRIPTION
## What does this PR do ?

Every change happening to an asset is now historized.

There is 4 categories of changes. After every change, a complete copy of the asset is saved into the `assets-history` collection. 

The document also contains additional informations about the change:
 - `measure`: asset receive a new measure (`event.measure.names` contains the name of the new updated measures)
 - `metadata`: metadata have been modified (`event.metadata.names` contains the name of the updated metadata)
 - `link`: a new device has been linked (`event.link.deviceId` contains the newly linked device ID)
 - `unlink`: a device has been unlinked (`event.unlink.deviceId` contains the unlinked device ID)
 
If metadata are updated during the measure ingestion pipeline, then the history document have both the `event.measure` and `event.metadata` properties.

<details><summary>Example of history document after receiving a measure</summary>

```
{
  "event": {
    "measure": {
      "names": [
        "temperatureExt"
      ]
    },
    "name": "measure"
  },
  "id": "Container-linked1",
  "asset": {
    "model": "Container",
    "reference": "linked1",
    "metadata": {
      "weight": 42042,
      "height": 11
    },
    "linkedDevices": [
      {
        "measureNames": [
          {
            "asset": "temperatureExt",
            "device": "temperature"
          }
        ],
        "_id": "DummyTemp-linked1"
      }
    ],
    "_kuzzle_info": {
      "updatedAt": 1672345639726,
      "updater": null
    },
    "measures": {
      "temperatureExt": {
        "measuredAt": 1672345639722,
        "name": "temperatureExt",
        "payloadUuids": [
          "267fe1a9-3d4f-4ad5-b4a8-383e38742b4e"
        ],
        "type": "temperature",
        "values": {
          "temperature": 42.2
        }
      }
    }
  }
}
```

</details>

### Other Changes

 - Use impersonated SDK in Assets and Devices controllers to preserve Kuzzle Metadata
