### PR TITLE
Fix Asset and Device creation from backend

### DIFF
--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -45,11 +45,11 @@ Feature: Asset Controller
     Then I should receive a "hits" array of objects matching:
       | _id            |
       | "Container-A1" |
-  # Delete
-  When I successfully execute the action "device-manager/assets":"delete" with args:
-    | engineId | "engine-kuzzle" |
-    | _id      | "Container-A1"  |
-  Then The document "engine-kuzzle":"assets":"Container-A1" does not exists
+    # Delete
+    When I successfully execute the action "device-manager/assets":"delete" with args:
+      | engineId | "engine-kuzzle" |
+      | _id      | "Container-A1"  |
+    Then The document "engine-kuzzle":"assets":"Container-A1" does not exists
 
   Scenario: Error when creating Asset from unknown model
     When I execute the action "device-manager/assets":"create" with args:
@@ -84,3 +84,10 @@ Feature: Asset Controller
       | _source.values.temperature | _source.asset._id   | _source.origin._id  | _source.asset.model |
       | 40                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
       | 41                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
+
+  Scenario: Create asset from backend side
+    When I successfully execute the action "tests":"createDigitalTwinFromBackend" with args:
+      | engineId       | "engine-kuzzle" |
+      | body.reference | "foobar"        |
+    Then The document "engine-kuzzle":"assets":"Container-foobar" exists
+    Then The document "engine-kuzzle":"devices":"DummyTemp-foobar" exists

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -4,7 +4,8 @@ import { Backend, KuzzleRequest } from "kuzzle";
 
 import { DeviceManagerPlugin } from "../../../index";
 import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
-import { registerTestPipes } from "./testPipes";
+import { registerTestPipes } from "./tests/pipes";
+import { TestsController } from "./tests/controller";
 
 const app = new Backend("kuzzle");
 
@@ -59,6 +60,8 @@ deviceManager.models.registerMeasure("acceleration", {
 registerTestPipes(app);
 
 app.plugin.use(deviceManager);
+
+app.controller.use(new TestsController(app));
 
 app.hook.register("request:onError", async (request: KuzzleRequest) => {
   app.log.error(request.error);

--- a/features/fixtures/application/tests/controller.ts
+++ b/features/fixtures/application/tests/controller.ts
@@ -1,0 +1,42 @@
+import { Backend, Controller, KuzzleRequest } from "kuzzle";
+import { ApiAssetCreateRequest, ApiAssetCreateResult } from "lib/modules/asset";
+import { ApiDeviceCreateRequest, ApiDeviceCreateResult } from "lib/modules/device";
+
+export class TestsController extends Controller {
+  constructor (app: Backend) {
+    super(app);
+
+    this.definition = {
+      actions: {
+        createDigitalTwinFromBackend: {
+          handler: this.createDigitalTwinFromBackend,
+        }
+      }
+    };
+  }
+
+  async createDigitalTwinFromBackend (request: KuzzleRequest) {
+    const engineId = request.getString('engineId');
+    const reference = request.getBodyString('reference');
+
+    await this.app.sdk.query<ApiAssetCreateRequest, ApiAssetCreateResult>({
+      controller: 'device-manager/assets',
+      action: 'create',
+      engineId,
+      body: {
+        model: 'Container',
+        reference,
+      }
+    });
+
+    await this.app.sdk.query<ApiDeviceCreateRequest, ApiDeviceCreateResult>({
+      controller: 'device-manager/devices',
+      action: 'create',
+      engineId,
+      body: {
+        model: 'DummyTemp',
+        reference
+      }
+    });
+  }
+}

--- a/features/fixtures/application/tests/controller.ts
+++ b/features/fixtures/application/tests/controller.ts
@@ -1,42 +1,45 @@
 import { Backend, Controller, KuzzleRequest } from "kuzzle";
 import { ApiAssetCreateRequest, ApiAssetCreateResult } from "lib/modules/asset";
-import { ApiDeviceCreateRequest, ApiDeviceCreateResult } from "lib/modules/device";
+import {
+  ApiDeviceCreateRequest,
+  ApiDeviceCreateResult,
+} from "lib/modules/device";
 
 export class TestsController extends Controller {
-  constructor (app: Backend) {
+  constructor(app: Backend) {
     super(app);
 
     this.definition = {
       actions: {
         createDigitalTwinFromBackend: {
           handler: this.createDigitalTwinFromBackend,
-        }
-      }
+        },
+      },
     };
   }
 
-  async createDigitalTwinFromBackend (request: KuzzleRequest) {
-    const engineId = request.getString('engineId');
-    const reference = request.getBodyString('reference');
+  async createDigitalTwinFromBackend(request: KuzzleRequest) {
+    const engineId = request.getString("engineId");
+    const reference = request.getBodyString("reference");
 
     await this.app.sdk.query<ApiAssetCreateRequest, ApiAssetCreateResult>({
-      controller: 'device-manager/assets',
-      action: 'create',
+      controller: "device-manager/assets",
+      action: "create",
       engineId,
       body: {
-        model: 'Container',
+        model: "Container",
         reference,
-      }
+      },
     });
 
     await this.app.sdk.query<ApiDeviceCreateRequest, ApiDeviceCreateResult>({
-      controller: 'device-manager/devices',
-      action: 'create',
+      controller: "device-manager/devices",
+      action: "create",
       engineId,
       body: {
-        model: 'DummyTemp',
-        reference
-      }
+        model: "DummyTemp",
+        reference,
+      },
     });
   }
 }

--- a/features/fixtures/application/tests/pipes.ts
+++ b/features/fixtures/application/tests/pipes.ts
@@ -7,7 +7,7 @@ import {
   EventMeasureProcessBefore,
   AssetContent,
   DeviceContent,
-} from "../../../index";
+} from "../../../../index";
 
 function checkEventWithDocument(app: Backend, event: string) {
   app.pipe.register(event, async (payload) => {

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -45,10 +45,10 @@ export class AssetService {
   private get impersonatedSdk() {
     return (user: User) => {
       if (user?._id) {
-        return this.sdk.as(user, { checkRights: false })
+        return this.sdk.as(user, { checkRights: false });
       }
 
-      return this.sdk
+      return this.sdk;
     };
   }
 

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -43,7 +43,13 @@ export class AssetService {
   }
 
   private get impersonatedSdk() {
-    return (user: User) => this.sdk.as(user, { checkRights: false });
+    return (user: User) => {
+      if (user?._id) {
+        return this.sdk.as(user, { checkRights: false })
+      }
+
+      return this.sdk
+    };
   }
 
   constructor(

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -42,7 +42,13 @@ export class DeviceService {
   }
 
   private get impersonatedSdk() {
-    return (user: User) => this.sdk.as(user, { checkRights: false });
+    return (user: User) => {
+      if (user?._id) {
+        return this.sdk.as(user, { checkRights: false })
+      }
+
+      return this.sdk
+    };
   }
 
   constructor(plugin: Plugin) {

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -44,10 +44,10 @@ export class DeviceService {
   private get impersonatedSdk() {
     return (user: User) => {
       if (user?._id) {
-        return this.sdk.as(user, { checkRights: false })
+        return this.sdk.as(user, { checkRights: false });
       }
 
-      return this.sdk
+      return this.sdk;
     };
   }
 


### PR DESCRIPTION
## What does this PR do ?

Every modification of a Digital Twin (Asset or Device) through associated controllers is contextualized with the user who made the request to keep a trace in Kuzzle metadata.

This allows for example to know who has modified a metadata or link a new device to an asset by consulting history documents in `assets-history` collection.

When a request is made to those controllers from the backend, there is no user since it's the EmbeddedSDK executing the request and it was causing an error.

This PR fix that, when the EmbeddedSDK is used to execute one of those action, it will use the user if the sdk was contextualized with [sdk.as](https://docs.kuzzle.io/core/2/guides/develop-on-kuzzle/embedded-sdk/#user-impersonation) method, otherwise the metadata will be set with the `null` user ID who represent the backend user.