### PR TITLE
Allow search query when retrieving asset measures

### DIFF
--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -92,4 +92,10 @@ Feature: Asset Controller
     Then I should receive a "measures" array of objects matching:
       | _source.values.temperature | _source.asset._id   | _source.origin._id  | _source.asset.model |
       | 40                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
+    When I successfully execute the action "device-manager/assets":"getMeasures" with args:
+      | engineId | "engine-ayse"       |
+      | _id      | "Container-linked1" |
+      | type     | "position"          |
+    Then I should receive a result matching:
+      | measures | [] |
 

--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -45,11 +45,11 @@ Feature: Asset Controller
     Then I should receive a "hits" array of objects matching:
       | _id            |
       | "Container-A1" |
-  # Delete
-  When I successfully execute the action "device-manager/assets":"delete" with args:
-    | engineId | "engine-kuzzle" |
-    | _id      | "Container-A1"  |
-  Then The document "engine-kuzzle":"assets":"Container-A1" does not exists
+    # Delete
+    When I successfully execute the action "device-manager/assets":"delete" with args:
+      | engineId | "engine-kuzzle" |
+      | _id      | "Container-A1"  |
+    Then The document "engine-kuzzle":"assets":"Container-A1" does not exists
 
   Scenario: Error when creating Asset from unknown model
     When I execute the action "device-manager/assets":"create" with args:
@@ -77,10 +77,19 @@ Feature: Asset Controller
       | "linked1" | 40          |
     And I refresh the collection "engine-ayse":"measures"
     When I successfully execute the action "device-manager/assets":"getMeasures" with args:
-      | engineId | "engine-ayse"       |
-      | _id      | "Container-linked1" |
-      | size     | 2                   |
+      | engineId  | "engine-ayse"                    |
+      | _id       | "Container-linked1"              |
+      | size      | 2                                |
+      | body.sort | { "values.temperature": "desc" } |
+    Then I should receive a "measures" array of objects matching:
+      | _source.values.temperature | _source.asset._id   | _source.origin._id  | _source.asset.model |
+      | 42                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
+      | 41                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
+    When I successfully execute the action "device-manager/assets":"getMeasures" with args:
+      | engineId   | "engine-ayse"                            |
+      | _id        | "Container-linked1"                      |
+      | body.query | { equals: { "values.temperature": 40 } } |
     Then I should receive a "measures" array of objects matching:
       | _source.values.temperature | _source.asset._id   | _source.origin._id  | _source.asset.model |
       | 40                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
-      | 41                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |
+

--- a/features/Asset/Controller.feature
+++ b/features/Asset/Controller.feature
@@ -81,6 +81,9 @@ Feature: Asset Controller
       | _id       | "Container-linked1"              |
       | size      | 2                                |
       | body.sort | { "values.temperature": "desc" } |
+    Then I should receive a result matching:
+      | total           | 3 |
+      | measures.length | 2 |
     Then I should receive a "measures" array of objects matching:
       | _source.values.temperature | _source.asset._id   | _source.origin._id  | _source.asset.model |
       | 42                         | "Container-linked1" | "DummyTemp-linked1" | "Container"         |

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -29,9 +29,17 @@ deviceManager.models.registerDevice("DummyTemp", {
 
 // Register an asset for the "commons" group
 
-deviceManager.models.registerAsset("commons", "Container", containerAssetDefinition);
+deviceManager.models.registerAsset(
+  "commons",
+  "Container",
+  containerAssetDefinition
+);
 
-deviceManager.models.registerAsset("commons", "Warehouse", warehouseAssetDefinition);
+deviceManager.models.registerAsset(
+  "commons",
+  "Warehouse",
+  warehouseAssetDefinition
+);
 
 deviceManager.models.registerMeasure("acceleration", {
   valuesMappings: {

--- a/features/fixtures/application/app.ts
+++ b/features/fixtures/application/app.ts
@@ -3,8 +3,11 @@ import util from "node:util";
 import { Backend, KuzzleRequest } from "kuzzle";
 
 import { DeviceManagerPlugin } from "../../../index";
+
 import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
 import { registerTestPipes } from "./testPipes";
+import { containerAssetDefinition } from "./assets/Container";
+import { warehouseAssetDefinition } from "./assets/Warehouse";
 
 const app = new Backend("kuzzle");
 
@@ -26,27 +29,9 @@ deviceManager.models.registerDevice("DummyTemp", {
 
 // Register an asset for the "commons" group
 
-deviceManager.models.registerAsset("commons", "Container", {
-  measures: [
-    { name: "temperatureExt", type: "temperature" },
-    { name: "temperatureInt", type: "temperature" },
-    { name: "position", type: "position" },
-  ],
-  metadataMappings: {
-    weight: { type: "integer" },
-    height: { type: "integer" },
-  },
-  defaultMetadata: {
-    height: 20,
-  },
-});
+deviceManager.models.registerAsset("commons", "Container", containerAssetDefinition);
 
-deviceManager.models.registerAsset("commons", "Warehouse", {
-  measures: [{ name: "position", type: "position" }],
-  metadataMappings: {
-    surface: { type: "integer" },
-  },
-});
+deviceManager.models.registerAsset("commons", "Warehouse", warehouseAssetDefinition);
 
 deviceManager.models.registerMeasure("acceleration", {
   valuesMappings: {

--- a/features/fixtures/application/assets/Container.ts
+++ b/features/fixtures/application/assets/Container.ts
@@ -3,9 +3,10 @@ import {
   AssetContent,
   TemperatureMeasurement,
   PositionMeasurement,
+  AssetModelDefinition,
 } from "../../../../index";
 
-interface ContainerMetadata extends Metadata {
+export interface ContainerMetadata extends Metadata {
   height: number;
   width: number;
 
@@ -15,15 +16,30 @@ interface ContainerMetadata extends Metadata {
   };
 }
 
-type ContainerMeasurements = {
+export type ContainerMeasurements = {
   temperatureExt: TemperatureMeasurement;
   position: PositionMeasurement;
 };
 
-interface ContainerAssetContent
+export interface ContainerAssetContent
   extends AssetContent<ContainerMeasurements, ContainerMetadata> {
   model: "Container";
 }
+
+export const containerAssetDefinition: AssetModelDefinition = {
+  measures: [
+    { name: "temperatureExt", type: "temperature" },
+    { name: "temperatureInt", type: "temperature" },
+    { name: "position", type: "position" },
+  ],
+  metadataMappings: {
+    weight: { type: "integer" },
+    height: { type: "integer" },
+  },
+  defaultMetadata: {
+    height: 20,
+  },
+};
 
 // This function is never called and only exists to make sure the types are correct
 function neverCalled() {

--- a/features/fixtures/application/assets/Warehouse.ts
+++ b/features/fixtures/application/assets/Warehouse.ts
@@ -1,0 +1,8 @@
+import { AssetModelDefinition } from "../../../../index";
+
+export const warehouseAssetDefinition: AssetModelDefinition = {
+  measures: [{ name: "position", type: "position" }],
+  metadataMappings: {
+    surface: { type: "integer" },
+  },
+};

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -74,6 +74,7 @@ export class AssetService {
       startAt,
       query,
       sort = { measuredAt: "desc" },
+      type,
     }: {
       sort?: JSONObject;
       query?: JSONObject;
@@ -81,6 +82,7 @@ export class AssetService {
       size?: number;
       startAt?: string;
       endAt?: string;
+      type?: string;
     }
   ): Promise<KDocument<MeasureContent>[]> {
     await this.get(engineId, assetId);
@@ -105,6 +107,10 @@ export class AssetService {
     const searchQuery: JSONObject = {
       and: [measuredAtRange],
     };
+
+    if (type) {
+      searchQuery.and.push({ equals: { type } });
+    }
 
     if (query) {
       searchQuery.and.push(query);

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -28,6 +28,7 @@ import {
 } from "./types/AssetEvents";
 import { AssetHistoryService } from "./AssetHistoryService";
 import { AssetHistoryEventMetadata } from "./types/AssetHistoryContent";
+import { ApiAssetGetMeasuresResult } from "./types/AssetApi";
 
 export class AssetService {
   private context: PluginContext;
@@ -84,7 +85,7 @@ export class AssetService {
       endAt?: string;
       type?: string;
     }
-  ): Promise<KDocument<MeasureContent>[]> {
+  ): Promise<ApiAssetGetMeasuresResult> {
     await this.get(engineId, assetId);
 
     const measuredAtRange = {
@@ -116,14 +117,14 @@ export class AssetService {
       searchQuery.and.push(query);
     }
 
-    const measures = await this.sdk.document.search<MeasureContent>(
+    const result = await this.sdk.document.search<MeasureContent>(
       engineId,
       InternalCollection.MEASURES,
       { query: searchQuery, sort },
       { from, lang: "koncorde", size: size }
     );
 
-    return measures.hits;
+    return { measures: result.hits, total: result.total };
   }
 
   public async get(

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -74,7 +74,14 @@ export class AssetService {
       startAt,
       query,
       sort = { measuredAt: "desc" },
-    }: { sort?: JSONObject; query?: JSONObject; from?: number; size?: number; startAt?: string; endAt?: string }
+    }: {
+      sort?: JSONObject;
+      query?: JSONObject;
+      from?: number;
+      size?: number;
+      startAt?: string;
+      endAt?: string;
+    }
   ): Promise<KDocument<MeasureContent>[]> {
     await this.get(engineId, assetId);
 
@@ -96,9 +103,7 @@ export class AssetService {
     }
 
     const searchQuery: JSONObject = {
-      and: [
-        measuredAtRange,
-      ]
+      and: [measuredAtRange],
     };
 
     if (query) {
@@ -109,7 +114,7 @@ export class AssetService {
       engineId,
       InternalCollection.MEASURES,
       { query: searchQuery, sort },
-      { size: size, from, lang: "koncorde" }
+      { from, lang: "koncorde", size: size }
     );
 
     return measures.hits;

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -106,7 +106,10 @@ export class AssetService {
     }
 
     const searchQuery: JSONObject = {
-      and: [measuredAtRange],
+      and: [
+        { equals: { "asset._id": assetId } },
+        measuredAtRange,
+      ],
     };
 
     if (type) {

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -106,10 +106,7 @@ export class AssetService {
     }
 
     const searchQuery: JSONObject = {
-      and: [
-        { equals: { "asset._id": assetId } },
-        measuredAtRange,
-      ],
+      and: [{ equals: { "asset._id": assetId } }, measuredAtRange],
     };
 
     if (type) {

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -162,12 +162,6 @@ export class AssetsController {
     const sort = request.input.body?.sort;
     const type = request.input.args.type;
 
-    if (((size || from) && startAt) || ((size || from) && endAt)) {
-      throw new BadRequestError(
-        'You cannot specify both a "size" or "from" and a "startAt" or "endAt"'
-      );
-    }
-
     const { measures, total } = await this.assetService.getMeasureHistory(
       engineId,
       id,

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -160,6 +160,7 @@ export class AssetsController {
     const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
     const query = request.input.body?.query;
     const sort = request.input.body?.sort;
+    const type = request.input.args.type;
 
     if (((size || from) && startAt) || ((size || from) && endAt)) {
       throw new BadRequestError(
@@ -174,6 +175,7 @@ export class AssetsController {
       size,
       sort,
       startAt,
+      type,
     });
 
     return { measures };

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -168,16 +168,20 @@ export class AssetsController {
       );
     }
 
-    const measures = await this.assetService.getMeasureHistory(engineId, id, {
-      endAt,
-      from,
-      query,
-      size,
-      sort,
-      startAt,
-      type,
-    });
+    const { measures, total } = await this.assetService.getMeasureHistory(
+      engineId,
+      id,
+      {
+        endAt,
+        from,
+        query,
+        size,
+        sort,
+        startAt,
+        type,
+      }
+    );
 
-    return { measures };
+    return { measures, total };
   }
 }

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -55,6 +55,10 @@ export class AssetsController {
               path: "device-manager/:engineId/assets/:_id/measures",
               verb: "get",
             },
+            {
+              path: "device-manager/:engineId/assets/:_id/measures",
+              verb: "post",
+            },
           ],
         },
       },
@@ -149,21 +153,27 @@ export class AssetsController {
     const id = request.getId();
     const engineId = request.getString("engineId");
     const size = request.input.args.size;
+    const from = request.input.args.from;
     const startAt = request.input.args.startAt
       ? request.getDate("startAt")
       : null;
     const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
+    const query = request.input.body?.query;
+    const sort = request.input.body?.sort;
 
-    if ((size && startAt) || (size && endAt)) {
+    if (((size || from) && startAt) || ((size || from) && endAt)) {
       throw new BadRequestError(
-        'You cannot specify both a "size" and a "startAt" or "endAt"'
+        'You cannot specify both a "size" or "from" and a "startAt" or "endAt"'
       );
     }
 
     const measures = await this.assetService.getMeasureHistory(engineId, id, {
       endAt,
       size,
+      from,
       startAt,
+      query,
+      sort,
     });
 
     return { measures };

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, ControllerDefinition, KuzzleRequest } from "kuzzle";
+import { ControllerDefinition, KuzzleRequest } from "kuzzle";
 
 import { AssetService } from "./AssetService";
 import { AssetSerializer } from "./model/AssetSerializer";

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -169,11 +169,11 @@ export class AssetsController {
 
     const measures = await this.assetService.getMeasureHistory(engineId, id, {
       endAt,
-      size,
       from,
-      startAt,
       query,
+      size,
       sort,
+      startAt,
     });
 
     return { measures };

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -92,4 +92,5 @@ export interface ApiAssetGetMeasuresRequest extends AssetsControllerRequest {
 }
 export type ApiAssetGetMeasuresResult = {
   measures: Array<KDocument<MeasureContent<JSONObject>>>;
+  total: number;
 };

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -77,9 +77,16 @@ export interface ApiAssetGetMeasuresRequest extends AssetsControllerRequest {
 
   size?: number;
 
+  from?: number;
+
   startAt?: string;
 
   endAt?: string;
+
+  body?: {
+    query?: JSONObject;
+    sort?: JSONObject;
+  }
 }
 export type ApiAssetGetMeasuresResult = {
   measures: Array<KDocument<MeasureContent<JSONObject>>>;

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -86,7 +86,7 @@ export interface ApiAssetGetMeasuresRequest extends AssetsControllerRequest {
   body?: {
     query?: JSONObject;
     sort?: JSONObject;
-  }
+  };
 }
 export type ApiAssetGetMeasuresResult = {
   measures: Array<KDocument<MeasureContent<JSONObject>>>;

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -83,6 +83,8 @@ export interface ApiAssetGetMeasuresRequest extends AssetsControllerRequest {
 
   endAt?: string;
 
+  type?: string;
+
   body?: {
     query?: JSONObject;
     sort?: JSONObject;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:lint:fix": "eslint ./lib --ext .ts --config .eslintrc.json --fix",
     "prettier": "npx prettier lib/ features/ --write",
     "build": "tsc --build tsconfig.json",
-    "package:create": "npm run build && npm pack"
+    "prepack": "npm run build"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/types/package.json
+++ b/types/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/kuzzleio/kuzzle-plugin-device-manager"
   },
   "scripts": {
+    "prepack": "npm run build",
     "build": "npm --prefix ../ run build && cp -r ../dist/ . && node scripts/copy-version.js"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## What does this PR do ?

This PR allows to pass a search query and a sort to the `device-manager/assets:getMeasures` action.

### Other changes

 - add a `type` to filter on measure types
 - add the `total` number of measures 