### PR TITLE
Add action to retrieve devices measures history

### DIFF
--- a/features/Device/Controller/GetMeasures.feature
+++ b/features/Device/Controller/GetMeasures.feature
@@ -1,0 +1,35 @@
+Feature: Get measures list
+
+  Scenario: Get device measures history
+    Given I send the following "dummy-temp" payloads:
+      | deviceEUI | temperature |
+      | "linked1" | 42          |
+      | "linked1" | 41          |
+      | "linked1" | 40          |
+    And I refresh the collection "engine-ayse":"measures"
+    When I successfully execute the action "device-manager/devices":"getMeasures" with args:
+      | engineId  | "engine-ayse"                    |
+      | _id       | "DummyTemp-linked1"              |
+      | size      | 2                                |
+      | body.sort | { "values.temperature": "desc" } |
+    Then I should receive a result matching:
+      | total           | 3 |
+      | measures.length | 2 |
+    Then I should receive a "measures" array of objects matching:
+      | _source.values.temperature | _source.origin._id  |
+      | 42                         | "DummyTemp-linked1" |
+      | 41                         | "DummyTemp-linked1" |
+    When I successfully execute the action "device-manager/devices":"getMeasures" with args:
+      | engineId   | "engine-ayse"                            |
+      | _id        | "DummyTemp-linked1"                      |
+      | body.query | { equals: { "values.temperature": 40 } } |
+    Then I should receive a "measures" array of objects matching:
+      | _source.values.temperature | _source.origin._id  |
+      | 40                         | "DummyTemp-linked1" |
+    When I successfully execute the action "device-manager/devices":"getMeasures" with args:
+      | engineId | "engine-ayse"       |
+      | _id      | "DummyTemp-linked1" |
+      | type     | "position"          |
+    Then I should receive a result matching:
+      | measures | [] |
+

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -47,7 +47,6 @@ export class AssetsController {
           handler: this.update.bind(this),
           http: [{ path: "device-manager/:engineId/assets/:_id", verb: "put" }],
         },
-
         getMeasures: {
           handler: this.getMeasures.bind(this),
           http: [

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -19,6 +19,7 @@ import {
 import { InternalCollection, DeviceManagerConfiguration } from "../../core";
 import { Metadata, lock, ask, onAsk } from "../shared";
 import { AskModelDeviceGet } from "../model";
+import { MeasureContent } from "../measure";
 
 import { DeviceContent } from "./types/DeviceContent";
 import { DeviceSerializer } from "./model/DeviceSerializer";
@@ -27,7 +28,10 @@ import {
   EventDeviceUpdateAfter,
   EventDeviceUpdateBefore,
 } from "./types/DeviceEvents";
-import { ApiDeviceLinkAssetRequest } from "./exports";
+import {
+  ApiDeviceLinkAssetRequest,
+  ApiDeviceGetMeasuresResult,
+} from "./types/DeviceApi";
 
 export class DeviceService {
   private config: DeviceManagerConfiguration;
@@ -608,6 +612,68 @@ export class DeviceService {
 
       return { asset: updatedAsset, device: updatedDevice };
     });
+  }
+
+  async getMeasureHistory(
+    engineId: string,
+    deviceId: string,
+    {
+      size = 25,
+      from = 0,
+      endAt,
+      startAt,
+      query,
+      sort = { measuredAt: "desc" },
+      type,
+    }: {
+      sort?: JSONObject;
+      query?: JSONObject;
+      from?: number;
+      size?: number;
+      startAt?: string;
+      endAt?: string;
+      type?: string;
+    }
+  ): Promise<ApiDeviceGetMeasuresResult> {
+    await this.get(engineId, deviceId);
+
+    const measuredAtRange = {
+      range: {
+        measuredAt: {
+          gte: 0,
+          lte: Number.MAX_SAFE_INTEGER,
+        },
+      },
+    };
+
+    if (startAt) {
+      measuredAtRange.range.measuredAt.gte = new Date(startAt).getTime();
+    }
+
+    if (endAt) {
+      measuredAtRange.range.measuredAt.lte = new Date(endAt).getTime();
+    }
+
+    const searchQuery: JSONObject = {
+      and: [{ equals: { "origin._id": deviceId } }, measuredAtRange],
+    };
+
+    if (type) {
+      searchQuery.and.push({ equals: { type } });
+    }
+
+    if (query) {
+      searchQuery.and.push(query);
+    }
+
+    const result = await this.sdk.document.search<MeasureContent>(
+      engineId,
+      InternalCollection.MEASURES,
+      { query: searchQuery, sort },
+      { from, lang: "koncorde", size: size }
+    );
+
+    return { measures: result.hits, total: result.total };
   }
 
   private async checkEngineExists(engineId: string) {

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -15,6 +15,7 @@ import {
   ApiDeviceSearchResult,
   ApiDeviceUnlinkAssetResult,
   ApiDeviceUpdateResult,
+  ApiDeviceGetMeasuresResult,
 } from "./types/DeviceApi";
 
 export class DevicesController {
@@ -89,6 +90,19 @@ export class DevicesController {
             {
               path: "device-manager/:engineId/devices/:_id/_unlink",
               verb: "delete",
+            },
+          ],
+        },
+        getMeasures: {
+          handler: this.getMeasures.bind(this),
+          http: [
+            {
+              path: "device-manager/:engineId/devices/:_id/measures",
+              verb: "get",
+            },
+            {
+              path: "device-manager/:engineId/devices/:_id/measures",
+              verb: "post",
             },
           ],
         },
@@ -261,5 +275,37 @@ export class DevicesController {
       asset: AssetSerializer.serialize(asset),
       device: DeviceSerializer.serialize(device),
     };
+  }
+
+  async getMeasures(
+    request: KuzzleRequest
+  ): Promise<ApiDeviceGetMeasuresResult> {
+    const id = request.getId();
+    const engineId = request.getString("engineId");
+    const size = request.input.args.size;
+    const from = request.input.args.from;
+    const startAt = request.input.args.startAt
+      ? request.getDate("startAt")
+      : null;
+    const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
+    const query = request.input.body?.query;
+    const sort = request.input.body?.sort;
+    const type = request.input.args.type;
+
+    const { measures, total } = await this.deviceService.getMeasureHistory(
+      engineId,
+      id,
+      {
+        endAt,
+        from,
+        query,
+        size,
+        sort,
+        startAt,
+        type,
+      }
+    );
+
+    return { measures, total };
   }
 }

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -1,5 +1,6 @@
 import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle";
 
+import { MeasureContent } from "../../measure";
 import { AssetContent } from "../../asset";
 import { Metadata } from "../../shared";
 
@@ -129,4 +130,29 @@ export interface ApiDeviceLinkAssetRequest extends DevicesControllerRequest {
 export type ApiDeviceLinkAssetResult = {
   asset: KDocument<AssetContent>;
   device: KDocument<DeviceContent>;
+};
+
+export interface ApiDeviceGetMeasuresRequest extends DevicesControllerRequest {
+  action: "getMeasures";
+
+  _id: string;
+
+  size?: number;
+
+  from?: number;
+
+  startAt?: string;
+
+  endAt?: string;
+
+  type?: string;
+
+  body?: {
+    query?: JSONObject;
+    sort?: JSONObject;
+  };
+}
+export type ApiDeviceGetMeasuresResult = {
+  measures: Array<KDocument<MeasureContent<JSONObject>>>;
+  total: number;
 };


### PR DESCRIPTION
## What does this PR do ?

Add a `device-manager/devices:getMeasures` action to retrieve measures history.

This action is the same as the one to retrieve assets measures.