### PR TITLE
Allows to implicitly link asset to device without specifying every measure names

### DIFF
--- a/features/Device/Controller/LinkAsset.feature
+++ b/features/Device/Controller/LinkAsset.feature
@@ -18,6 +18,7 @@ Feature: LinkAsset
       | linkedDevices[0].measureNames[0].asset  | "temperatureExt"      |
       | linkedDevices[0].measureNames[0].device | "temperature"         |
       | _kuzzle_info.updater                    | "-1"                  |
+    # Link second device
     When I successfully execute the action "device-manager/devices":"linkAsset" with args:
       | _id                         | "DummyTemp-unlinked2" |
       | assetId                     | "Container-unlinked1" |
@@ -30,6 +31,34 @@ Feature: LinkAsset
       | linkedDevices[0].measureNames[0].device | "temperature"         |
       | linkedDevices[1]._id                    | "DummyTemp-unlinked2" |
       | linkedDevices[1].measureNames[0].asset  | "temperatureInt"      |
+
+  Scenario: Link device with default measure names
+    Given I successfully execute the action "device-manager/devices":"linkAsset" with args:
+      | _id                         | "DummyTemp-unlinked1" |
+      | assetId                     | "Container-unlinked1" |
+      | engineId                    | "engine-ayse"         |
+      | body.measureNames[0].device | "temperature"         |
+      | body.measureNames[0].asset  | "temperatureExt"      |
+    When I successfully execute the action "device-manager/devices":"linkAsset" with args:
+      | _id                         | "DummyTempPosition-unlinked3" |
+      | assetId                     | "Container-unlinked1"         |
+      | engineId                    | "engine-ayse"                 |
+      | implicitMeasuresLinking     | true                          |
+      | body.measureNames[0].device | "temperature"                 |
+      | body.measureNames[0].asset  | "temperatureInt"              |
+    And The document "engine-ayse":"assets":"Container-unlinked1" content match:
+      # Keep the previously linked measure
+      | linkedDevices[0]._id                    | "DummyTemp-unlinked1"         |
+      | linkedDevices[0].measureNames[0].asset  | "temperatureExt"              |
+      | linkedDevices[0].measureNames[0].device | "temperature"                 |
+      # Explicitly linked measure
+      | linkedDevices[1]._id                    | "DummyTempPosition-unlinked3" |
+      | linkedDevices[1].measureNames.length    | 2                             |
+      | linkedDevices[1].measureNames[0].asset  | "temperatureInt"              |
+      | linkedDevices[1].measureNames[0].device | "temperature"                 |
+      # Implicitly linked measure
+      | linkedDevices[1].measureNames[1].asset  | "position"                    |
+      | linkedDevices[1].measureNames[1].device | "position"                    |
 
   Scenario: Error when device is already linked
     When I execute the action "device-manager/devices":"linkAsset" with args:

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -46,6 +46,16 @@ const deviceAyseUnlinked2 = {
 };
 const deviceAyseUnlinked2Id = `${deviceAyseUnlinked2.model}-${deviceAyseUnlinked2.reference}`;
 
+const deviceAyseUnlinked3 = {
+  model: "DummyTempPosition",
+  reference: "unlinked3",
+  metadata: {},
+  measures: {},
+  engineId: "engine-ayse",
+  assetId: null,
+};
+const deviceAyseUnlinked3Id = `${deviceAyseUnlinked3.model}-${deviceAyseUnlinked3.reference}`;
+
 const assetAyseLinked1 = {
   model: "Container",
   reference: "linked1",
@@ -97,14 +107,21 @@ module.exports = {
     devices: [
       { index: { _id: deviceAyseLinked1Id } },
       deviceAyseLinked1,
+
       { index: { _id: deviceAyseLinked2Id } },
       deviceAyseLinked2,
+
       { index: { _id: deviceDetached1Id } },
       deviceDetached1,
+
       { index: { _id: deviceAyseUnlinked1Id } },
       deviceAyseUnlinked1,
+
       { index: { _id: deviceAyseUnlinked2Id } },
       deviceAyseUnlinked2,
+
+      { index: { _id: deviceAyseUnlinked3Id } },
+      deviceAyseUnlinked3,
     ],
   },
 
@@ -113,18 +130,26 @@ module.exports = {
     devices: [
       { index: { _id: deviceAyseLinked1Id } },
       deviceAyseLinked1,
+
       { index: { _id: deviceAyseLinked2Id } },
       deviceAyseLinked2,
+
       { index: { _id: deviceAyseUnlinked1Id } },
       deviceAyseUnlinked1,
+
       { index: { _id: deviceAyseUnlinked2Id } },
       deviceAyseUnlinked2,
+
+      { index: { _id: deviceAyseUnlinked3Id } },
+      deviceAyseUnlinked3,
     ],
     assets: [
       { index: { _id: assetAyseLinked1Id } },
       assetAyseLinked1,
+
       { index: { _id: assetAyseLinked2Id } },
       assetAyseLinked2,
+
       { index: { _id: assetAyseUnlinkedId } },
       assetAyseUnlinked,
     ],

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -466,7 +466,7 @@ export class DeviceService {
 
       this.checkAlreadyProvidedMeasures(asset, measureNames);
 
-      if (implicitMeasuresLinking === true) {
+      if (implicitMeasuresLinking) {
         this.generateMissingAssetMeasureNames(
           asset,
           assetModel,

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -237,6 +237,7 @@ export class DevicesController {
     const measureNames = request.getBodyArray(
       "measureNames"
     ) as ApiDeviceLinkAssetRequest["body"]["measureNames"];
+    const implicitMeasuresLinking = request.input.args.implicitMeasuresLinking;
     const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.linkAsset(
@@ -245,7 +246,7 @@ export class DevicesController {
       deviceId,
       assetId,
       measureNames,
-      { refresh }
+      { implicitMeasuresLinking, refresh }
     );
 
     return {

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -237,7 +237,9 @@ export class DevicesController {
     const measureNames = request.getBodyArray(
       "measureNames"
     ) as ApiDeviceLinkAssetRequest["body"]["measureNames"];
-    const implicitMeasuresLinking = request.getBoolean('implicitMeasuresLinking')
+    const implicitMeasuresLinking = request.getBoolean(
+      "implicitMeasuresLinking"
+    );
     const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.linkAsset(

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -237,7 +237,7 @@ export class DevicesController {
     const measureNames = request.getBodyArray(
       "measureNames"
     ) as ApiDeviceLinkAssetRequest["body"]["measureNames"];
-    const implicitMeasuresLinking = request.input.args.implicitMeasuresLinking;
+    const implicitMeasuresLinking = request.getBoolean('implicitMeasuresLinking')
     const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.linkAsset(

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -112,9 +112,20 @@ export interface ApiDeviceLinkAssetRequest extends DevicesControllerRequest {
 
   assetId: string;
 
+  /**
+   * If true, then all the measures from the device will be linked to the asset
+   * if possible.
+   *
+   * They will have the same name on the asset as on the device.
+   */
+  implicitMeasuresLinking?: boolean;
+
   body?: {
     /**
-     * Names of the linked measures
+     * Names of the linked measures.
+     *
+     * If a measure is not explicitly linked, it will be linked in the asset with
+     * the same name as in the device.
      *
      * Array<{ asset: string, device: string }>
      *
@@ -124,7 +135,7 @@ export interface ApiDeviceLinkAssetRequest extends DevicesControllerRequest {
      *   { asset: "externalTemperature", device: "temperature" }
      * ]
      */
-    measureNames: Array<{ asset: string; device: string }>;
+    measureNames?: Array<{ asset: string; device: string }>;
   };
 }
 export type ApiDeviceLinkAssetResult = {

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -113,19 +113,26 @@ export interface ApiDeviceLinkAssetRequest extends DevicesControllerRequest {
   assetId: string;
 
   /**
-   * If true, then all the measures from the device will be linked to the asset
-   * if possible.
+   * This option allows to not specify the names of all the measures that should
+   * be linked to the asset.
    *
-   * They will have the same name on the asset as on the device.
+   * The algorithm will go through all the measures names provided by the device
+   * and add the one who are present with the same name in the asset.
+   *
+   * It will not add the measure if:
+   *   - it has been specified in the link request
+   *   - it was already present in the asset
+   *
+   * @example
+   *   if the device provide a measure of type "temperature" with the name "temp"
+   *   if the asset has declared a measure of type "temperature" with the name "temp"
+   *   then the measure will be automatically added in the link and will later be propagated to the asset
    */
   implicitMeasuresLinking?: boolean;
 
   body?: {
     /**
      * Names of the linked measures.
-     *
-     * If a measure is not explicitly linked, it will be linked in the asset with
-     * the same name as in the device.
      *
      * Array<{ asset: string, device: string }>
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.5.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {


### PR DESCRIPTION
## What does this PR do ?

Add the `implicitMeasuresLinking` option to `device-manager/devices:linkAsset` action.

This option allows to not specify the names of all the measures that should be linked to the asset. The algorithm will go through all the measures names provided by the device and add the one who are present with the same name in the asset. 

It will not add the measure if:
 - it has been specified in the link request
 - it was already present in the asset
