### PR TITLE
Release 2.1.1 - imports types directly from kuzzle-sdk package

### DIFF
--- a/features/fixtures/application/decoders/DummyTempDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempDecoder.ts
@@ -1,4 +1,5 @@
-import { JSONObject, PreconditionError } from "kuzzle";
+import { PreconditionError } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import {
   Decoder,

--- a/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
+++ b/features/fixtures/application/decoders/DummyTempPositionDecoder.ts
@@ -1,4 +1,5 @@
-import { JSONObject, PreconditionError } from "kuzzle";
+import { PreconditionError } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import {
   Decoder,

--- a/features/fixtures/application/tests/pipes.ts
+++ b/features/fixtures/application/tests/pipes.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import { Backend, KDocument } from "kuzzle";
+import { Backend } from "kuzzle";
+import { KDocument } from "kuzzle-sdk";
 import should from "should";
 
 import {

--- a/lib/core/DeviceManagerConfiguration.ts
+++ b/lib/core/DeviceManagerConfiguration.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 export type DeviceManagerConfiguration = {
   /**

--- a/lib/core/DeviceManagerEngine.ts
+++ b/lib/core/DeviceManagerEngine.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
-import { Backend, InternalError, JSONObject, Plugin } from "kuzzle";
+import { Backend, InternalError, Plugin } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 import { AbstractEngine, ConfigManager } from "kuzzle-plugin-commons";
 
 import { assetsMappings, assetsHistoryMappings } from "../modules/asset";

--- a/lib/core/DeviceManagerPlugin.ts
+++ b/lib/core/DeviceManagerPlugin.ts
@@ -2,11 +2,11 @@ import _ from "lodash";
 import {
   Plugin,
   PluginContext,
-  JSONObject,
   PluginImplementationError,
   KuzzleRequest,
   BadRequestError,
 } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 import { ConfigManager, EngineController } from "kuzzle-plugin-commons";
 
 import {

--- a/lib/core/registers/ModelsRegister.ts
+++ b/lib/core/registers/ModelsRegister.ts
@@ -1,9 +1,5 @@
-import {
-  Inflector,
-  JSONObject,
-  PluginContext,
-  PluginImplementationError,
-} from "kuzzle";
+import { Inflector, PluginContext, PluginImplementationError } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import { NamedMeasures } from "../../modules/decoder";
 import { MeasureDefinition } from "../../modules/measure";

--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -1,4 +1,5 @@
-import { KDocument, PluginContext } from "kuzzle";
+import { PluginContext } from "kuzzle";
+import { KDocument } from "kuzzle-sdk";
 
 import {
   DeviceManagerConfiguration,

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -1,14 +1,6 @@
 import _ from "lodash";
-import {
-  Backend,
-  BadRequestError,
-  JSONObject,
-  KDocument,
-  KHit,
-  PluginContext,
-  SearchResult,
-  User,
-} from "kuzzle";
+import { Backend, BadRequestError, PluginContext, User } from "kuzzle";
+import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import { MeasureContent } from "../measure/";
 import { AskDeviceUnlinkAsset } from "../device";

--- a/lib/modules/asset/model/AssetSerializer.ts
+++ b/lib/modules/asset/model/AssetSerializer.ts
@@ -1,4 +1,4 @@
-import { KDocument } from "kuzzle";
+import { KDocument } from "kuzzle-sdk";
 
 import { AssetContent, AssetMeasureContext } from "../types/AssetContent";
 

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle";
+import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import { MeasureContent } from "../../../modules/measure";
 import { Metadata } from "../../shared";

--- a/lib/modules/asset/types/AssetContent.ts
+++ b/lib/modules/asset/types/AssetContent.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import { DigitalTwinContent, Metadata } from "../../shared";
 

--- a/lib/modules/asset/types/AssetEvents.ts
+++ b/lib/modules/asset/types/AssetEvents.ts
@@ -1,4 +1,4 @@
-import { KDocument } from "kuzzle";
+import { KDocument } from "kuzzle-sdk";
 
 import { Metadata } from "../../../modules/shared";
 

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocumentContent } from "kuzzle";
+import { JSONObject, KDocumentContent } from "kuzzle-sdk";
 
 import { Metadata } from "../../shared";
 

--- a/lib/modules/decoder/DecodedPayload.ts
+++ b/lib/modules/decoder/DecodedPayload.ts
@@ -1,4 +1,5 @@
-import { JSONObject, BadRequestError } from "kuzzle";
+import { BadRequestError } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import { DecodedMeasurement } from "../measure";
 

--- a/lib/modules/decoder/Decoder.ts
+++ b/lib/modules/decoder/Decoder.ts
@@ -1,10 +1,6 @@
-import {
-  HttpRoute,
-  JSONObject,
-  KuzzleRequest,
-  PreconditionError,
-} from "kuzzle";
+import { HttpRoute, KuzzleRequest, PreconditionError } from "kuzzle";
 import _ from "lodash";
+import { JSONObject } from "kuzzle-sdk";
 
 import { DecodedPayload } from "./DecodedPayload";
 import { DecoderContent } from "./types/DecoderContent";

--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -1,10 +1,5 @@
-import {
-  Backend,
-  JSONObject,
-  KDocument,
-  KuzzleRequest,
-  PluginContext,
-} from "kuzzle";
+import { Backend, KuzzleRequest, PluginContext } from "kuzzle";
+import { JSONObject, KDocument } from "kuzzle-sdk";
 import { v4 as uuidv4 } from "uuid";
 
 import {

--- a/lib/modules/decoder/types/PayloadApi.ts
+++ b/lib/modules/decoder/types/PayloadApi.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 interface PayloadsControllerRequest {
   controller: "device-manager/payloads";

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -1,14 +1,5 @@
-import {
-  Backend,
-  BadRequestError,
-  JSONObject,
-  KDocument,
-  KHit,
-  Plugin,
-  PluginContext,
-  SearchResult,
-  User,
-} from "kuzzle";
+import { Backend, BadRequestError, Plugin, PluginContext, User } from "kuzzle";
+import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import {
   AskAssetHistoryAdd,

--- a/lib/modules/device/model/DeviceSerializer.ts
+++ b/lib/modules/device/model/DeviceSerializer.ts
@@ -1,4 +1,4 @@
-import { KDocument } from "kuzzle";
+import { KDocument } from "kuzzle-sdk";
 
 import { DeviceContent } from "../types/DeviceContent";
 

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle";
+import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import { DecodedMeasurement, MeasureContent } from "../../measure";
 import { AssetContent } from "../../asset";

--- a/lib/modules/device/types/DeviceContent.ts
+++ b/lib/modules/device/types/DeviceContent.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import { DigitalTwinContent, Metadata } from "../../shared";
 

--- a/lib/modules/device/types/DeviceEvents.ts
+++ b/lib/modules/device/types/DeviceEvents.ts
@@ -1,4 +1,5 @@
-import { KDocument, User } from "kuzzle";
+import { User } from "kuzzle";
+import { KDocument } from "kuzzle-sdk";
 
 import { Metadata } from "../../../modules/shared";
 

--- a/lib/modules/measure/types/MeasureContent.ts
+++ b/lib/modules/measure/types/MeasureContent.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocumentContent } from "kuzzle";
+import { JSONObject, KDocumentContent } from "kuzzle-sdk";
 
 import { Metadata } from "../../../modules/shared";
 import { AssetMeasureContext } from "../../../modules/asset";

--- a/lib/modules/measure/types/MeasureDefinition.ts
+++ b/lib/modules/measure/types/MeasureDefinition.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 /**
  * Represents a measure definition registered by the Device Manager

--- a/lib/modules/measure/types/MeasureEvents.ts
+++ b/lib/modules/measure/types/MeasureEvents.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocument } from "kuzzle";
+import { JSONObject, KDocument } from "kuzzle-sdk";
 
 import { DeviceContent } from "../../../modules/device";
 import { AssetContent } from "../../../modules/asset";

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -1,11 +1,10 @@
 import {
   BadRequestError,
   Inflector,
-  JSONObject,
-  KDocument,
   NotFoundError,
   PluginContext,
 } from "kuzzle";
+import { JSONObject, KDocument } from "kuzzle-sdk";
 
 import {
   AskEngineUpdateAll,

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocument } from "kuzzle";
+import { JSONObject, KDocument } from "kuzzle-sdk";
 
 import {
   AssetModelContent,

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocumentContent } from "kuzzle";
+import { JSONObject, KDocumentContent } from "kuzzle-sdk";
 
 import { NamedMeasures } from "../../../modules/decoder";
 

--- a/lib/modules/model/types/ModelDefinition.ts
+++ b/lib/modules/model/types/ModelDefinition.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 import { Decoder, NamedMeasures } from "../../../modules/decoder";
 

--- a/lib/modules/shared/types/DigitalTwinContent.ts
+++ b/lib/modules/shared/types/DigitalTwinContent.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocumentContent } from "kuzzle";
+import { JSONObject, KDocumentContent } from "kuzzle-sdk";
 
 import { EmbeddedMeasure } from "./EmbeddedMeasure";
 import { Metadata } from "./Metadata";

--- a/lib/modules/shared/types/EmbeddedMeasure.ts
+++ b/lib/modules/shared/types/EmbeddedMeasure.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 export type EmbeddedMeasure<TMeasureValue extends JSONObject = JSONObject> = {
   /**

--- a/lib/modules/shared/utils/flattenObject.ts
+++ b/lib/modules/shared/utils/flattenObject.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle";
+import { JSONObject } from "kuzzle-sdk";
 
 /**
  * Flatten an object transform:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.5.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {

--- a/tests/helpers/document.ts
+++ b/tests/helpers/document.ts
@@ -1,9 +1,0 @@
-export function documentExists(index: string, collection: string, id: string) {
-  return {
-    controller: "document",
-    action: "exists",
-    index,
-    collection,
-    _id: id,
-  };
-}


### PR DESCRIPTION
## What does this PR do ?

Import types declared in `kuzzle-sdk` directly from this package and not from `kuzzle` to avoid type mismatch.