### PR TITLE
Fix type of assetId and engineId

### DIFF
--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -91,6 +91,8 @@ export class DeviceService {
         metadata,
         model,
         reference,
+        assetId: null,
+        engineId: null
       },
     };
 

--- a/lib/modules/device/types/DeviceContent.ts
+++ b/lib/modules/device/types/DeviceContent.ts
@@ -12,9 +12,9 @@ export interface DeviceContent<
   /**
    * Linked asset unique identifier
    */
-  assetId?: string;
+  assetId: string | null;
 
   /**
    */
-  engineId?: string;
+  engineId: string;
 }


### PR DESCRIPTION
## What does this PR do ?

Device `assetId` and `engineId` properties are `null` by default