### PR TITLE
Support nested metadata diff for asset history

### DIFF
--- a/features/fixtures/application/assets/Container.ts
+++ b/features/fixtures/application/assets/Container.ts
@@ -35,6 +35,12 @@ export const containerAssetDefinition: AssetModelDefinition = {
   metadataMappings: {
     weight: { type: "integer" },
     height: { type: "integer" },
+    trailer: {
+      properties: {
+        weight: { type: "integer" },
+        capacity: { type: "integer" },
+      },
+    },
   },
   defaultMetadata: {
     height: 20,

--- a/features/fixtures/application/tests/pipes.ts
+++ b/features/fixtures/application/tests/pipes.ts
@@ -96,6 +96,7 @@ export function registerTestPipes(app: Backend) {
         device._source.metadata.color === "test-metadata-history-with-measure"
       ) {
         asset._source.metadata.weight = 42042;
+        asset._source.metadata.trailer.capacity = 2048;
       }
 
       return { asset, device, measures };

--- a/features/fixtures/fixtures.js
+++ b/features/fixtures/fixtures.js
@@ -62,6 +62,10 @@ const assetAyseLinked1 = {
   metadata: {
     weight: 10,
     height: 11,
+    trailer: {
+      weight: 128,
+      capacity: 1024,
+    },
   },
   linkedDevices: [
     {

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -19,7 +19,7 @@ import {
   AssetHistoryEventMeasure,
   AssetHistoryEventMetadata,
 } from "../asset";
-import { Metadata, lock, ask, onAsk } from "../shared";
+import { Metadata, lock, ask, onAsk, objectDiff } from "../shared";
 import { AssetSerializer } from "../asset";
 
 import {
@@ -206,7 +206,7 @@ export class MeasureService {
                   name: "measure",
                 };
 
-                const metadataDiff = this.compareMetadata(
+                const metadataDiff = objectDiff(
                   originalAssetMetadata,
                   updatedAsset._source.metadata
                 );
@@ -255,18 +255,6 @@ export class MeasureService {
         );
       }
     });
-  }
-
-  private compareMetadata(before: JSONObject, after: JSONObject): string[] {
-    const names: string[] = [];
-
-    for (const [key, value] of Object.entries(before)) {
-      if (after[key] !== value) {
-        names.push(key);
-      }
-    }
-
-    return names;
   }
 
   private updateDeviceMeasures(

--- a/lib/modules/measure/types/MeasureContent.ts
+++ b/lib/modules/measure/types/MeasureContent.ts
@@ -38,6 +38,10 @@ export type MeasureOriginDevice = {
 };
 
 export type MeasureOriginComputed = {
+  /**
+   * Computed measures are not automatically added into the asset and device
+   * documents at the end of the ingestion pipeline.
+   */
   type: "computed";
 
   /**

--- a/lib/modules/shared/index.ts
+++ b/lib/modules/shared/index.ts
@@ -5,4 +5,5 @@ export * from "./types/KuzzleRole";
 export * from "./utils/lock";
 export * from "./utils/flattenObject";
 export * from "./utils/ask";
+export * from "./utils/objectDiff";
 export * from "./Module";

--- a/lib/modules/shared/utils/objectDiff.ts
+++ b/lib/modules/shared/utils/objectDiff.ts
@@ -1,0 +1,39 @@
+import { JSONObject } from "kuzzle-sdk";
+import _ from "lodash";
+
+export function objectDiff(base: JSONObject, object: JSONObject) {
+  const changes: string[] = [];
+
+  const walkObject = (_base: any, _object: any, path: any = []) => {
+    for (const key of Object.keys(_base)) {
+      if (_object[key] === undefined) {
+        const ar: [] = [];
+        const ar2: [] = [];
+        ar.concat(ar2);
+        changes.push([...path, key].join("."));
+      }
+    }
+
+    for (const key of Object.keys(_object)) {
+      if (_base[key] === undefined) {
+        changes.push([...path, key].join("."));
+      } else if (
+        !_.isEqual(_object[key], _base[key]) &&
+        _.isObject(_object[key]) &&
+        _.isObject(_base[key])
+      ) {
+        walkObject(_base[key], _object[key], [...path, key]);
+      } else if (
+        !_.isObject(_object[key]) &&
+        !_.isObject(_base[key]) &&
+        _base[key] !== _object[key]
+      ) {
+        changes.push([...path, key].join("."));
+      }
+    }
+  };
+
+  walkObject(base, object);
+
+  return changes;
+}

--- a/lib/modules/shared/utils/objectDiff.ts
+++ b/lib/modules/shared/utils/objectDiff.ts
@@ -7,9 +7,6 @@ export function objectDiff(base: JSONObject, object: JSONObject) {
   const walkObject = (_base: any, _object: any, path: any = []) => {
     for (const key of Object.keys(_base)) {
       if (_object[key] === undefined) {
-        const ar: [] = [];
-        const ar2: [] = [];
-        ar.concat(ar2);
         changes.push([...path, key].join("."));
       }
     }

--- a/tests/helpers/payloads.ts
+++ b/tests/helpers/payloads.ts
@@ -1,6 +1,6 @@
 import { JSONObject, Kuzzle } from "kuzzle-sdk";
 
-export async function sendDummyTemp (sdk: Kuzzle, body: JSONObject) {
+export async function sendDummyTemp(sdk: Kuzzle, body: JSONObject) {
   await sdk.query({
     controller: "device-manager/payloads",
     action: "dummy-temp",

--- a/tests/modules/assets/asset-history.test.ts
+++ b/tests/modules/assets/asset-history.test.ts
@@ -76,7 +76,7 @@ describe("DeviceController: receiveMeasure", () => {
           names: ["temperatureExt"],
         },
         metadata: {
-          names: ["weight"],
+          names: ["weight", "trailer.capacity"],
         },
       },
     });


### PR DESCRIPTION
## What does this PR do ?

When an asset receive a measure, we also check if a metadata was updated in the ingestion pipeline. If it's the case then it appear in the `event` property:

```js
  "asset": { /* asset content */ },
  "event": {
    "measure": {
      "names": [
        "temperatureExt"
      ]
    },
    "name": "measure",   // history document from a new mesure
    "metadata": {              // but a metadata was also changed in the ingestion pipeline
      "names": [
        "weight",                 // simple metadata, was supported
        "trailer.capacity"    // nested metadata, supported now
      ]
    }
  },
  "id": "Container-linked1"
```