### PR TITLE
Add lang search parameter in ApiAssetSearchRequest type

### DIFF
--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -66,6 +66,8 @@ export interface ApiAssetSearchRequest extends AssetsControllerRequest {
 
   scrollTTL?: string;
 
+  lang?: "koncorde" | "elasticsearch";
+
   body: JSONObject;
 }
 export type ApiAssetSearchResult = SearchResult<KHit<AssetContent>>;


### PR DESCRIPTION
## What does this PR do ?

`lang: "koncorde" | "elasticsearch"` parameter missing from the ApiAssetSearchRequest

* add the lang parameter to ApiAssetSearchRequest