### PR TITLE
Add `originId` digital twins embedded measures

### DIFF
--- a/features/fixtures/application/tests/pipes.ts
+++ b/features/fixtures/application/tests/pipes.ts
@@ -6,7 +6,6 @@ import should from "should";
 import {
   MeasureContent,
   EventMeasureProcessBefore,
-  AssetContent,
   DeviceContent,
   TemperatureMeasurement,
 } from "../../../../index";
@@ -85,6 +84,7 @@ export function registerTestPipes(app: Backend) {
               values: {
                 temperature: temperatureInt.values.temperature,
               },
+              originId: device._id,
             };
           }
         }
@@ -131,6 +131,7 @@ export function registerTestPipes(app: Backend) {
           payloadUuids: measure.origin.payloadUuids,
           type: measure.type,
           values: measure.values,
+          originId: device._id,
         };
       }
 

--- a/lib/core/DeviceManagerEngine.ts
+++ b/lib/core/DeviceManagerEngine.ts
@@ -9,7 +9,10 @@ import {
   DeviceModelContent,
   MeasureModelContent,
 } from "../modules/model";
-import { measuresMappings } from "../modules/measure";
+import {
+  getEmbeddedMeasureMappings,
+  measuresMappings,
+} from "../modules/measure";
 import { devicesMappings } from "../modules/device";
 import { onAsk } from "../modules/shared";
 import { NamedMeasures } from "../modules/decoder";
@@ -225,17 +228,10 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
           );
         }
 
-        mappings.properties.measures.properties[measureName] = {
-          properties: {
-            measuredAt: { type: "date" },
-            name: { type: "keyword" },
-            payloadUuids: { type: "keyword" },
-            type: { type: "keyword" },
-            values: {
-              properties: measureModel._source.measure.valuesMappings,
-            },
-          },
-        };
+        mappings.properties.measures.properties[measureName] =
+          getEmbeddedMeasureMappings(
+            measureModel._source.measure.valuesMappings
+          );
       }
     }
 

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -292,6 +292,7 @@ export class MeasureService {
       device._source.measures[measureName] = {
         measuredAt: measurement.measuredAt,
         name: measureName,
+        originId: measurement.origin._id,
         payloadUuids: measurement.origin.payloadUuids,
         type: measurement.type,
         values: measurement.values,
@@ -330,6 +331,7 @@ export class MeasureService {
       asset._source.measures[measureName] = {
         measuredAt: measurement.measuredAt,
         name: measureName,
+        originId: measurement.origin._id,
         payloadUuids: measurement.origin.payloadUuids,
         type: measurement.type,
         values: measurement.values,

--- a/lib/modules/measure/collections/getEmbeddedMeasureMappings.ts
+++ b/lib/modules/measure/collections/getEmbeddedMeasureMappings.ts
@@ -1,0 +1,16 @@
+import { JSONObject } from "kuzzle-sdk";
+
+export const getEmbeddedMeasureMappings: (values: JSONObject) => JSONObject = (
+  valuesMappings
+) => ({
+  properties: {
+    measuredAt: { type: "date" },
+    name: { type: "keyword" },
+    payloadUuids: { type: "keyword" },
+    type: { type: "keyword" },
+    values: {
+      properties: valuesMappings,
+    },
+    originId: { type: "keyword" },
+  },
+});

--- a/lib/modules/measure/index.ts
+++ b/lib/modules/measure/index.ts
@@ -6,3 +6,4 @@ export * from "./measures";
 export * from "./MeasureModule";
 export * from "./roles/RoleMeasuresAdmin";
 export * from "./roles/RoleMeasuresReader";
+export * from "./collections/getEmbeddedMeasureMappings";

--- a/lib/modules/shared/types/EmbeddedMeasure.ts
+++ b/lib/modules/shared/types/EmbeddedMeasure.ts
@@ -26,4 +26,9 @@ export type EmbeddedMeasure<TMeasureValue extends JSONObject = JSONObject> = {
    * Name of the measure for the digital twin
    */
   name: string;
+
+  /**
+   * Origin ID of the measure (deviceId in most cases)
+   */
+  originId: string;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,21 +15,21 @@
       },
       "devDependencies": {
         "@types/jest": "^29.4.0",
-        "@types/node": "^18.13.0",
-        "axios": "^1.3.2",
+        "@types/node": "^18.14.1",
+        "axios": "^1.3.4",
         "cucumber": "^6.0.5",
         "ergol": "^1.0.2",
         "eslint-plugin-kuzzle": "^0.0.6",
-        "jest": "^29.4.1",
-        "kuzzle": "^2.20.2",
-        "kuzzle-sdk": "^7.10.5",
+        "jest": "^29.4.3",
+        "kuzzle": "^2.21.0",
+        "kuzzle-sdk": "^7.10.6",
         "should": "^13.2.3",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
-        "kuzzle": "^2.20.2"
+        "kuzzle": "^2.21.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -960,16 +960,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.1.tgz",
-      "integrity": "sha512-m+XpwKSi3PPM9znm5NGS8bBReeAJJpSkL1OuFCqaMaJL2YX9YXLkkI+MBchMPwu+ZuM2rynL51sgfkQteQ1CKQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.4.3.tgz",
+      "integrity": "sha512-W/o/34+wQuXlgqlPYTansOSiBnuxrTv61dEVkA6HNmpcgHLUjfaUbdqt6oVvOzaawwo9IdW9QOtMgQ1ScSZC4A==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-message-util": "^29.4.3",
+        "jest-util": "^29.4.3",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -977,37 +977,37 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.4.1.tgz",
-      "integrity": "sha512-RXFTohpBqpaTebNdg5l3I5yadnKo9zLBajMT0I38D0tDhreVBYv3fA8kywthI00sWxPztWLD3yjiUkewwu/wKA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.4.3.tgz",
+      "integrity": "sha512-56QvBq60fS4SPZCuM7T+7scNrkGIe7Mr6PVIXUpu48ouvRaWOFqRPV91eifvFM0ay2HmfswXiGf97NGUN5KofQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.4.1",
-        "@jest/reporters": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/console": "^29.4.3",
+        "@jest/reporters": "^29.4.3",
+        "@jest/test-result": "^29.4.3",
+        "@jest/transform": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.4.0",
-        "jest-config": "^29.4.1",
-        "jest-haste-map": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-resolve": "^29.4.1",
-        "jest-resolve-dependencies": "^29.4.1",
-        "jest-runner": "^29.4.1",
-        "jest-runtime": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "jest-validate": "^29.4.1",
-        "jest-watcher": "^29.4.1",
+        "jest-changed-files": "^29.4.3",
+        "jest-config": "^29.4.3",
+        "jest-haste-map": "^29.4.3",
+        "jest-message-util": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.4.3",
+        "jest-resolve-dependencies": "^29.4.3",
+        "jest-runner": "^29.4.3",
+        "jest-runtime": "^29.4.3",
+        "jest-snapshot": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "jest-validate": "^29.4.3",
+        "jest-watcher": "^29.4.3",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.4.3",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -1051,88 +1051,88 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.1.tgz",
-      "integrity": "sha512-pJ14dHGSQke7Q3mkL/UZR9ZtTOxqskZaC91NzamEH4dlKRt42W+maRBXiw/LWkdJe+P0f/zDR37+SPMplMRlPg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.4.3.tgz",
+      "integrity": "sha512-dq5S6408IxIa+lr54zeqce+QgI+CJT4nmmA+1yzFgtcsGK8c/EyiUb9XQOgz3BMKrRDfKseeOaxj2eO8LlD3lA==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/fake-timers": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
-        "jest-mock": "^29.4.1"
+        "jest-mock": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.1.tgz",
-      "integrity": "sha512-ZxKJP5DTUNF2XkpJeZIzvnzF1KkfrhEF6Rz0HGG69fHl6Bgx5/GoU3XyaeFYEjuuKSOOsbqD/k72wFvFxc3iTw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.4.3.tgz",
+      "integrity": "sha512-iktRU/YsxEtumI9zsPctYUk7ptpC+AVLLk1Ax3AsA4g1C+8OOnKDkIQBDHtD5hA/+VtgMd5AWI5gNlcAlt2vxQ==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.4.1",
-        "jest-snapshot": "^29.4.1"
+        "expect": "^29.4.3",
+        "jest-snapshot": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
-      "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.3.tgz",
+      "integrity": "sha512-/6JWbkxHOP8EoS8jeeTd9dTfc9Uawi+43oLKHfp6zzux3U2hqOOVnV3ai4RpDYHOccL6g+5nrxpoc8DmJxtXVQ==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.2.0"
+        "jest-get-type": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.1.tgz",
-      "integrity": "sha512-/1joI6rfHFmmm39JxNfmNAO3Nwm6Y0VoL5fJDy7H1AtWrD1CgRtqJbN9Ld6rhAkGO76qqp4cwhhxJ9o9kYjQMw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.4.3.tgz",
+      "integrity": "sha512-4Hote2MGcCTWSD2gwl0dwbCpBRHhE6olYEuTj8FMowdg3oQWNKr2YuxenPQYZ7+PfqPY1k98wKDU4Z+Hvd4Tiw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.4.1",
-        "jest-mock": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "jest-message-util": "^29.4.3",
+        "jest-mock": "^29.4.3",
+        "jest-util": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.1.tgz",
-      "integrity": "sha512-znoK2EuFytbHH0ZSf2mQK2K1xtIgmaw4Da21R2C/NE/+NnItm5mPEFQmn8gmF3f0rfOlmZ3Y3bIf7bFj7DHxAA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.4.3.tgz",
+      "integrity": "sha512-8BQ/5EzfOLG7AaMcDh7yFCbfRLtsc+09E1RQmRBI4D6QQk4m6NSK/MXo+3bJrBN0yU8A2/VIcqhvsOLFmziioA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/expect": "^29.4.1",
-        "@jest/types": "^29.4.1",
-        "jest-mock": "^29.4.1"
+        "@jest/environment": "^29.4.3",
+        "@jest/expect": "^29.4.3",
+        "@jest/types": "^29.4.3",
+        "jest-mock": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.4.1.tgz",
-      "integrity": "sha512-AISY5xpt2Xpxj9R6y0RF1+O6GRy9JsGa8+vK23Lmzdy1AYcpQn5ItX79wJSsTmfzPKSAcsY1LNt/8Y5Xe5LOSg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.4.3.tgz",
+      "integrity": "sha512-sr2I7BmOjJhyqj9ANC6CTLsL4emMoka7HkQpcoMRlhCbQJjz2zsRzw0BDPiPyEFDXAbxKgGFYuQZiSJ1Y6YoTg==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/console": "^29.4.3",
+        "@jest/test-result": "^29.4.3",
+        "@jest/transform": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@jridgewell/trace-mapping": "^0.3.15",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -1145,9 +1145,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "jest-worker": "^29.4.1",
+        "jest-message-util": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "jest-worker": "^29.4.3",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
-      "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
       "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.25.16"
@@ -1188,9 +1188,9 @@
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.2.0.tgz",
-      "integrity": "sha512-1NX9/7zzI0nqa6+kgpSdKPK+WU1p+SJk3TloWZf5MzPbxri9UEeXX5bWZAPCzbQcyuAzubcdUHA7hcNznmRqWQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.4.3.tgz",
+      "integrity": "sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.15",
@@ -1212,13 +1212,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.1.tgz",
-      "integrity": "sha512-WRt29Lwt+hEgfN8QDrXqXGgCTidq1rLyFqmZ4lmJOpVArC8daXrZWkWjiaijQvgd3aOUj2fM8INclKHsQW9YyQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.4.3.tgz",
+      "integrity": "sha512-Oi4u9NfBolMq9MASPwuWTlC5WvmNRwI4S8YrQg5R5Gi47DYlBe3sh7ILTqi/LGrK1XUE4XY9KZcQJTH1WJCLLA==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/console": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -1227,14 +1227,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.4.1.tgz",
-      "integrity": "sha512-v5qLBNSsM0eHzWLXsQ5fiB65xi49A3ILPSFQKPXzGL4Vyux0DPZAIN7NAFJa9b4BiTDP9MBF/Zqc/QA1vuiJ0w==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.4.3.tgz",
+      "integrity": "sha512-yi/t2nES4GB4G0mjLc0RInCq/cNr9dNwJxcGg8sslajua5Kb4kmozAc+qPLzplhBgfw1vLItbjyHzUN92UXicw==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.4.1",
+        "@jest/test-result": "^29.4.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
+        "jest-haste-map": "^29.4.3",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1242,26 +1242,26 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.1.tgz",
-      "integrity": "sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.4.3.tgz",
+      "integrity": "sha512-8u0+fBGWolDshsFgPQJESkDa72da/EVwvL+II0trN2DR66wMwiQ9/CihaGfHdlLGFzbBZwMykFtxuwFdZqlKwg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@jridgewell/trace-mapping": "^0.3.15",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-util": "^29.4.1",
+        "jest-haste-map": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.4.3",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.0"
+        "write-file-atomic": "^4.0.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -1278,12 +1278,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
-      "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.3.tgz",
+      "integrity": "sha512-bPYfw8V65v17m2Od1cv44FH+SiKW7w2Xu7trhcdTLUmSv85rfKsP+qXSjO4KGJr4dtPSzl/gvslZBXctf1qGEA==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.0",
+        "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -1472,9 +1472,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.21",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -1617,9 +1617,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg=="
+      "version": "18.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
+      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2193,9 +2193,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
-      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -2204,15 +2204,15 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.1.tgz",
-      "integrity": "sha512-xBZa/pLSsF/1sNpkgsiT3CmY7zV1kAsZ9OxxtrFqYucnOuRftXAfcJqcDVyOPeN4lttWTwhLdu0T9f8uvoPEUg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.4.3.tgz",
+      "integrity": "sha512-o45Wyn32svZE+LnMVWv/Z4x0SwtLbh4FyGcYtR20kIWd+rdrDZ9Fzq8Ml3MYLD+mZvEdzCjZsCnYZ2jpJyQ+Nw==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.4.1",
+        "@jest/transform": "^29.4.3",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.4.0",
+        "babel-preset-jest": "^29.4.3",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -2241,9 +2241,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.4.0.tgz",
-      "integrity": "sha512-a/sZRLQJEmsmejQ2rPEUe35nO1+C9dc9O1gplH1SXmJxveQSRUYdBk8yGZG/VOUuZs1u2aHZJusEGoRMbhhwCg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.4.3.tgz",
+      "integrity": "sha512-mB6q2q3oahKphy5V7CpnNqZOCkxxZ9aokf1eh82Dy3jQmg4xvM1tGrh5y6BQUJh4a3Pj9+eLfwvAZ7VNKg7H8Q==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -2279,12 +2279,12 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.4.0.tgz",
-      "integrity": "sha512-fUB9vZflUSM3dO/6M2TCAepTzvA4VkOvl67PjErcrQMGt9Eve7uazaeyCZ2th3UtI7ljpiBJES0F7A1vBRsLZA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.4.3.tgz",
+      "integrity": "sha512-gWx6COtSuma6n9bw+8/F+2PCXrIgxV/D1TJFnp6OyBK2cxPWg0K9p/sriNYeifKjpUkMViWQ09DSWtzJQRETsw==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^29.4.0",
+        "babel-plugin-jest-hoist": "^29.4.3",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
@@ -3272,9 +3272,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
-      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
+      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -4036,16 +4036,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
-      "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.3.tgz",
+      "integrity": "sha512-uC05+Q7eXECFpgDrHdXA4k2rpMyStAYPItEDLyQDo5Ta7fVkJnNA/4zh/OIVkVVNZ1oOK1PipQoyNjuZ6sz6Dg==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "@jest/expect-utils": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.4.3",
+        "jest-message-util": "^29.4.3",
+        "jest-util": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5499,15 +5499,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.1.tgz",
-      "integrity": "sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.4.3.tgz",
+      "integrity": "sha512-XvK65feuEFGZT8OO0fB/QAQS+LGHvQpaadkH5p47/j3Ocqq3xf2pK9R+G0GzgfuhXVxEv76qCOOcMb5efLk6PA==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/core": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.4.1"
+        "jest-cli": "^29.4.3"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -5525,9 +5525,9 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "29.4.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.4.0.tgz",
-      "integrity": "sha512-rnI1oPxgFghoz32Y8eZsGJMjW54UlqT17ycQeCEktcxxwqqKdlj9afl8LNeO0Pbu+h2JQHThQP0BzS67eTRx4w==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.4.3.tgz",
+      "integrity": "sha512-Vn5cLuWuwmi2GNNbokPOEcvrXGSGrqVnPEZV7rC6P7ck07Dyw9RFnvWglnupSh+hGys0ajGtw/bc2ZgweljQoQ==",
       "dev": true,
       "dependencies": {
         "execa": "^5.0.0",
@@ -5538,28 +5538,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.1.tgz",
-      "integrity": "sha512-v02NuL5crMNY4CGPHBEflLzl4v91NFb85a+dH9a1pUNx6Xjggrd8l9pPy4LZ1VYNRXlb+f65+7O/MSIbLir6pA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.4.3.tgz",
+      "integrity": "sha512-Vw/bVvcexmdJ7MLmgdT3ZjkJ3LKu8IlpefYokxiqoZy6OCQ2VAm6Vk3t/qHiAGUXbdbJKJWnc8gH3ypTbB/OBw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/expect": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.4.3",
+        "@jest/expect": "^29.4.3",
+        "@jest/test-result": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.4.1",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-runtime": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-each": "^29.4.3",
+        "jest-matcher-utils": "^29.4.3",
+        "jest-message-util": "^29.4.3",
+        "jest-runtime": "^29.4.3",
+        "jest-snapshot": "^29.4.3",
+        "jest-util": "^29.4.3",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.4.3",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -5568,21 +5568,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.4.1.tgz",
-      "integrity": "sha512-jz7GDIhtxQ37M+9dlbv5K+/FVcIo1O/b1sX3cJgzlQUf/3VG25nvuWzlDC4F1FLLzUThJeWLu8I7JF9eWpuURQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.4.3.tgz",
+      "integrity": "sha512-PiiAPuFNfWWolCE6t3ZrDXQc6OsAuM3/tVW0u27UWc1KE+n/HSn5dSE6B2juqN7WP+PP0jAcnKtGmI4u8GMYCg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/core": "^29.4.3",
+        "@jest/test-result": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "jest-validate": "^29.4.1",
+        "jest-config": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "jest-validate": "^29.4.3",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -5602,31 +5602,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.4.1.tgz",
-      "integrity": "sha512-g7p3q4NuXiM4hrS4XFATTkd+2z0Ml2RhFmFPM8c3WyKwVDNszbl4E7cV7WIx1YZeqqCtqbtTtZhGZWJlJqngzg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.4.3.tgz",
+      "integrity": "sha512-eCIpqhGnIjdUCXGtLhz4gdDoxKSWXKjzNcc5r+0S1GKOp2fwOipx5mRcwa9GB/ArsxJ1jlj2lmlD9bZAsBxaWQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.4.1",
-        "@jest/types": "^29.4.1",
-        "babel-jest": "^29.4.1",
+        "@jest/test-sequencer": "^29.4.3",
+        "@jest/types": "^29.4.3",
+        "babel-jest": "^29.4.3",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.4.1",
-        "jest-environment-node": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-regex-util": "^29.2.0",
-        "jest-resolve": "^29.4.1",
-        "jest-runner": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "jest-validate": "^29.4.1",
+        "jest-circus": "^29.4.3",
+        "jest-environment-node": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.4.3",
+        "jest-runner": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "jest-validate": "^29.4.3",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.4.3",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -5647,24 +5647,24 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
-      "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.3.tgz",
+      "integrity": "sha512-YB+ocenx7FZ3T5O9lMVMeLYV4265socJKtkwgk/6YUz/VsEzYDkiMuMhWzZmxm3wDRQvayJu/PjkjjSkjoHsCA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.3.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.2.0.tgz",
-      "integrity": "sha512-bkxUsxTgWQGbXV5IENmfiIuqZhJcyvF7tU4zJ/7ioTutdz4ToB5Yx6JOFBpgI+TphRY4lhOyCWGNH/QFQh5T6A==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
+      "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -5674,62 +5674,62 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.1.tgz",
-      "integrity": "sha512-QlYFiX3llJMWUV0BtWht/esGEz9w+0i7BHwODKCze7YzZzizgExB9MOfiivF/vVT0GSQ8wXLhvHXh3x2fVD4QQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.4.3.tgz",
+      "integrity": "sha512-1ElHNAnKcbJb/b+L+7j0/w7bDvljw4gTv1wL9fYOczeJrbTbkMGQ5iQPFJ3eFQH19VPTx1IyfePdqSpePKss7Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.2.0",
-        "jest-util": "^29.4.1",
-        "pretty-format": "^29.4.1"
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "pretty-format": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.1.tgz",
-      "integrity": "sha512-x/H2kdVgxSkxWAIlIh9MfMuBa0hZySmfsC5lCsWmWr6tZySP44ediRKDUiNggX/eHLH7Cd5ZN10Rw+XF5tXsqg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.4.3.tgz",
+      "integrity": "sha512-gAiEnSKF104fsGDXNkwk49jD/0N0Bqu2K9+aMQXA6avzsA9H3Fiv1PW2D+gzbOSR705bWd2wJZRFEFpV0tXISg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.4.3",
+        "@jest/fake-timers": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
-        "jest-mock": "^29.4.1",
-        "jest-util": "^29.4.1"
+        "jest-mock": "^29.4.3",
+        "jest-util": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
-      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
+      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.1.tgz",
-      "integrity": "sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.4.3.tgz",
+      "integrity": "sha512-eZIgAS8tvm5IZMtKlR8Y+feEOMfo2pSQkmNbufdbMzMSn9nitgGxF1waM/+LbryO3OkMcKS98SUb+j/cQxp/vQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.2.0",
-        "jest-util": "^29.4.1",
-        "jest-worker": "^29.4.1",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "jest-worker": "^29.4.3",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -5741,46 +5741,46 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.1.tgz",
-      "integrity": "sha512-akpZv7TPyGMnH2RimOCgy+hPmWZf55EyFUvymQ4LMsQP8xSPlZumCPtXGoDhFNhUE2039RApZkTQDKU79p/FiQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.4.3.tgz",
+      "integrity": "sha512-9yw4VC1v2NspMMeV3daQ1yXPNxMgCzwq9BocCwYrRgXe4uaEJPAN0ZK37nFBhcy3cUwEVstFecFLaTHpF7NiGA==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
-      "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.3.tgz",
+      "integrity": "sha512-TTciiXEONycZ03h6R6pYiZlSkvYgT0l8aa49z/DLSGYjex4orMUcafuLXYyyEDWB1RKglq00jzwY00Ei7yFNVg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "pretty-format": "^29.4.1"
+        "jest-diff": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
-      "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.3.tgz",
+      "integrity": "sha512-1Y8Zd4ZCN7o/QnWdMmT76If8LuDv23Z1DRovBj/vcSFNlGCJGoO8D1nJDw1AdyAGUk0myDLFGN5RbNeJyCRGCw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.4.3",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -5789,14 +5789,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.1.tgz",
-      "integrity": "sha512-MwA4hQ7zBOcgVCVnsM8TzaFLVUD/pFWTfbkY953Y81L5ret3GFRZtmPmRFAjKQSdCKoJvvqOu6Bvfpqlwwb0dQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.4.3.tgz",
+      "integrity": "sha512-LjFgMg+xed9BdkPMyIJh+r3KeHt1klXPJYBULXVVAkbTaaKjPX1o1uVCAZADMEp/kOxGTwy/Ot8XbvgItOrHEg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
-        "jest-util": "^29.4.1"
+        "jest-util": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5820,26 +5820,26 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "29.2.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.2.0.tgz",
-      "integrity": "sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
+      "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.1.tgz",
-      "integrity": "sha512-j/ZFNV2lm9IJ2wmlq1uYK0Y/1PiyDq9g4HEGsNTNr3viRbJdV+8Lf1SXIiLZXFvyiisu0qUyIXGBnw+OKWkJwQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.4.3.tgz",
+      "integrity": "sha512-GPokE1tzguRyT7dkxBim4wSx6E45S3bOQ7ZdKEG+Qj0Oac9+6AwJPCk0TZh5Vu0xzeX4afpb+eDmgbmZFFwpOw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
+        "jest-haste-map": "^29.4.3",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.4.1",
-        "jest-validate": "^29.4.1",
+        "jest-util": "^29.4.3",
+        "jest-validate": "^29.4.3",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -5849,43 +5849,43 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.4.1.tgz",
-      "integrity": "sha512-Y3QG3M1ncAMxfjbYgtqNXC5B595zmB6e//p/qpA/58JkQXu/IpLDoLeOa8YoYfsSglBKQQzNUqtfGJJT/qLmJg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.4.3.tgz",
+      "integrity": "sha512-uvKMZAQ3nmXLH7O8WAOhS5l0iWyT3WmnJBdmIHiV5tBbdaDZ1wqtNX04FONGoaFvSOSHBJxnwAVnSn1WHdGVaw==",
       "dev": true,
       "dependencies": {
-        "jest-regex-util": "^29.2.0",
-        "jest-snapshot": "^29.4.1"
+        "jest-regex-util": "^29.4.3",
+        "jest-snapshot": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.4.1.tgz",
-      "integrity": "sha512-8d6XXXi7GtHmsHrnaqBKWxjKb166Eyj/ksSaUYdcBK09VbjPwIgWov1VwSmtupCIz8q1Xv4Qkzt/BTo3ZqiCeg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.4.3.tgz",
+      "integrity": "sha512-GWPTEiGmtHZv1KKeWlTX9SIFuK19uLXlRQU43ceOQ2hIfA5yPEJC7AMkvFKpdCHx6pNEdOD+2+8zbniEi3v3gA==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.4.1",
-        "@jest/environment": "^29.4.1",
-        "@jest/test-result": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/console": "^29.4.3",
+        "@jest/environment": "^29.4.3",
+        "@jest/test-result": "^29.4.3",
+        "@jest/transform": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.2.0",
-        "jest-environment-node": "^29.4.1",
-        "jest-haste-map": "^29.4.1",
-        "jest-leak-detector": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-resolve": "^29.4.1",
-        "jest-runtime": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "jest-watcher": "^29.4.1",
-        "jest-worker": "^29.4.1",
+        "jest-docblock": "^29.4.3",
+        "jest-environment-node": "^29.4.3",
+        "jest-haste-map": "^29.4.3",
+        "jest-leak-detector": "^29.4.3",
+        "jest-message-util": "^29.4.3",
+        "jest-resolve": "^29.4.3",
+        "jest-runtime": "^29.4.3",
+        "jest-util": "^29.4.3",
+        "jest-watcher": "^29.4.3",
+        "jest-worker": "^29.4.3",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -5894,32 +5894,31 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.1.tgz",
-      "integrity": "sha512-UXTMU9uKu2GjYwTtoAw5rn4STxWw/nadOfW7v1sx6LaJYa3V/iymdCLQM6xy3+7C6mY8GfX22vKpgxY171UIoA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.4.3.tgz",
+      "integrity": "sha512-F5bHvxSH+LvLV24vVB3L8K467dt3y3dio6V3W89dUz9nzvTpqd/HcT9zfYKL2aZPvD63vQFgLvaUX/UpUhrP6Q==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.4.1",
-        "@jest/fake-timers": "^29.4.1",
-        "@jest/globals": "^29.4.1",
-        "@jest/source-map": "^29.2.0",
-        "@jest/test-result": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/environment": "^29.4.3",
+        "@jest/fake-timers": "^29.4.3",
+        "@jest/globals": "^29.4.3",
+        "@jest/source-map": "^29.4.3",
+        "@jest/test-result": "^29.4.3",
+        "@jest/transform": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-mock": "^29.4.1",
-        "jest-regex-util": "^29.2.0",
-        "jest-resolve": "^29.4.1",
-        "jest-snapshot": "^29.4.1",
-        "jest-util": "^29.4.1",
-        "semver": "^7.3.5",
+        "jest-haste-map": "^29.4.3",
+        "jest-message-util": "^29.4.3",
+        "jest-mock": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.4.3",
+        "jest-snapshot": "^29.4.3",
+        "jest-util": "^29.4.3",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -5928,9 +5927,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.1.tgz",
-      "integrity": "sha512-l4iV8EjGgQWVz3ee/LR9sULDk2pCkqb71bjvlqn+qp90lFwpnulHj4ZBT8nm1hA1C5wowXLc7MGnw321u0tsYA==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.4.3.tgz",
+      "integrity": "sha512-NGlsqL0jLPDW91dz304QTM/SNO99lpcSYYAjNiX0Ou+sSGgkanKBcSjCfp/pqmiiO1nQaOyLp6XQddAzRcx3Xw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -5939,23 +5938,23 @@
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.4.1",
-        "@jest/transform": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/expect-utils": "^29.4.3",
+        "@jest/transform": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/babel__traverse": "^7.0.6",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.4.1",
+        "expect": "^29.4.3",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.4.1",
-        "jest-get-type": "^29.2.0",
-        "jest-haste-map": "^29.4.1",
-        "jest-matcher-utils": "^29.4.1",
-        "jest-message-util": "^29.4.1",
-        "jest-util": "^29.4.1",
+        "jest-diff": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "jest-haste-map": "^29.4.3",
+        "jest-matcher-utils": "^29.4.3",
+        "jest-message-util": "^29.4.3",
+        "jest-util": "^29.4.3",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.4.1",
+        "pretty-format": "^29.4.3",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -5963,12 +5962,12 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
-      "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.3.tgz",
+      "integrity": "sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -5980,17 +5979,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.1.tgz",
-      "integrity": "sha512-qNZXcZQdIQx4SfUB/atWnI4/I2HUvhz8ajOSYUu40CSmf9U5emil8EDHgE7M+3j9/pavtk3knlZBDsgFvv/SWw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.4.3.tgz",
+      "integrity": "sha512-J3u5v7aPQoXPzaar6GndAVhdQcZr/3osWSgTeKg5v574I9ybX/dTyH0AJFb5XgXIB7faVhf+rS7t4p3lL9qFaw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.4.1",
+        "@jest/types": "^29.4.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.2.0",
+        "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.4.1"
+        "pretty-format": "^29.4.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6009,18 +6008,18 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.4.1.tgz",
-      "integrity": "sha512-vFOzflGFs27nU6h8dpnVRER3O2rFtL+VMEwnG0H3KLHcllLsU8y9DchSh0AL/Rg5nN1/wSiQ+P4ByMGpuybaVw==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.4.3.tgz",
+      "integrity": "sha512-zwlXH3DN3iksoIZNk73etl1HzKyi5FuQdYLnkQKm5BW4n8HpoG59xSwpVdFrnh60iRRaRBGw0gcymIxjJENPcA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.4.1",
-        "@jest/types": "^29.4.1",
+        "@jest/test-result": "^29.4.3",
+        "@jest/types": "^29.4.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.4.1",
+        "jest-util": "^29.4.3",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -6055,13 +6054,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.1.tgz",
-      "integrity": "sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.4.3.tgz",
+      "integrity": "sha512-GLHN/GTAAMEy5BFdvpUfzr9Dr80zQqBrh0fz1mtRMe05hqP45+HfQltu7oTBfduD0UeZs09d+maFtFYAXFWvAA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.4.1",
+        "jest-util": "^29.4.3",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -6277,9 +6276,9 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "node_modules/kuzzle": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/kuzzle/-/kuzzle-2.20.2.tgz",
-      "integrity": "sha512-Be++tFidn7OUWk5dubKGyagTg+XA6LMe9FIl8DjLCqjw4JRxiuxPgPhpnJb0Bu75YJyGKHpphPcVNufVicUgiQ==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/kuzzle/-/kuzzle-2.21.0.tgz",
+      "integrity": "sha512-pehceh9D0+6BnazoZSeCByuNjiQlOwKH3tAY3aPdbl75UDycQZQC6A8lIxt3Tcv4syeVab1fqp8LtiBsMpmzkw==",
       "dependencies": {
         "@elastic/elasticsearch": "https://github.com/elastic/elasticsearch-js/archive/refs/tags/v7.13.0.tar.gz",
         "aedes": "^0.46.3",
@@ -6425,9 +6424,9 @@
       }
     },
     "node_modules/kuzzle-sdk": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.10.5.tgz",
-      "integrity": "sha512-Iy2mLReKIHZWWDZoOkHoPSyQx8hDF5Zn3fwYnljW39cfjfM+dqvwg4c+2ltNQp077LppWLpyZSv+jxFOOOHKQA==",
+      "version": "7.10.6",
+      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.10.6.tgz",
+      "integrity": "sha512-OJmJMP0fy+GlH/va2wRmL3OGqbBFM/V8cmr82ub2lfog++w10sL+vrq6CRgO3jAGPuALN5D2AqtfSwA/slWxuQ==",
       "dependencies": {
         "min-req-promise": "^1.0.1",
         "ws": "^8.8.1"
@@ -7933,12 +7932,12 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
-      "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.3.tgz",
+      "integrity": "sha512-cvpcHTc42lcsvOOAzd3XuNWTcvk1Jmnzqeu+WsOuiPmxUJTnkbAcFNsRKvEpBEUFVUgy/GTZLulZDcDEi+CIlA==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.0",
+        "@jest/schemas": "^29.4.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -9504,9 +9503,9 @@
       "dev": true
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
-      "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
+      "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -9807,16 +9806,16 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-      "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/ws": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "kuzzle-plugin-commons": "https://github.com/kuzzleio/kuzzle-plugin-commons/archive/refs/tags/1.0.5.tar.gz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,21 +32,21 @@
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",
-    "@types/node": "^18.13.0",
-    "axios": "^1.3.2",
+    "@types/node": "^18.14.1",
+    "axios": "^1.3.4",
     "cucumber": "^6.0.5",
     "ergol": "^1.0.2",
     "eslint-plugin-kuzzle": "^0.0.6",
-    "jest": "^29.4.1",
-    "kuzzle": "^2.20.2",
-    "kuzzle-sdk": "^7.10.5",
+    "jest": "^29.4.3",
+    "kuzzle": "^2.21.0",
+    "kuzzle-sdk": "^7.10.6",
     "should": "^13.2.3",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "kuzzle": "^2.20.2"
+    "kuzzle": "^2.21.0"
   },
   "files": [
     "dist/**/*"

--- a/tests/modules/devices/action-receive-measure.test.ts
+++ b/tests/modules/devices/action-receive-measure.test.ts
@@ -122,6 +122,7 @@ describe("DeviceController: receiveMeasure", () => {
     expect(device._source).toMatchObject({
       measures: {
         temperature: {
+          originId: "DummyTemp-linked1",
           values: {
             temperature: 25.5,
           },


### PR DESCRIPTION
## What does this PR do ?

Add the `originId` property to `EmbeddedMeasure` which contains the Device ID when the measure comes from a Device.

It's more easier to retrieve the device who sent the measure, otherwise developers needs to find the device ID in the `linkedDevices` array from the measure name.