### PR TITLE
Fix action name link => _link

### DIFF
--- a/doc/2/controllers/devices/linkAsset/index.md
+++ b/doc/2/controllers/devices/linkAsset/index.md
@@ -16,7 +16,7 @@ This action is idempotent for a device, meaning that you can replace an existing
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/:engineId/devices/:_id/link/:assetId
+URL: http://kuzzle:7512/_/device-manager/:engineId/devices/:_id/_link/:assetId
 Method: PUT
 ```
 


### PR DESCRIPTION
## Fix action name link => _link
![image](https://user-images.githubusercontent.com/78204354/225614428-acc114a1-b918-41ff-b8cb-8d461e7a026c.png)

### How should this be manually tested?

  - Step 1 : clone and run a backend
  - Step 2 : try to link a device to a payload using the _link in the query string
