### PR TITLE
Fix engine creation

### DIFF
--- a/lib/core/DeviceManagerEngine.ts
+++ b/lib/core/DeviceManagerEngine.ts
@@ -98,17 +98,10 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
     promises.push(this.createMeasuresCollection(index, group));
 
-    promises.push(this.engineConfigManager.createCollection(index));
-
-    await Promise.all(promises);
+    const collections = await Promise.all(promises);
 
     return {
-      collections: [
-        InternalCollection.ASSETS,
-        this.engineConfigManager.collection,
-        InternalCollection.DEVICES,
-        InternalCollection.MEASURES,
-      ],
+      collections: [this.engineConfigManager.collection, ...collections],
     };
   }
 


### PR DESCRIPTION
## What does this PR do ?

1) remove unnecessary call to `engineConfigManager.createCollection` since it's already done in `AbstractEngine` class from `kuzzle-plugin-commons`

2) add the asset history collection in the method return