### PR TITLE
ModelService upsert -> createOrReplace

### DIFF
--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -76,12 +76,13 @@ export class ModelService {
 
     this.checkDefaultValues(metadataMappings, defaultMetadata);
 
-    const assetModel = await this.sdk.document.upsert<AssetModelContent>(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-      ModelSerializer.id<AssetModelContent>("asset", modelContent),
-      modelContent
-    );
+    const assetModel =
+      await this.sdk.document.createOrReplace<AssetModelContent>(
+        this.config.adminIndex,
+        InternalCollection.MODELS,
+        ModelSerializer.id<AssetModelContent>("asset", modelContent),
+        modelContent
+      );
 
     await this.sdk.collection.refresh(
       this.config.adminIndex,
@@ -132,12 +133,13 @@ export class ModelService {
       type: "device",
     };
 
-    const assetModel = await this.sdk.document.upsert<DeviceModelContent>(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-      ModelSerializer.id<DeviceModelContent>("device", modelContent),
-      modelContent
-    );
+    const assetModel =
+      await this.sdk.document.createOrReplace<DeviceModelContent>(
+        this.config.adminIndex,
+        InternalCollection.MODELS,
+        ModelSerializer.id<DeviceModelContent>("device", modelContent),
+        modelContent
+      );
 
     await this.sdk.collection.refresh(
       this.config.adminIndex,
@@ -157,12 +159,13 @@ export class ModelService {
       type: "measure",
     };
 
-    const assetModel = await this.sdk.document.upsert<MeasureModelContent>(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-      ModelSerializer.id<MeasureModelContent>("measure", modelContent),
-      modelContent
-    );
+    const assetModel =
+      await this.sdk.document.createOrReplace<MeasureModelContent>(
+        this.config.adminIndex,
+        InternalCollection.MODELS,
+        ModelSerializer.id<MeasureModelContent>("measure", modelContent),
+        modelContent
+      );
 
     await this.sdk.collection.refresh(
       this.config.adminIndex,

--- a/tests/scenario/migrated/model-controller.test.ts
+++ b/tests/scenario/migrated/model-controller.test.ts
@@ -58,7 +58,10 @@ describe("features/Model/Controller", () => {
       body: {
         engineGroup: "commons",
         model: "Plane",
-        metadataMappings: { company2: { type: "keyword" } },
+        metadataMappings: {
+          company: { type: "keyword" },
+          company2: { type: "keyword" },
+        },
         measures: [
           { name: "temperatureExt", type: "temperature" },
           { name: "position", type: "position" },
@@ -230,7 +233,10 @@ describe("features/Model/Controller", () => {
           { type: "battery", name: "battery" },
           { type: "temperature", name: "temperature" },
         ],
-        metadataMappings: { network2: { type: "keyword" } },
+        metadataMappings: {
+          network: { type: "keyword" },
+          network2: { type: "keyword" },
+        },
       },
     });
 
@@ -360,7 +366,10 @@ describe("features/Model/Controller", () => {
       action: "writeMeasure",
       body: {
         type: "presence",
-        valuesMappings: { presence2: { type: "boolean" } },
+        valuesMappings: {
+          presence: { type: "boolean" },
+          presence2: { type: "boolean" },
+        },
       },
     });
 

--- a/tests/scenario/modules/models/model-controller.test.ts
+++ b/tests/scenario/modules/models/model-controller.test.ts
@@ -1,0 +1,230 @@
+import { KDocument } from "kuzzle";
+import {
+  ApiModelWriteAssetRequest,
+  ApiModelWriteDeviceRequest,
+  ApiModelWriteMeasureRequest,
+  AssetModelContent,
+  DeviceModelContent,
+  MeasureModelContent,
+} from "../../../../lib/modules/model";
+import { setupHooks } from "../../../helpers";
+
+jest.setTimeout(10000);
+
+describe("features/Model/Controller", () => {
+  const sdk = setupHooks();
+
+  it("Should allow deleting metadata mappings and measures from an Asset model", async () => {
+    await sdk.query<ApiModelWriteAssetRequest>({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroup: "commons",
+        model: "Plane",
+        metadataMappings: {
+          company: { type: "keyword" },
+          company2: { type: "keyword" },
+        },
+        measures: [
+          { name: "temperatureExt", type: "temperature" },
+          { name: "position", type: "position" },
+        ],
+      },
+    });
+
+    await expect(
+      sdk.document.get<AssetModelContent>(
+        "device-manager",
+        "models",
+        "model-asset-Plane"
+      )
+    ).resolves.toMatchObject<Partial<KDocument<AssetModelContent>>>({
+      _source: {
+        type: "asset",
+        engineGroup: "commons",
+        asset: {
+          model: "Plane",
+          metadataMappings: {
+            company: { type: "keyword" },
+            company2: { type: "keyword" },
+          },
+          defaultMetadata: {},
+          measures: [
+            { name: "temperatureExt", type: "temperature" },
+            { name: "position", type: "position" },
+          ],
+        },
+      },
+    });
+
+    await sdk.query<ApiModelWriteAssetRequest>({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroup: "commons",
+        model: "Plane",
+        metadataMappings: {
+          company: { type: "keyword" },
+        },
+        measures: [{ name: "temperatureExt", type: "temperature" }],
+      },
+    });
+
+    await expect(
+      sdk.document.get<AssetModelContent>(
+        "device-manager",
+        "models",
+        "model-asset-Plane"
+      )
+    ).resolves.toMatchObject<Partial<KDocument<AssetModelContent>>>({
+      _source: {
+        type: "asset",
+        engineGroup: "commons",
+        asset: {
+          model: "Plane",
+          metadataMappings: {
+            company: { type: "keyword" },
+          },
+          defaultMetadata: {},
+          measures: [{ name: "temperatureExt", type: "temperature" }],
+        },
+      },
+    });
+  });
+
+  it("Should allow deleting metadata mappings and measures from a Device model", async () => {
+    await sdk.query<ApiModelWriteDeviceRequest>({
+      controller: "device-manager/models",
+      action: "writeDevice",
+      body: {
+        model: "Zigbee",
+        measures: [
+          { type: "battery", name: "battery" },
+          { type: "temperature", name: "temperature" },
+        ],
+        metadataMappings: {
+          network: { type: "keyword" },
+          network2: { type: "keyword" },
+        },
+      },
+    });
+
+    await expect(
+      sdk.document.get<DeviceModelContent>(
+        "device-manager",
+        "models",
+        "model-device-Zigbee"
+      )
+    ).resolves.toMatchObject<Partial<KDocument<DeviceModelContent>>>({
+      _source: {
+        type: "device",
+        device: {
+          model: "Zigbee",
+          metadataMappings: {
+            network: { type: "keyword" },
+            network2: { type: "keyword" },
+          },
+          defaultMetadata: {},
+          measures: [
+            { type: "battery", name: "battery" },
+            { type: "temperature", name: "temperature" },
+          ],
+        },
+      },
+    });
+
+    await sdk.query<ApiModelWriteDeviceRequest>({
+      controller: "device-manager/models",
+      action: "writeDevice",
+      body: {
+        model: "Zigbee",
+        measures: [{ type: "battery", name: "battery" }],
+        metadataMappings: {
+          network: { type: "keyword" },
+        },
+      },
+    });
+
+    await expect(
+      sdk.document.get<DeviceModelContent>(
+        "device-manager",
+        "models",
+        "model-device-Zigbee"
+      )
+    ).resolves.toMatchObject<Partial<KDocument<DeviceModelContent>>>({
+      _source: {
+        type: "device",
+        device: {
+          model: "Zigbee",
+          metadataMappings: {
+            network: { type: "keyword" },
+          },
+          defaultMetadata: {},
+          measures: [{ type: "battery", name: "battery" }],
+        },
+      },
+    });
+  });
+
+  it("Should allow deleting values mappings from a Measure model", async () => {
+    await sdk.query<ApiModelWriteMeasureRequest>({
+      controller: "device-manager/models",
+      action: "writeMeasure",
+      body: {
+        type: "presence",
+        valuesMappings: {
+          presence: { type: "boolean" },
+          presence2: { type: "boolean" },
+        },
+      },
+    });
+
+    await expect(
+      sdk.document.get<MeasureModelContent>(
+        "device-manager",
+        "models",
+        "model-measure-presence"
+      )
+    ).resolves.toMatchObject<Partial<KDocument<MeasureModelContent>>>({
+      _source: {
+        type: "measure",
+        measure: {
+          type: "presence",
+          valuesMappings: {
+            presence: { type: "boolean" },
+            presence2: { type: "boolean" },
+          },
+        },
+      },
+    });
+
+    await sdk.query<ApiModelWriteMeasureRequest>({
+      controller: "device-manager/models",
+      action: "writeMeasure",
+      body: {
+        type: "presence",
+        valuesMappings: {
+          presence: { type: "boolean" },
+        },
+      },
+    });
+
+    await expect(
+      sdk.document.get<MeasureModelContent>(
+        "device-manager",
+        "models",
+        "model-measure-presence"
+      )
+    ).resolves.toMatchObject<Partial<KDocument<MeasureModelContent>>>({
+      _source: {
+        type: "measure",
+        measure: {
+          type: "presence",
+          valuesMappings: {
+            presence: { type: "boolean" },
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do ?
This PR changes the `document.upsert` calls in `ModelService` into `document.createOrReplace` calls, in order to match the behavior described in the documentation.

It also updates the related tests.