### PR TITLE
Full path nested metadata when create/update assets

### DIFF
--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -129,7 +129,7 @@ export class AssetService {
     engineId: string,
     assetId: string
   ): Promise<KDocument<AssetContent>> {
-    return await this.sdk.document.get<AssetContent>(
+    return this.sdk.document.get<AssetContent>(
       engineId,
       InternalCollection.ASSETS,
       assetId

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -4,7 +4,7 @@ import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import { MeasureContent } from "../measure/";
 import { AskDeviceUnlinkAsset } from "../device";
-import { EmbeddedMeasure, Metadata, lock, ask } from "../shared";
+import { EmbeddedMeasure, Metadata, lock, ask, flattenObject } from "../shared";
 import {
   DeviceManagerConfiguration,
   InternalCollection,
@@ -129,13 +129,11 @@ export class AssetService {
     engineId: string,
     assetId: string
   ): Promise<KDocument<AssetContent>> {
-    const asset = await this.sdk.document.get<AssetContent>(
+    return await this.sdk.document.get<AssetContent>(
       engineId,
       InternalCollection.ASSETS,
       assetId
     );
-
-    return asset;
   }
 
   /**
@@ -166,12 +164,11 @@ export class AssetService {
         { refresh, source: true }
       );
 
-      // @todo fix the metadata path for nested metadata
       await this.assetHistoryService.add<AssetHistoryEventMetadata>(
         engineId,
         {
           metadata: {
-            names: Object.keys(updatedPayload.metadata),
+            names: Object.keys(flattenObject(updatedPayload.metadata)),
           },
           name: "metadata",
         },
@@ -245,7 +242,7 @@ export class AssetService {
         engineId,
         {
           metadata: {
-            names: Object.keys(asset._source.metadata),
+            names: Object.keys(flattenObject(asset._source.metadata)),
           },
           name: "metadata",
         },

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -4,18 +4,21 @@ import { Metadata } from "../../shared";
 
 import { AssetContent } from "./AssetContent";
 
+export type AssetHistoryMetadata = {
+  names: string[];
+};
+
 export type AssetHistoryEventMeasure = {
   name: "measure";
   measure: {
     names: string[];
   };
+  metadata?: AssetHistoryMetadata;
 };
 
 export type AssetHistoryEventMetadata = {
   name: "metadata";
-  metadata: {
-    names: string[];
-  };
+  metadata: AssetHistoryMetadata;
 };
 
 export type AssetHistoryEventLink = {

--- a/tests/scenario/modules/assets/asset-history.test.ts
+++ b/tests/scenario/modules/assets/asset-history.test.ts
@@ -112,12 +112,11 @@ describe("DeviceController: receiveMeasure", () => {
 
     await sdk.collection.refresh("engine-ayse", "assets");
 
-    const result2 = await sdk.document.get<AssetContent>(
+    expect((await sdk.document.get<AssetContent>(
       "engine-ayse",
       "assets",
       "Container-linked1"
-    );
-    expect(result2._source.metadata).toMatchObject({
+    ))._source.metadata).toMatchObject({
       height: 11,
       person: {
         company: "Kuzzle",
@@ -179,12 +178,11 @@ describe("DeviceController: receiveMeasure", () => {
 
     await sdk.collection.refresh("engine-ayse", "assets");
 
-    const result2 = await sdk.document.get<AssetContent>(
+    expect((await sdk.document.get<AssetContent>(
       "engine-ayse",
       "assets",
       "Container-linked3"
-    );
-    expect(result2._source.metadata).toMatchObject({
+    ))._source.metadata).toMatchObject({
       height: 20,
       person: {
         company: "Kuzzle",

--- a/tests/scenario/modules/assets/asset-history.test.ts
+++ b/tests/scenario/modules/assets/asset-history.test.ts
@@ -112,11 +112,15 @@ describe("DeviceController: receiveMeasure", () => {
 
     await sdk.collection.refresh("engine-ayse", "assets");
 
-    expect((await sdk.document.get<AssetContent>(
-      "engine-ayse",
-      "assets",
-      "Container-linked1"
-    ))._source.metadata).toMatchObject({
+    expect(
+      (
+        await sdk.document.get<AssetContent>(
+          "engine-ayse",
+          "assets",
+          "Container-linked1"
+        )
+      )._source.metadata
+    ).toMatchObject({
       height: 11,
       person: {
         company: "Kuzzle",
@@ -178,11 +182,15 @@ describe("DeviceController: receiveMeasure", () => {
 
     await sdk.collection.refresh("engine-ayse", "assets");
 
-    expect((await sdk.document.get<AssetContent>(
-      "engine-ayse",
-      "assets",
-      "Container-linked3"
-    ))._source.metadata).toMatchObject({
+    expect(
+      (
+        await sdk.document.get<AssetContent>(
+          "engine-ayse",
+          "assets",
+          "Container-linked3"
+        )
+      )._source.metadata
+    ).toMatchObject({
       height: 20,
       person: {
         company: "Kuzzle",

--- a/tests/scenario/modules/assets/asset-history.test.ts
+++ b/tests/scenario/modules/assets/asset-history.test.ts
@@ -1,4 +1,4 @@
-import { AssetHistoryContent } from "../../../../index";
+import { AssetContent, AssetHistoryContent } from "../../../../index";
 
 import { sendDummyTempPayloads, setupHooks } from "../../../helpers";
 
@@ -41,6 +41,9 @@ describe("DeviceController: receiveMeasure", () => {
         deviceEUI: "linked1",
         temperature: 21,
         metadata: {
+          // Specify a string for test pipes (see in tests/application/tests/pipes.ts), add in metadata:
+          //  weight = 42042;
+          //  trailer.capacity = 2048;
           color: "test-metadata-history-with-measure",
         },
       },
@@ -64,6 +67,131 @@ describe("DeviceController: receiveMeasure", () => {
         metadata: {
           names: ["weight", "trailer.capacity"],
         },
+      },
+    });
+  });
+
+  it("should add a metadata event to the history entry when update an asset", async () => {
+    await sdk.query({
+      controller: "device-manager/assets",
+      action: "update",
+      engineId: "engine-ayse",
+      _id: "Container-linked1",
+      body: {
+        metadata: {
+          trailer: {
+            capacity: 1234,
+            weight: 128,
+          },
+          person: {
+            company: "Kuzzle",
+          },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("engine-ayse", "assets-history");
+
+    const result = await sdk.document.search<AssetHistoryContent>(
+      "engine-ayse",
+      "assets-history",
+      {
+        sort: { "_kuzzle_info.createdAt": "desc" },
+      }
+    );
+
+    expect(result.hits[0]._source).toMatchObject({
+      id: "Container-linked1",
+      event: {
+        name: "metadata",
+        metadata: {
+          names: ["trailer.capacity", "trailer.weight", "person.company"],
+        },
+      },
+    });
+
+    await sdk.collection.refresh("engine-ayse", "assets");
+
+    const result2 = await sdk.document.get<AssetContent>(
+      "engine-ayse",
+      "assets",
+      "Container-linked1"
+    );
+    expect(result2._source.metadata).toMatchObject({
+      height: 11,
+      person: {
+        company: "Kuzzle",
+      },
+      trailer: {
+        capacity: 1234,
+        weight: 128,
+      },
+    });
+  });
+
+  it("should add a metadata event to the history entry when create an asset", async () => {
+    await sdk.query({
+      controller: "device-manager/assets",
+      action: "create",
+      engineId: "engine-ayse",
+      body: {
+        model: "Container",
+        reference: "linked3",
+        metadata: {
+          trailer: {
+            capacity: 1234,
+            weight: 128,
+          },
+          person: {
+            company: "Kuzzle",
+          },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("engine-ayse", "assets-history");
+
+    const result = await sdk.document.search<AssetHistoryContent>(
+      "engine-ayse",
+      "assets-history",
+      {
+        sort: { "_kuzzle_info.createdAt": "desc" },
+      }
+    );
+
+    // Update metadata from:  { weight: 10, height: 11, trailer: { weight: 128, capacity: 1024 } }
+    // to:                    { trailer: { weight: 128, capacity: 1234 }, person: { company: 'Kuzzle' } }
+    expect(result.hits[0]._source).toMatchObject({
+      id: "Container-linked3",
+      event: {
+        name: "metadata",
+        metadata: {
+          names: [
+            "weight",
+            "height",
+            "trailer.capacity",
+            "trailer.weight",
+            "person.company",
+          ],
+        },
+      },
+    });
+
+    await sdk.collection.refresh("engine-ayse", "assets");
+
+    const result2 = await sdk.document.get<AssetContent>(
+      "engine-ayse",
+      "assets",
+      "Container-linked3"
+    );
+    expect(result2._source.metadata).toMatchObject({
+      height: 20,
+      person: {
+        company: "Kuzzle",
+      },
+      trailer: {
+        capacity: 1234,
+        weight: 128,
       },
     });
   });


### PR DESCRIPTION
- When an asset is created or updated, we saved the complete paths in asset history document.

Closes #276 