### PR TITLE
Split tsconfig for tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,11 @@
 {
-  "plugins": ["kuzzle"],
+  "plugins": ["kuzzle", "jest"],
   "extends": [
     "plugin:kuzzle/default",
     "plugin:kuzzle/node",
-    "plugin:kuzzle/typescript"
+    "plugin:kuzzle/typescript",
+    "plugin:jest/recommended",
+    "plugin:jest/style"
   ],
   "overrides": [
     {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,9 +2,9 @@ import type { Config } from "@jest/types";
 
 // Sync object
 const config: Config.InitialOptions = {
-  verbose: true,
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
+    "^.+\\.tsx?$": ["ts-jest", { tsconfig: "./tests/tsconfig.json" }],
   },
+  verbose: true,
 };
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/node": "^18.15.3",
         "axios": "^1.3.4",
         "ergol": "^1.0.2",
+        "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-kuzzle": "^0.0.6",
         "jest": "^29.5.0",
         "kuzzle": "^2.21.1",
@@ -3589,6 +3590,30 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.10.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-plugin-kuzzle": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/node": "^18.15.3",
     "axios": "^1.3.4",
     "ergol": "^1.0.2",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-kuzzle": "^0.0.6",
     "jest": "^29.5.0",
     "kuzzle": "^2.21.1",

--- a/tests/scenario/modules/devices/action-receive-measure.test.ts
+++ b/tests/scenario/modules/devices/action-receive-measure.test.ts
@@ -114,8 +114,8 @@ describe("DeviceController: receiveMeasure", () => {
   });
 
   it("should raise an error when receiving a undeclared measure", async () => {
-    try {
-      await sdk.query<
+    await expect(
+      sdk.query<
         ApiDeviceReceiveMeasuresRequest,
         ApiDeviceReceiveMeasuresResult
       >({
@@ -135,11 +135,9 @@ describe("DeviceController: receiveMeasure", () => {
             },
           ],
         },
-      });
-    } catch (error) {
-      expect(error.message).toBe(
-        'Measure "temperatureInternal" is not declared for this device model.'
-      );
-    }
+      })
+    ).rejects.toThrow(
+      'Measure "temperatureInternal" is not declared for this device model.'
+    );
   });
 });

--- a/tests/scenario/modules/devices/action-scrud.test.ts
+++ b/tests/scenario/modules/devices/action-scrud.test.ts
@@ -105,8 +105,8 @@ describe("Device SCRUD", () => {
   });
 
   it("should return an error when creating device of unknown model", async () => {
-    try {
-      await sdk.query<ApiDeviceCreateRequest, ApiDeviceCreateResult>({
+    await expect(
+      sdk.query<ApiDeviceCreateRequest, ApiDeviceCreateResult>({
         controller: "device-manager/devices",
         action: "create",
         engineId: "engine-ayse",
@@ -114,9 +114,7 @@ describe("Device SCRUD", () => {
           model: "NotExisting",
           reference: "scrudme",
         },
-      });
-    } catch (error) {
-      expect(error.message).toBe('Unknown Device model "NotExisting".');
-    }
+      })
+    ).rejects.toThrow('Unknown Device model "NotExisting".');
   });
 });

--- a/tests/scenario/modules/ingestion-pipeline/propagation.test.ts
+++ b/tests/scenario/modules/ingestion-pipeline/propagation.test.ts
@@ -28,7 +28,7 @@ describe("Ingestion Pipeline: propagation", () => {
       (m) => m._source.type === "temperature"
     );
 
-    expect(batteryMeasure?._source.asset).toBe(null);
+    expect(batteryMeasure?._source.asset).toBeNull();
 
     for (const temperatureMeasure of temperatureMeasures) {
       expect(temperatureMeasure._source.asset?._id).toBe("Container-linked1");

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [ "**/*.ts" ],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
   "rootDir": "lib/",
   "include": [
     "lib/**/*.ts",
-    "tests/**/*.ts",
+    "tests/application/**/*.ts",
     "index.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## What does this PR do ?
This PR splits the Typescript config in order to avoid emitting test scenarios in production code.
It also adds linting to the tests.