### PR TITLE
Allow JSONObject in metadata

### DIFF
--- a/lib/modules/shared/types/Metadata.ts
+++ b/lib/modules/shared/types/Metadata.ts
@@ -1,9 +1,12 @@
+import { JSONObject } from "kuzzle-sdk";
+
 export type MetadataValue =
   | boolean
   | number
   | string
   | { lat: number; lon: number }
-  | null;
+  | null
+  | JSONObject;
 
 export type Metadata = Record<
   string,


### PR DESCRIPTION
## What does this PR do ?

Allow to specify nested metadata

Example:
```js
  metadata: {
    geofence: {
      name: 'Amazon Saran',
      group: 'warehouse',
      polygon: [
        // array of coordinates
      ],
      disabled: false,
    },
  },
```