### PR TITLE
Export default mappings

### DIFF
--- a/lib/modules/asset/collections/assetsHistoryMappings.ts
+++ b/lib/modules/asset/collections/assetsHistoryMappings.ts
@@ -1,3 +1,8 @@
+/**
+ * Base mappings for the "assetsHistory" collection.
+ *
+ * Those mappings does not contains the `asset` mappings.
+ */
 export const assetsHistoryMappings = {
   dynamic: "strict",
   properties: {

--- a/lib/modules/asset/collections/assetsMappings.ts
+++ b/lib/modules/asset/collections/assetsMappings.ts
@@ -1,3 +1,8 @@
+/**
+ * Base mappings for the "assets" collection.
+ *
+ * Those mappings does not contains the `measures` and `metadata` mappings.
+ */
 export const assetsMappings = {
   dynamic: "strict",
   properties: {

--- a/lib/modules/asset/exports.ts
+++ b/lib/modules/asset/exports.ts
@@ -4,3 +4,5 @@ export * from "./types/AssetEvents";
 export * from "./types/AssetApi";
 export * from "./roles/RoleAssetsAdmin";
 export * from "./roles/RoleAssetsReader";
+export * from "./collections/assetsMappings";
+export * from "./collections/assetsHistoryMappings";

--- a/lib/modules/device/collections/deviceMappings.ts
+++ b/lib/modules/device/collections/deviceMappings.ts
@@ -1,3 +1,8 @@
+/**
+ * Base mappings for the "devices" collection.
+ *
+ * Those mappings does not contains the `measures` and `metadata` mappings.
+ */
 export const devicesMappings = {
   dynamic: "strict",
   properties: {

--- a/lib/modules/device/exports.ts
+++ b/lib/modules/device/exports.ts
@@ -4,3 +4,4 @@ export * from "./types/DeviceEvents";
 export * from "./roles/RoleDevicesAdmin";
 export * from "./roles/RoleDevicesPlatformAdmin";
 export * from "./roles/RoleDevicesReader";
+export * from "./collections/deviceMappings";

--- a/lib/modules/measure/collections/measuresMappings.ts
+++ b/lib/modules/measure/collections/measuresMappings.ts
@@ -1,3 +1,8 @@
+/**
+ * Base mappings for the "measures" collection.
+ *
+ * Those mappings does not contains the `values` mappings and `asset.metadata` mappings.
+ */
 export const measuresMappings = {
   dynamic: "strict",
   properties: {

--- a/lib/modules/measure/exports.ts
+++ b/lib/modules/measure/exports.ts
@@ -4,3 +4,4 @@ export * from "./types/MeasureDefinition";
 export * from "./measures";
 export * from "./roles/RoleMeasuresAdmin";
 export * from "./roles/RoleMeasuresReader";
+export * from "./collections/measuresMappings";

--- a/lib/modules/model/collections/modelsMappings.ts
+++ b/lib/modules/model/collections/modelsMappings.ts
@@ -2,6 +2,9 @@ import { CollectionMappings } from "kuzzle";
 
 /* eslint-disable sort-keys */
 
+/**
+ * Mappings for models configuration documents
+ */
 export const modelsMappings: CollectionMappings = {
   dynamic: "strict",
   properties: {


### PR DESCRIPTION
## What does this PR do ?

Export the base mappings for the plugin collection.

This can be used to define other collection based on KDM collections.

Example usage https://github.com/kuzzleio/kuzzle-iot-backend/pull/18