### PR TITLE
Add `persist:before` event to the ingestion pipeline

### DIFF
--- a/doc/2/concepts/measures-ingestion/index.md
+++ b/doc/2/concepts/measures-ingestion/index.md
@@ -119,6 +119,7 @@ This method takes the raw data frame as a parameter and can indicate that:
 Depending on the result of the `validate` method, the API action will return either a `200` status (Case 1 and 2) or a `4**` status (case 3).
 
 For each case, a state and a reason is stored inside the payload document:
+
 1. the payload has a VALID state.
 2. the payload is discarded by user validation and has a SKIP state and a dedicated reason (which can be overridden by throwing a SkipError exception).
 3. the payload has an ERROR state and a reason equal to the error message.
@@ -278,6 +279,10 @@ The `device-manager:measures:process:before` event is triggered with an object c
 ::: info
 An isolated version of the event is also available: `engine:<engine-id>:device-manager:measures:process:before`
 :::
+
+Another event is triggered after updating the asset and the device with the latest measures but before being persisted: `device-manager:measures:persist:after`.
+
+The object passed to the event is the same as for the previous event.
 
 ### Enrich existing measures
 

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -26,8 +26,10 @@ import { ask, keepStack, lock, Metadata, objectDiff, onAsk } from "../shared";
 import { DecodedMeasurement, MeasureContent } from "./types/MeasureContent";
 import {
   AskMeasureIngest,
+  EventMeasurePersistBefore,
   EventMeasureProcessAfter,
   EventMeasureProcessBefore,
+  TenantEventMeasurePersistBefore,
   TenantEventMeasureProcessAfter,
   TenantEventMeasureProcessBefore,
 } from "./types/MeasureEvents";
@@ -137,14 +139,17 @@ export class MeasureService {
         assetStates = await this.updateAssetMeasures(asset, measures);
       }
 
-      await this.app.trigger("device-manager:measures:persist:before", {
-        asset,
-        device,
-        measures,
-      });
+      await this.app.trigger<EventMeasurePersistBefore>(
+        "device-manager:measures:persist:before",
+        {
+          asset,
+          device,
+          measures,
+        }
+      );
 
       if (engineId) {
-        await this.app.trigger(
+        await this.app.trigger<TenantEventMeasurePersistBefore>(
           `engine:${engineId}:device-manager:measures:persist:before`,
           { asset, device, measures }
         );

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -137,6 +137,19 @@ export class MeasureService {
         assetStates = await this.updateAssetMeasures(asset, measures);
       }
 
+      await this.app.trigger("device-manager:measures:persist:before", {
+        asset,
+        device,
+        measures,
+      });
+
+      if (engineId) {
+        await this.app.trigger(
+          `engine:${engineId}:device-manager:measures:persist:before`,
+          { asset, device, measures }
+        );
+      }
+
       const promises = [];
 
       promises.push(

--- a/lib/modules/measure/types/MeasureEvents.ts
+++ b/lib/modules/measure/types/MeasureEvents.ts
@@ -26,28 +26,63 @@ export type AskMeasureIngest = {
  * Event before starting to process new measures.
  *
  * Useful to enrich measures before they are saved.
- *
- * Only measures documents can be modified
  */
 export type EventMeasureProcessBefore = {
   name: "device-manager:measures:process:before";
 
   args: [
     {
-      readonly asset: KDocument<AssetContent>;
-      readonly device: KDocument<DeviceContent>;
+      asset: KDocument<AssetContent>;
+      device: KDocument<DeviceContent>;
       measures: MeasureContent[];
     }
   ];
 };
 
+/**
+ * Tenant event before starting to process new measures.
+ *
+ * Useful to enrich measures before they are saved.
+ */
 export type TenantEventMeasureProcessBefore = {
   name: `engine:${string}:device-manager:measures:process:before`;
 
   args: [
     {
-      readonly asset: KDocument<AssetContent>;
-      readonly device: KDocument<DeviceContent>;
+      asset: KDocument<AssetContent>;
+      device: KDocument<DeviceContent>;
+      measures: MeasureContent[];
+    }
+  ];
+};
+
+/**
+ * Event triggered after updating device and asset with new measures but
+ * before persistence in database.
+ */
+export type EventMeasurePersistBefore = {
+  name: "device-manager:measures:persist:before";
+
+  args: [
+    {
+      asset: KDocument<AssetContent>;
+      device: KDocument<DeviceContent>;
+      measures: MeasureContent[];
+    }
+  ];
+};
+
+/**
+ * Tenant event triggered after updating device and asset with new measures but
+ * before persistence in database.
+ */
+export type TenantEventMeasurePersistBefore = {
+  name: `engine:${string}:device-manager:measures:persist:before`;
+
+  args: [
+    {
+      asset: KDocument<AssetContent>;
+      device: KDocument<DeviceContent>;
       measures: MeasureContent[];
     }
   ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kuzzle-device-manager",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuzzle-device-manager",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Manage your IoT devices and assets. Choose a provisioning strategy, receive and decode payload, handle your IoT business logic.",
   "author": "The Kuzzle Team (support@kuzzle.io)",
   "repository": {

--- a/tests/application/tests/pipes.ts
+++ b/tests/application/tests/pipes.ts
@@ -3,10 +3,28 @@ import { Backend } from "kuzzle";
 import {
   MeasureContent,
   EventMeasureProcessBefore,
+  EventMeasurePersistBefore,
   TemperatureMeasurement,
 } from "../../../index";
 
 export function registerTestPipes(app: Backend) {
+  app.pipe.register<EventMeasurePersistBefore>(
+    "device-manager:measures:persist:before",
+    async ({ asset, device, measures }) => {
+      const color = device._source.metadata.color;
+
+      if (color === "test-persist-before-event-temperature-42") {
+        if (asset._source.measures.temperatureExt.values.temperature !== 42) {
+          throw new Error(
+            "The asset document in this event should already contains the updated measure"
+          );
+        }
+      }
+
+      return { asset, device, measures };
+    }
+  );
+
   app.pipe.register<EventMeasureProcessBefore>(
     "device-manager:measures:process:before",
     async ({ asset, device, measures }) => {

--- a/tests/scenario/modules/ingestion-pipeline/pipeline-persist-before.test.ts
+++ b/tests/scenario/modules/ingestion-pipeline/pipeline-persist-before.test.ts
@@ -1,0 +1,25 @@
+import { ContainerAssetContent } from "../../../application/assets/Container";
+
+import { sendDummyTempPayloads, setupHooks } from "../../../helpers";
+
+jest.setTimeout(10000);
+
+describe("Ingestion Pipeline: persist before", () => {
+  const sdk = setupHooks();
+
+  it("expose the updated asset and device", async () => {
+    // Pipe will fail if something is wrong
+    await expect(
+      sendDummyTempPayloads(sdk, [
+        {
+          deviceEUI: "linked1",
+          temperature: 42,
+          metadata: {
+            // search this string to find the associated pipe
+            color: "test-persist-before-event-temperature-42",
+          },
+        },
+      ])
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/scenario/modules/ingestion-pipeline/pipeline-process-before.test.ts
+++ b/tests/scenario/modules/ingestion-pipeline/pipeline-process-before.test.ts
@@ -4,7 +4,7 @@ import { sendDummyTempPayloads, setupHooks } from "../../../helpers";
 
 jest.setTimeout(10000);
 
-describe("Ingestion Pipeline: before ingestion", () => {
+describe("Ingestion Pipeline: process before", () => {
   const sdk = setupHooks();
 
   it("allows to add a new measure only to the asset", async () => {


### PR DESCRIPTION
## What does this PR do ?

Add a new event triggered after measure have been updated in asset and device but before persistence.

This allow to modify the final state of the asset/device before saving them.

Needed for https://github.com/kuzzleio/kuzzle-iot-backend/pull/19