### PR TITLE
fix: CSV column headers and path to values should not be the same

### DIFF
--- a/lib/modules/measure/MeasureExporter.ts
+++ b/lib/modules/measure/MeasureExporter.ts
@@ -171,25 +171,29 @@ export class MeasureExporter {
         }
       );
 
-      const columns = [
-        "measuredAt",
-        "type",
-        "origin._id",
-        "origin.deviceModel",
-        "asset._id",
-        "asset.model",
-        ...modelDocument[target].measures.map((m) => `values.${m.name}`),
-      ];
+      const columns: Map<string, string> = new Map([
+        ["measuredAt", "measuredAt"],
+        ["type", "type"],
+        ["deviceId", "origin._id"],
+        ["deviceModel", "origin.deviceModel"],
+        ["assetId", "asset._id"],
+        ["assetModel", "asset.model"],
+        ...modelDocument[target].measures.map((m) => [
+          m.name,
+          `values.${m.type}`,
+        ]),
+      ]);
 
-      stream.write(stringify([["_id", ...columns]]));
+      stream.write(stringify([["_id", ...columns.keys()]]));
 
+      const pathsToValue = Array.from(columns.values());
       while (result) {
         for (const hit of result.hits) {
           stream.write(
             stringify([
               [
                 hit._id,
-                ...columns.map((column) => _.get(hit._source, column, null)),
+                ...pathsToValue.map((path) => _.get(hit._source, path, null)),
               ],
             ])
           );

--- a/tests/scenario/modules/assets/action-export-measures.test.ts
+++ b/tests/scenario/modules/assets/action-export-measures.test.ts
@@ -48,7 +48,7 @@ describe("AssetsController:exportMeasures", () => {
       action: "exportMeasures",
       engineId: "engine-ayse",
       _id: "Container-linked2",
-      type: "position",
+      type: "temperature",
     });
 
     const response = await axios.get("http://localhost:7512" + result.link, {
@@ -67,7 +67,7 @@ describe("AssetsController:exportMeasures", () => {
 
     expect(csv).toHaveLength(5);
     expect(csv[0]).toBe(
-      "_id,measuredAt,type,origin._id,origin.deviceModel,asset._id,asset.model,values.temperatureExt,values.temperatureInt,values.position,values.temperatureWeather\n"
+      "_id,measuredAt,type,deviceId,deviceModel,assetId,assetModel,temperatureExt,temperatureInt,position,temperatureWeather\n"
     );
     const [
       _id,
@@ -77,13 +77,21 @@ describe("AssetsController:exportMeasures", () => {
       originDeviceModel,
       assetId,
       assetModel,
-    ] = csv[1].split(",");
+      temperatureExt,
+      temperatureInt,
+      position,
+      temperatureWeather,
+    ] = csv[1].replace("\n", "").split(",");
     expect(typeof _id).toBe("string");
     expect(typeof parseFloat(measuredAt)).toBe("number");
-    expect(type).toBe("position");
+    expect(type).toBe("temperature");
     expect(originId).toBe("DummyTempPosition-linked2");
     expect(originDeviceModel).toBe("DummyTempPosition");
     expect(assetId).toBe("Container-linked2");
     expect(assetModel).toBe("Container");
+    expect(temperatureExt).toBe("17.3");
+    expect(temperatureInt).toBe("17.3");
+    expect(position).toBe("");
+    expect(temperatureWeather).toBe("17.3");
   });
 });

--- a/tests/scenario/modules/devices/action-export-measures.test.ts
+++ b/tests/scenario/modules/devices/action-export-measures.test.ts
@@ -54,7 +54,7 @@ describe("DevicesController:exportMeasures", () => {
 
     expect(csv).toHaveLength(25);
     expect(csv[0]).toBe(
-      "_id,measuredAt,type,origin._id,origin.deviceModel,asset._id,asset.model,values.temperature,values.battery\n"
+      "_id,measuredAt,type,deviceId,deviceModel,assetId,assetModel,temperature,battery\n"
     );
     const [
       _id,
@@ -108,7 +108,7 @@ describe("DevicesController:exportMeasures", () => {
 
     expect(csv).toHaveLength(3);
     expect(csv[0]).toBe(
-      "_id,measuredAt,type,origin._id,origin.deviceModel,asset._id,asset.model,values.temperature,values.battery\n"
+      "_id,measuredAt,type,deviceId,deviceModel,assetId,assetModel,temperature,battery\n"
     );
   });
 });


### PR DESCRIPTION
## What does this PR do ?

This PR fixes empty values when measure named differed from measure types.
Previously, when you had a measure named `temperatureExt` of type `temperature`, it tried to get the value with the current path : `values.temperatureExt` where it should have been `values.temperature`.

Plus, this allows us to use custom header names instead of the paths to the value.