### PR TITLE
Fix composite measures should be correctly exported to CSV

### DIFF
--- a/lib/modules/measure/measures/PositionMeasure.ts
+++ b/lib/modules/measure/measures/PositionMeasure.ts
@@ -13,8 +13,8 @@ export type PositionMeasurement = {
 
 export const positionMeasureDefinition: MeasureDefinition = {
   valuesMappings: {
+    position: { type: "geo_point" },
     accuracy: { type: "float" },
     altitude: { type: "float" },
-    position: { type: "geo_point" },
   },
 };

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -22,7 +22,11 @@ import {
   DeviceModelContent,
   MeasureModelContent,
 } from "./types/ModelContent";
-import { AskModelAssetGet, AskModelDeviceGet } from "./types/ModelEvents";
+import {
+  AskModelAssetGet,
+  AskModelDeviceGet,
+  AskModelMeasureGet,
+} from "./types/ModelEvents";
 
 export class ModelService {
   private config: DeviceManagerConfiguration;
@@ -54,6 +58,14 @@ export class ModelService {
         const deviceModel = await this.getDevice(model);
 
         return deviceModel._source;
+      }
+    );
+    onAsk<AskModelMeasureGet>(
+      "ask:device-manager:model:measure:get",
+      async ({ type }) => {
+        const measureModel = await this.getMeasure(type);
+
+        return measureModel._source;
       }
     );
   }

--- a/lib/modules/model/types/ModelEvents.ts
+++ b/lib/modules/model/types/ModelEvents.ts
@@ -1,4 +1,8 @@
-import { AssetModelContent, DeviceModelContent } from "./ModelContent";
+import {
+  AssetModelContent,
+  DeviceModelContent,
+  MeasureModelContent,
+} from "./ModelContent";
 
 export type AskModelAssetGet = {
   name: "ask:device-manager:model:asset:get";
@@ -14,4 +18,12 @@ export type AskModelDeviceGet = {
   payload: { model: string };
 
   result: DeviceModelContent;
+};
+
+export type AskModelMeasureGet = {
+  name: "ask:device-manager:model:measure:get";
+
+  payload: { type: string };
+
+  result: MeasureModelContent;
 };

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -1,15 +1,15 @@
 import util from "node:util";
 
-import { Backend, HttpStream, KuzzleRequest } from "kuzzle";
+import { Backend, KuzzleRequest } from "kuzzle";
 
 import { DeviceManagerPlugin } from "../../index";
 
-import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
-import { registerTestPipes } from "./tests/pipes";
-import { TestsController } from "./tests/controller";
 import { containerAssetDefinition } from "./assets/Container";
 import { warehouseAssetDefinition } from "./assets/Warehouse";
-import { PassThrough } from "node:stream";
+import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
+import { TestsController } from "./tests/controller";
+import { registerTestPipes } from "./tests/pipes";
+import { accelerationMeasureDefinition } from "./measures/AccelerationMeasure";
 
 const app = new Backend("kuzzle");
 
@@ -43,13 +43,7 @@ deviceManager.models.registerAsset(
   warehouseAssetDefinition
 );
 
-deviceManager.models.registerMeasure("acceleration", {
-  valuesMappings: {
-    x: { type: "float" },
-    y: { type: "float" },
-    z: { type: "float" },
-  },
-});
+deviceManager.models.registerMeasure("acceleration", accelerationMeasureDefinition);
 
 registerTestPipes(app);
 
@@ -69,29 +63,6 @@ app.config.content.plugins["kuzzle-plugin-logger"].services.stdout.level =
   "debug";
 // @ts-ignore
 app.config.content.limits.documentsWriteCount = 5000;
-
-let searchQuery;
-
-async function sendResult(stream, searchQuery) {
-  let result = await app.sdk.document.search(
-    "device-manager",
-    "payloads",
-    {
-      query: searchQuery,
-    },
-    { scroll: "5s" }
-  );
-
-  while (result) {
-    for (const hit of result.hits) {
-      stream.write(JSON.stringify(hit));
-    }
-
-    result = await result.next();
-  }
-
-  stream.end();
-}
 
 app
   .start()

--- a/tests/application/decoders/DummyTempDecoder.ts
+++ b/tests/application/decoders/DummyTempDecoder.ts
@@ -7,10 +7,12 @@ import {
   TemperatureMeasurement,
   BatteryMeasurement,
 } from "../../../index";
+import { AccelerationMeasurement } from "../measures/AccelerationMeasure";
 
 export class DummyTempDecoder extends Decoder {
   public measures = [
     { name: "temperature", type: "temperature" },
+    { name: "acceleration", type: "acceleration" },
     { name: "battery", type: "battery" },
   ] as const;
 
@@ -72,6 +74,25 @@ export class DummyTempDecoder extends Decoder {
         },
       }
     );
+
+    if (payload.acceleration !== undefined) {
+      decodedPayload.addMeasurement<AccelerationMeasurement>(
+        payload.deviceEUI,
+        "acceleration",
+        {
+          measuredAt: payload.measuredAt || Date.now(),
+          type: "acceleration",
+          values: {
+            acceleration: {
+              x: payload.acceleration.x,
+              y: payload.acceleration.y,
+              z: payload.acceleration.z,
+            },
+            accuracy: payload.acceleration.accuracy,
+          },
+        }
+      );
+    }
 
     decodedPayload.addMeasurement<BatteryMeasurement>(
       payload.deviceEUI,

--- a/tests/application/measures/AccelerationMeasure.ts
+++ b/tests/application/measures/AccelerationMeasure.ts
@@ -1,0 +1,25 @@
+import { MeasureDefinition } from "lib/modules/measure";
+
+/* eslint-disable sort-keys */
+
+export type AccelerationMeasurement = {
+  acceleration: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  accuracy: number;
+};
+
+export const accelerationMeasureDefinition: MeasureDefinition = {
+  valuesMappings: {
+    acceleration: {
+      properties: {
+        x: { type: "float" },
+        y: { type: "float" },
+        z: { type: "float" },
+      },
+    },
+    accuracy: { type: "float" },
+  },
+};

--- a/tests/scenario/migrated/model-controller.test.ts
+++ b/tests/scenario/migrated/model-controller.test.ts
@@ -548,6 +548,7 @@ describe("features/Model/Controller", () => {
           metadataMappings: { color: { type: "keyword" } },
           measures: [
             { name: "temperature", type: "temperature" },
+            { name: "acceleration", type: "acceleration" },
             { name: "battery", type: "battery" },
           ],
         },

--- a/tests/scenario/modules/assets/action-export-measures.test.ts
+++ b/tests/scenario/modules/assets/action-export-measures.test.ts
@@ -10,7 +10,7 @@ jest.setTimeout(10000);
 describe("AssetsController:exportMeasures", () => {
   const sdk = setupHooks();
 
-  it("should prepare export of position measures and return a CSV as stream", async () => {
+  it("should prepare export of temperature measures and return a CSV as stream", async () => {
     await sendPayloads(sdk, "dummy-temp-position", [
       {
         deviceEUI: "linked2",

--- a/tests/scenario/modules/assets/action-export-measures.test.ts
+++ b/tests/scenario/modules/assets/action-export-measures.test.ts
@@ -67,7 +67,7 @@ describe("AssetsController:exportMeasures", () => {
 
     expect(csv).toHaveLength(5);
     expect(csv[0]).toBe(
-      "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperatureExt,temperatureInt,position,temperatureWeather\n"
+      "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperatureExt,temperatureInt,position,position.accuracy,position.altitude,temperatureWeather\n"
     );
     const [
       payloadId,

--- a/tests/scenario/modules/devices/action-export-measures.test.ts
+++ b/tests/scenario/modules/devices/action-export-measures.test.ts
@@ -29,7 +29,23 @@ describe("DevicesController:exportMeasures", () => {
       { deviceEUI: "linked1", temperature: 40 },
       { deviceEUI: "linked1", temperature: 39 },
       { deviceEUI: "linked1", temperature: 38 },
-      { deviceEUI: "linked1", temperature: 37 },
+      {
+        deviceEUI: "linked1",
+        temperature: 37,
+        acceleration: {
+          x: 1,
+          y: 2.5,
+          z: -1,
+          accuracy: 0.1,
+        },
+        /**
+         * Here we specify a measuredAt, because of a side effect in the decoder.
+         * Sometimes the acceleration measurement would be registered earlier than the temperature's one.
+         *
+         * The +1sec is to ensure that those two measures will always remain the last ones.
+         */
+        measuredAt: Date.now() + 1000,
+      },
     ]);
     await sdk.collection.refresh("engine-ayse", "measures");
 
@@ -52,28 +68,49 @@ describe("DevicesController:exportMeasures", () => {
       response.data.on("end", resolve);
     });
 
-    expect(csv).toHaveLength(25);
+    expect(csv).toHaveLength(26);
     expect(csv[0]).toBe(
-      "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperature,battery\n"
+      "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperature,acceleration.x,acceleration.y,acceleration.z,acceleration.accuracy,battery\n"
     );
     const [
       payloadId,
       measuredAt,
-      measureType,
+      tempMeasureType,
       deviceId,
       deviceModel,
       assetId,
       assetModel,
       temperature,
     ] = csv[1].split(",");
+    const [
+      ,
+      ,
+      accMeasureType,
+      ,
+      ,
+      ,
+      ,
+      ,
+      accelerationX,
+      accelerationY,
+      accelerationZ,
+      accelerationAccuracy,
+    ] = csv[2].split(",");
+
     expect(typeof payloadId).toBe("string");
     expect(typeof parseFloat(measuredAt)).toBe("number");
-    expect(measureType).toBe("temperature");
+    expect(tempMeasureType).toBe("temperature");
     expect(deviceId).toBe("DummyTemp-linked1");
     expect(deviceModel).toBe("DummyTemp");
     expect(assetId).toBe("Container-linked1");
     expect(assetModel).toBe("Container");
     expect(parseFloat(temperature)).toBe(37);
+
+    expect(accMeasureType).toBe("acceleration");
+    expect(parseFloat(accelerationX)).toBe(1);
+    expect(parseFloat(accelerationY)).toBe(2.5);
+    expect(parseFloat(accelerationZ)).toBe(-1);
+    expect(parseFloat(accelerationAccuracy)).toBe(0.1);
   });
 
   it("should generate a authenticated link", async () => {
@@ -108,7 +145,7 @@ describe("DevicesController:exportMeasures", () => {
 
     expect(csv).toHaveLength(3);
     expect(csv[0]).toBe(
-      "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperature,battery\n"
+      "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperature,acceleration.x,acceleration.y,acceleration.z,acceleration.accuracy,battery\n"
     );
   });
 });


### PR DESCRIPTION
## What does this PR do ?

Composite measures (measures with multiple properties, which can be objects) are now correctly exported. Before, only the property with the name equal to the measure type was exported (see the issue below).
Fixes #308.

### Other changes

<!--
  Please outline any changes not directly linked to the main issue, but made because of it.
  For instance: on-the-fly fixes, dependencies updates and so on.
-->
* Property "position" was moved to the top of the `valueMappings` for the position measurement. It helps with consistency (which means, we do not need to sort properties from the mappings to display in a logical order the columns in the csv export).

### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->
* Ordering some imports
* Corrected a misnamed test
