### PR TITLE
fix(docs): wrong arguments in models' getDevice request

### DIFF
--- a/doc/2/controllers/assets/get-measures/index.md
+++ b/doc/2/controllers/assets/get-measures/index.md
@@ -16,7 +16,7 @@ Retrieves measures from an asset.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/getMeasures
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/measures
 Method: GET or POST
 ```
 

--- a/doc/2/controllers/assets/get-measures/index.md
+++ b/doc/2/controllers/assets/get-measures/index.md
@@ -2,12 +2,12 @@
 code: true
 type: page
 title: getMeasures
-description: Retrieves measure from an asset
+description: Retrieves measures from an asset
 ---
 
 # getMeasures
 
-Retrieves measure from an asset.
+Retrieves measures from an asset.
 
 ---
 
@@ -16,7 +16,7 @@ Retrieves measure from an asset.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/measures
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/getMeasures
 Method: GET or POST
 ```
 
@@ -51,13 +51,12 @@ Method: GET or POST
 ## Arguments
 
 - `engineId`: engine id
-- `_id`: asset id
-  ISO_8601
-- `from`: paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
-- `size`: set the maximum number of documents returned per result page
-- `startAt`: beginning of time range (ISO 8601)
-- `endAt`: end of time range (ISO 8601)
-- `type`: measure type
+- `_id`: asset id (ISO_8601)
+- `from` (optional): paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
+- `size` (optional): set the maximum number of documents returned per result page
+- `startAt` (optional): beginning of time range (ISO 8601)
+- `endAt` (optional): end of time range (ISO 8601)
+- `type` (optional): measure type
 
 ## Body properties
 
@@ -73,7 +72,7 @@ Method: GET or POST
   "status": 200,
   "error": null,
   "controller": "device-manager/assets",
-  "action": "search",
+  "action": "getMeasures",
   "requestId": "<unique request identifier>",
   "result": {
     "measures": [

--- a/doc/2/controllers/models/get-asset/index.md
+++ b/doc/2/controllers/models/get-asset/index.md
@@ -24,10 +24,10 @@ Method: GET
 
 ```js
 {
-  "controller": "device-manager/assets",
+  "controller": "device-manager/models",
   "action": "getAsset",
   "engineGroup": "<engineGroup>",
-  "_id": "<modelId>"
+  "model": "<asset model>"
 }
 ```
 
@@ -36,7 +36,7 @@ Method: GET
 ## Arguments
 
 - `engineGroup`: name of the engine group
-- `_id`: asset model id
+- `model`: asset model
 
 ---
 

--- a/doc/2/controllers/models/get-device/index.md
+++ b/doc/2/controllers/models/get-device/index.md
@@ -16,7 +16,7 @@ Gets a device model.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/models/device/:model
+URL: http://kuzzle:7512/_/device-manager/models/device/:id
 Method: GET
 ```
 

--- a/doc/2/controllers/models/get-device/index.md
+++ b/doc/2/controllers/models/get-device/index.md
@@ -26,7 +26,7 @@ Method: GET
 {
   "controller": "device-manager/models",
   "action": "getDevice",
-  "model": "<modelId>"
+  "model": "<device model>"
 }
 ```
 
@@ -34,7 +34,7 @@ Method: GET
 
 ## Arguments
 
-- `model`: device model id
+- `model`: device model
 
 ---
 

--- a/doc/2/controllers/models/get-device/index.md
+++ b/doc/2/controllers/models/get-device/index.md
@@ -7,7 +7,7 @@ description: Gets an device model
 
 # getDevice
 
-Gets an device model.
+Gets a device model.
 
 ---
 
@@ -16,7 +16,7 @@ Gets an device model.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/models/device/:_id
+URL: http://kuzzle:7512/_/device-manager/models/device/:model
 Method: GET
 ```
 
@@ -26,8 +26,7 @@ Method: GET
 {
   "controller": "device-manager/models",
   "action": "getDevice",
-  "engineId": "<engineId>",
-  "_id": "<modelId>"
+  "model": "<modelId>"
 }
 ```
 
@@ -35,8 +34,7 @@ Method: GET
 
 ## Arguments
 
-- `engineId`: engine id
-- `_id`: device model id
+- `model`: device model id
 
 ---
 

--- a/doc/2/controllers/models/get-measure/index.md
+++ b/doc/2/controllers/models/get-measure/index.md
@@ -26,7 +26,7 @@ Method: GET
 {
   "controller": "device-manager/models",
   "action": "getMeasure",
-  "_id": "<modelId>"
+  "type": "<measure type>"
 }
 ```
 
@@ -34,8 +34,7 @@ Method: GET
 
 ## Arguments
 
-- `engineId`: engine id
-- `_id`: measure model id
+- `type`: The type of measure you want to retreive.
 
 ---
 

--- a/doc/2/controllers/models/get-measure/index.md
+++ b/doc/2/controllers/models/get-measure/index.md
@@ -34,7 +34,7 @@ Method: GET
 
 ## Arguments
 
-- `type`: The type of measure you want to retreive.
+- `type`: measure type
 
 ---
 


### PR DESCRIPTION
## What does this PR do ?

Fixes incorrect arguments in the request to retrieve a device's model.

## ToDos
- [x] getAsset: wrong arguments & wrong controller & wrong slug route argument
- [x] getMeasure: wrong argument (type) & wrong slug route argument