### PR TITLE
feat: digitaltwin exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ dist/
 types/dist/
 
 # Test files
-asset.csv
+/*.csv

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -122,3 +122,15 @@ export interface ApiAssetExportMeasuresRequest extends AssetsControllerRequest {
 export type ApiAssetExportMeasuresResult = {
   link: string;
 };
+
+export interface ApiAssetExportRequest extends AssetsControllerRequest {
+  action: "export";
+
+  body?: {
+    query?: JSONObject;
+    sort?: JSONObject;
+  };
+}
+export type ApiAssetExportResult = {
+  link: string;
+};

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -222,3 +222,15 @@ export interface ApiDeviceReceiveMeasuresRequest<
   };
 }
 export type ApiDeviceReceiveMeasuresResult = void;
+
+export interface ApiDeviceExportRequest extends DevicesControllerRequest {
+  action: "export";
+
+  body?: {
+    query?: JSONObject;
+    sort?: JSONObject;
+  };
+}
+export type ApiDeviceExportResult = {
+  link: string;
+};

--- a/lib/modules/shared/index.ts
+++ b/lib/modules/shared/index.ts
@@ -1,3 +1,4 @@
+export * from "./services";
 export * from "./Module";
 export * from "./types/DigitalTwinContent";
 export * from "./types/Metadata";

--- a/lib/modules/shared/services/AbstractExporter.ts
+++ b/lib/modules/shared/services/AbstractExporter.ts
@@ -10,6 +10,7 @@ import {
   User,
 } from "kuzzle";
 import { EngineContent } from "kuzzle-plugin-commons";
+import _ from "lodash";
 
 import { DeviceManagerPlugin, InternalCollection } from "../../plugin";
 
@@ -37,7 +38,7 @@ export abstract class AbstractExporter<P extends ExportParams = ExportParams> {
   };
 
   constructor(
-    private plugin: DeviceManagerPlugin,
+    protected plugin: DeviceManagerPlugin,
     protected target: InternalCollection,
     config: Partial<ExporterOption> = {}
   ) {
@@ -87,11 +88,6 @@ export abstract class AbstractExporter<P extends ExportParams = ExportParams> {
    */
   abstract sendExport(engineId: string, exportId: string): Promise<Readable>;
 
-  protected abstract formatHit(
-    columns: Column[],
-    hit: KHit<KDocumentContentGeneric>
-  ): string[];
-
   async prepareExport(engineId: string, user: User, params: P) {
     const exportId = randomUUID();
 
@@ -114,6 +110,13 @@ export abstract class AbstractExporter<P extends ExportParams = ExportParams> {
     }
 
     return link;
+  }
+
+  protected formatHit(
+    columns: Column[],
+    hit: KHit<KDocumentContentGeneric>
+  ): string[] {
+    return columns.map(({ path }) => _.get(hit, path, null));
   }
 
   async getExport(engineId: string, exportId: string): Promise<P> {

--- a/lib/modules/shared/services/AbstractExporter.ts
+++ b/lib/modules/shared/services/AbstractExporter.ts
@@ -1,0 +1,156 @@
+import { UUID, randomUUID } from "node:crypto";
+import { PassThrough, Readable } from "node:stream";
+import { stringify } from "csv-stringify/sync";
+import {
+  JSONObject,
+  KDocumentContentGeneric,
+  KHit,
+  NotFoundError,
+  SearchResult,
+  User,
+} from "kuzzle";
+import { EngineContent } from "kuzzle-plugin-commons";
+
+import { DeviceManagerPlugin, InternalCollection } from "../../plugin";
+
+export interface ExporterOption {
+  /**
+   * Expiration time of export in seconds before being invalid
+   */
+  expireTime: number;
+}
+
+export interface ExportParams {
+  query: JSONObject;
+  sort?: JSONObject;
+}
+
+export interface Column {
+  header: string;
+  path: string;
+  isMeasure?: boolean;
+}
+
+export abstract class AbstractExporter<P extends ExportParams = ExportParams> {
+  protected config: ExporterOption = {
+    expireTime: 2 * 60,
+  };
+
+  constructor(
+    private plugin: DeviceManagerPlugin,
+    protected target: InternalCollection,
+    config: Partial<ExporterOption> = {}
+  ) {
+    if (Object.keys(config).length > 0) {
+      this.config = {
+        ...this.config,
+        ...config,
+      };
+    }
+  }
+
+  protected get sdk() {
+    return this.plugin.context.accessors.sdk;
+  }
+
+  protected get ms() {
+    return this.sdk.ms;
+  }
+
+  protected get log() {
+    return this.plugin.context.log;
+  }
+
+  protected async getEngine(engineId: string): Promise<EngineContent> {
+    const engine = await this.sdk.document.get<{ engine: EngineContent }>(
+      this.plugin.config.adminIndex,
+      InternalCollection.CONFIG,
+      `engine-device-manager--${engineId}`
+    );
+
+    return engine._source.engine;
+  }
+
+  protected abstract exportRedisKey(engineId: string, exportId: string): string;
+
+  protected abstract getLink(
+    engineId: string,
+    exportId: UUID,
+    params: P
+  ): string;
+
+  /**
+   * Retrieve a prepared export and write each document as a CSV in the stream
+   *
+   * This method never returns a rejected promise, but write potential error in
+   * the stream.
+   */
+  abstract sendExport(engineId: string, exportId: string): Promise<Readable>;
+
+  protected abstract formatHit(
+    columns: Column[],
+    hit: KHit<KDocumentContentGeneric>
+  ): string[];
+
+  async prepareExport(engineId: string, user: User, params: P) {
+    const exportId = randomUUID();
+
+    await this.ms.setex(
+      this.exportRedisKey(engineId, exportId),
+      JSON.stringify(params),
+      this.config.expireTime
+    );
+
+    let link = this.getLink(engineId, exportId, params);
+    if (user._id !== "-1") {
+      const { result } = await this.sdk.as(user).query({
+        action: "createToken",
+        controller: "auth",
+        expiresIn: this.config.expireTime * 1000,
+        singleUse: true,
+      });
+
+      link += `?jwt=${result.token}`;
+    }
+
+    return link;
+  }
+
+  async getExport(engineId: string, exportId: string): Promise<P> {
+    const exportParams = await this.sdk.ms.get(
+      this.exportRedisKey(engineId, exportId)
+    );
+
+    if (!exportParams) {
+      throw new NotFoundError(`Export "${exportId}" not found or expired.`);
+    }
+
+    return JSON.parse(exportParams);
+  }
+
+  async getExportStream(
+    request: SearchResult<KHit<KDocumentContentGeneric>>,
+    columns: Column[]
+  ) {
+    const stream = new PassThrough();
+
+    let result = request;
+    try {
+      stream.write(stringify([columns.map((column) => column.header)]));
+
+      while (result) {
+        for (const hit of result.hits) {
+          stream.write(stringify([this.formatHit(columns, hit)]));
+        }
+
+        result = await result.next();
+      }
+    } catch (error) {
+      stream.write(error.message);
+    } finally {
+      stream.end();
+    }
+
+    return stream;
+  }
+}

--- a/lib/modules/shared/services/DigitalTwinExporter.ts
+++ b/lib/modules/shared/services/DigitalTwinExporter.ts
@@ -1,0 +1,140 @@
+import { UUID } from "node:crypto";
+import { JSONObject } from "kuzzle";
+
+import { NamedMeasures } from "../../decoder";
+import { InternalCollection } from "../../plugin";
+import {
+  AskModelMeasureGet,
+  AssetModelContent,
+  DeviceModelContent,
+} from "../../model";
+import { DigitalTwinContent, ask, flattenObject } from "../";
+import { AbstractExporter, Column } from "./AbstractExporter";
+
+interface MeasureColumn extends Column {
+  isMeasure: boolean;
+}
+
+export class DigitalTwinExporter extends AbstractExporter {
+  protected exportRedisKey(engineId: string, exportId: string) {
+    return `exports:${engineId}:${this.target}:${exportId}`;
+  }
+
+  protected getLink(engineId: string, exportId: UUID) {
+    return `/_/device-manager/${engineId}/${this.target}/_export/${exportId}`;
+  }
+
+  async sendExport(engineId: string, exportId: string) {
+    try {
+      const { query, sort } = await this.getExport(engineId, exportId);
+
+      const digitalTwins = await this.sdk.document.search<DigitalTwinContent>(
+        engineId,
+        this.target,
+        { query, sort },
+        { lang: "koncorde", size: 200 }
+      );
+
+      const namedMeasures = await this.getNamedMeasures(engineId);
+      const measureColumns = await this.generateMeasureColumns(namedMeasures);
+
+      const columns: Column[] = [
+        { header: "Model", path: "_source.model" },
+        { header: "Reference", path: "_source.reference" },
+        ...measureColumns,
+        { header: "lastMeasuredAt", path: "_source.lastMeasuredAt" },
+      ];
+
+      const stream = this.getExportStream(digitalTwins, columns);
+      await this.sdk.ms.del(this.exportRedisKey(engineId, exportId));
+
+      return stream;
+    } catch (error) {
+      this.log.error(error);
+    }
+  }
+
+  /**
+   * Get the deduplicated Named Measures get from models
+   */
+  private async getNamedMeasures(engineId: string): Promise<NamedMeasures> {
+    const type = this.target === InternalCollection.ASSETS ? "asset" : "device";
+    const query: JSONObject = {
+      and: [{ equals: { type } }],
+    };
+
+    if (this.target === InternalCollection.ASSETS) {
+      const engine = await this.getEngine(engineId);
+      query.and.push({ equals: { engineGroup: engine.group } });
+    }
+
+    let result = await this.sdk.document.search<
+      AssetModelContent | DeviceModelContent
+    >(
+      this.plugin.config.adminIndex,
+      InternalCollection.MODELS,
+      {
+        query: { equals: { type } },
+      },
+      { lang: "koncorde" }
+    );
+
+    // ? Use a map to dedup the NamedMeasures get from models
+    const namedMeasures = new Map<string, NamedMeasures[0]>();
+    while (result) {
+      for (const { _source } of result.hits) {
+        for (const namedMeasure of _source[type].measures as NamedMeasures) {
+          if (!namedMeasures.has(namedMeasure.name)) {
+            namedMeasures.set(namedMeasure.name, namedMeasure);
+          }
+        }
+      }
+      result = await result.next();
+    }
+
+    // ? Ensure stable measures order
+    return [...namedMeasures.values()].sort((a, b) => {
+      if (a.name < b.name) {
+        return -1;
+      }
+      if (a.name > b.name) {
+        return 1;
+      }
+      return 0;
+    });
+  }
+
+  private async generateMeasureColumns(
+    namedMeasures: NamedMeasures
+  ): Promise<MeasureColumn[]> {
+    const columns: MeasureColumn[] = [];
+
+    const measuresPath = new Map<string, string[]>();
+    for (const { name, type } of namedMeasures) {
+      if (!measuresPath.has(name)) {
+        const { measure: measureDefinition } = await ask<AskModelMeasureGet>(
+          "ask:device-manager:model:measure:get",
+          { type }
+        );
+
+        const flattenMeasuresPath = Object.keys(
+          flattenObject(measureDefinition.valuesMappings)
+        ).map((path) => path.replace(".type", "").replace(".properties", ""));
+
+        measuresPath.set(name, flattenMeasuresPath);
+      }
+
+      for (const path of measuresPath.get(name)) {
+        const header = `${name}.${path}`.replace(`${name}.${type}`, name);
+
+        columns.push({
+          header,
+          isMeasure: true,
+          path: `_source.measures.${name}.values.${path}`,
+        });
+      }
+    }
+
+    return columns;
+  }
+}

--- a/lib/modules/shared/services/index.ts
+++ b/lib/modules/shared/services/index.ts
@@ -1,1 +1,2 @@
 export * from "./AbstractExporter";
+export * from "./DigitalTwinExporter";

--- a/lib/modules/shared/services/index.ts
+++ b/lib/modules/shared/services/index.ts
@@ -1,0 +1,1 @@
+export * from "./AbstractExporter";

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/lodash": "^4.14.195",
         "@types/node": "^18.15.13",
         "axios": "^1.3.6",
+        "csv-parse": "^5.4.0",
         "cz-conventional-changelog": "^3.3.0",
         "ergol": "^1.0.2",
         "eslint-plugin-jest": "^27.2.1",
@@ -4600,6 +4601,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.4.0.tgz",
+      "integrity": "sha512-JiQosUWiOFgp4hQn0an+SBoV9IKdqzhROM0iiN4LB7UpfJBlsSJlWl9nq4zGgxgMAzHJ6V4t29VAVD+3+2NJAg==",
+      "dev": true
     },
     "node_modules/csv-stringify": {
       "version": "6.3.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/lodash": "^4.14.195",
     "@types/node": "^18.15.13",
     "axios": "^1.3.6",
+    "csv-parse": "^5.4.0",
     "cz-conventional-changelog": "^3.3.0",
     "ergol": "^1.0.2",
     "eslint-plugin-jest": "^27.2.1",

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -58,6 +58,31 @@ const deviceAyseUnlinked3 = {
 };
 const deviceAyseUnlinked3Id = `${deviceAyseUnlinked3.model}-${deviceAyseUnlinked3.reference}`;
 
+const deviceAyseWarehouse = {
+  model: "DummyTempPosition",
+  reference: "warehouse",
+  metadata: {},
+  measures: {},
+  engineId: "engine-ayse",
+  assetId: "Warehouse-linked",
+};
+const deviceAyseWarehouseId = `${deviceAyseWarehouse.model}-${deviceAyseWarehouse.reference}`;
+
+const assetAyseWarehouseLinked = {
+  model: "Warehouse",
+  reference: "linked",
+  metadata: {
+    surface: 512,
+  },
+  linkedDevices: [
+    {
+      measureNames: [{ asset: "position", device: "position" }],
+      _id: "DummyTempPosition-warehouse",
+    },
+  ],
+};
+const assetAyseWarehouseLinkedId = `${assetAyseWarehouseLinked.model}-${assetAyseWarehouseLinked.reference}`;
+
 const assetAyseLinked1 = {
   model: "Container",
   reference: "linked1",
@@ -170,6 +195,9 @@ export default {
 
       { index: { _id: deviceAyseUnlinked3Id } },
       deviceAyseUnlinked3,
+
+      { index: { _id: deviceAyseWarehouseId } },
+      deviceAyseWarehouse,
     ],
   },
 
@@ -190,6 +218,9 @@ export default {
 
       { index: { _id: deviceAyseUnlinked3Id } },
       deviceAyseUnlinked3,
+
+      { index: { _id: deviceAyseWarehouseId } },
+      deviceAyseWarehouse,
     ],
     assets: [
       { index: { _id: assetAyseLinked1Id } },
@@ -206,6 +237,9 @@ export default {
 
       { index: { _id: assetAyseGroupedId2 } },
       assetAyseGrouped2,
+
+      { index: { _id: assetAyseWarehouseLinkedId } },
+      assetAyseWarehouseLinked,
     ],
     ...assetGroupFixtures,
   },

--- a/tests/scenario/modules/assets/action-export-measures.test.ts
+++ b/tests/scenario/modules/assets/action-export-measures.test.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { parse as csvParse } from "csv-parse/sync";
 
 import { ApiAssetExportMeasuresRequest } from "../../../../index";
 
@@ -78,7 +79,8 @@ describe("AssetsController:exportMeasures", () => {
       temperatureInt,
       position,
       temperatureWeather,
-    ] = csv[1].replace("\n", "").split(",");
+    ] = csvParse(csv[1])[0];
+
     expect(typeof payloadId).toBe("string");
     expect(typeof parseFloat(measuredAt)).toBe("number");
     expect(measureType).toBe("temperature");

--- a/tests/scenario/modules/assets/action-export-measures.test.ts
+++ b/tests/scenario/modules/assets/action-export-measures.test.ts
@@ -1,5 +1,4 @@
 import axios from "axios";
-import { writeFileSync } from "fs";
 
 import { ApiAssetExportMeasuresRequest } from "../../../../index";
 
@@ -62,8 +61,6 @@ describe("AssetsController:exportMeasures", () => {
     await new Promise((resolve) => {
       response.data.on("end", resolve);
     });
-
-    writeFileSync("./asset.csv", csv.join(""));
 
     expect(csv).toHaveLength(5);
     expect(csv[0]).toBe(

--- a/tests/scenario/modules/assets/action-export.test.ts
+++ b/tests/scenario/modules/assets/action-export.test.ts
@@ -1,0 +1,110 @@
+import { writeFileSync } from "node:fs";
+import axios from "axios";
+import { parse as csvParse } from "csv-parse/sync";
+
+import { ApiAssetExportRequest, ApiAssetExportResult } from "../../../../index";
+
+import { sendDummyTempPositionPayloads, setupHooks } from "../../../helpers";
+import fixtures from "../../../fixtures/fixtures";
+
+const assetCount = fixtures["engine-ayse"].assets.length / 2;
+jest.setTimeout(10000);
+
+function getExportedColums(row) {
+  const parsedRow = csvParse(row)[0];
+
+  return {
+    model: parsedRow[0],
+    reference: parsedRow[1],
+    position: parsedRow[2],
+    positionAccuracy: parsedRow[3],
+    positionAltitude: parsedRow[4],
+    temperatureExt: parsedRow[5],
+    temperatureInt: parsedRow[6],
+    temperatureWeather: parsedRow[7],
+    lastMeasuredAt: parsedRow[8],
+  };
+}
+
+describe("AssetsController:exportMeasures", () => {
+  const sdk = setupHooks();
+
+  it("should prepare export of different assets types and return a CSV as stream", async () => {
+    await sendDummyTempPositionPayloads(sdk, [
+      {
+        deviceEUI: "warehouse",
+        temperature: 23.3,
+        location: { lat: 42.2, lon: 2.42, accuracy: 2100 },
+        battery: 0.8,
+        // ? Use date now - 1s to ensure this asset are second in export
+        measuredAt: Date.now() - 2000,
+      },
+      {
+        deviceEUI: "linked2",
+        temperature: 23.3,
+        location: { lat: 42.2, lon: 2.42, accuracy: 2100 },
+        battery: 0.8,
+        // ? Use date now to ensure this asset is first in export
+        measuredAt: Date.now(),
+      },
+    ]);
+    await sdk.collection.refresh("engine-ayse", "assets");
+    const { result } = await sdk.query<
+      ApiAssetExportRequest,
+      ApiAssetExportResult
+    >({
+      controller: "device-manager/assets",
+      action: "export",
+      engineId: "engine-ayse",
+      body: {
+        sort: { lastMeasuredAt: "desc" },
+      },
+    });
+
+    expect(typeof result.link).toBe("string");
+
+    const response = await axios.get("http://localhost:7512" + result.link, {
+      responseType: "stream",
+    });
+
+    const csv = [];
+    response.data.on("data", (chunk) => {
+      csv.push(chunk.toString());
+    });
+    await new Promise((resolve) => {
+      response.data.on("end", resolve);
+    });
+
+    writeFileSync("./assets.csv", csv.join(""));
+
+    expect(csv[0]).toBe(
+      "Model,Reference,position,position.accuracy,position.altitude,temperatureExt,temperatureInt,temperatureWeather,lastMeasuredAt\n"
+    );
+
+    expect(csv).toHaveLength(assetCount + 1);
+
+    const row1 = getExportedColums(csv[1]);
+
+    expect(row1.model).toBe("Container");
+    expect(typeof row1.reference).toBe("string");
+    expect(typeof row1.position).toBe("string");
+    expect(typeof parseFloat(row1.positionAccuracy)).toBe("number");
+    expect(typeof parseFloat(row1.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row1.temperatureExt)).toBe("number");
+    expect(typeof parseFloat(row1.temperatureInt)).toBe("number");
+    expect(typeof parseFloat(row1.temperatureWeather)).toBe("number");
+    expect(typeof parseFloat(row1.lastMeasuredAt)).toBe("number");
+
+    const row2 = getExportedColums(csv[2]);
+
+    expect(row2.model).toBe("Warehouse");
+    expect(typeof row2.reference).toBe("string");
+    expect(typeof row2.position).toBe("string");
+    expect(typeof parseFloat(row2.positionAccuracy)).toBe("number");
+    expect(typeof parseFloat(row2.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row2.temperatureExt)).toBe("number");
+    expect(typeof parseFloat(row2.temperatureInt)).toBe("number");
+    expect(typeof parseFloat(row2.temperatureWeather)).toBe("number");
+    expect(typeof parseFloat(row2.lastMeasuredAt)).toBe("number");
+  });
+});

--- a/tests/scenario/modules/devices/action-export-measures.test.ts
+++ b/tests/scenario/modules/devices/action-export-measures.test.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { parse as csvParse } from "csv-parse/sync";
 
 import { ApiDeviceExportMeasuresRequest } from "../../../../index";
 
@@ -72,6 +73,7 @@ describe("DevicesController:exportMeasures", () => {
     expect(csv[0]).toBe(
       "Payload Id,Measured At,Measure Type,Device Id,Device Model,Asset Id,Asset Model,temperature,accelerationSensor.x,accelerationSensor.y,accelerationSensor.z,accelerationSensor.accuracy,battery\n"
     );
+
     const [
       payloadId,
       measuredAt,
@@ -81,7 +83,7 @@ describe("DevicesController:exportMeasures", () => {
       assetId,
       assetModel,
       temperature,
-    ] = csv[1].split(",");
+    ] = csvParse(csv[1])[0];
     const [
       ,
       ,
@@ -95,7 +97,7 @@ describe("DevicesController:exportMeasures", () => {
       accelerationY,
       accelerationZ,
       accelerationAccuracy,
-    ] = csv[2].split(",");
+    ] = csvParse(csv[2])[0];
 
     expect(typeof payloadId).toBe("string");
     expect(typeof parseFloat(measuredAt)).toBe("number");

--- a/tests/scenario/modules/devices/action-export.test.ts
+++ b/tests/scenario/modules/devices/action-export.test.ts
@@ -1,0 +1,124 @@
+import axios from "axios";
+import { parse as csvParse } from "csv-parse/sync";
+
+import {
+  ApiDeviceExportRequest,
+  ApiDeviceExportResult,
+} from "../../../../index";
+
+import {
+  sendDummyTempPositionPayloads,
+  sendDummyTempPayloads,
+  setupHooks,
+} from "../../../helpers";
+import fixtures from "../../../fixtures/fixtures";
+
+const deviceCount = fixtures["engine-ayse"].devices.length / 2;
+jest.setTimeout(10000);
+
+function getExportedColums(row) {
+  const parsedRow = csvParse(row)[0];
+
+  return {
+    model: parsedRow[0],
+    reference: parsedRow[1],
+    accelerationSensorX: parsedRow[2],
+    accelerationSensorY: parsedRow[3],
+    accelerationSensorZ: parsedRow[4],
+    accelerationSensorAccuracy: parsedRow[5],
+    battery: parsedRow[6],
+    position: parsedRow[7],
+    positionAccuracy: parsedRow[8],
+    positionAltitude: parsedRow[9],
+    temperature: parsedRow[10],
+    lastMeasuredAt: parsedRow[11],
+  };
+}
+
+describe("AssetsController:exportMeasures", () => {
+  const sdk = setupHooks();
+
+  it("should prepare export of different devices types and return a CSV as stream", async () => {
+    await sendDummyTempPayloads(sdk, [
+      {
+        deviceEUI: "linked1",
+        temperature: 23.3,
+        battery: 0.8,
+        // ? Use date now - 1s to ensure this asset are second in export
+        measuredAt: Date.now() - 1000,
+      },
+    ]);
+    await sendDummyTempPositionPayloads(sdk, [
+      {
+        deviceEUI: "linked2",
+        temperature: 23.3,
+        location: { lat: 42.2, lon: 2.42, accuracy: 2100 },
+        battery: 0.8,
+        // ? Use date now to ensure this asset is first in export
+        measuredAt: Date.now(),
+      },
+    ]);
+    await sdk.collection.refresh("engine-ayse", "devices");
+    const { result } = await sdk.query<
+      ApiDeviceExportRequest,
+      ApiDeviceExportResult
+    >({
+      controller: "device-manager/devices",
+      action: "export",
+      engineId: "engine-ayse",
+      body: {
+        sort: { lastMeasuredAt: "desc" },
+      },
+    });
+
+    expect(typeof result.link).toBe("string");
+
+    const response = await axios.get("http://localhost:7512" + result.link, {
+      responseType: "stream",
+    });
+
+    const csv = [];
+    response.data.on("data", (chunk) => {
+      csv.push(chunk.toString());
+    });
+    await new Promise((resolve) => {
+      response.data.on("end", resolve);
+    });
+
+    expect(csv[0]).toBe(
+      "Model,Reference,accelerationSensor.x,accelerationSensor.y,accelerationSensor.z,accelerationSensor.accuracy,battery,position,position.accuracy,position.altitude,temperature,lastMeasuredAt\n"
+    );
+
+    expect(csv).toHaveLength(deviceCount + 1);
+
+    const row1 = getExportedColums(csv[1]);
+
+    expect(row1.model).toBe("DummyTempPosition");
+    expect(typeof row1.reference).toBe("string");
+    expect(typeof parseFloat(row1.accelerationSensorX)).toBe("number");
+    expect(typeof parseFloat(row1.accelerationSensorY)).toBe("number");
+    expect(typeof parseFloat(row1.accelerationSensorZ)).toBe("number");
+    expect(typeof parseFloat(row1.accelerationSensorAccuracy)).toBe("number");
+    expect(typeof parseFloat(row1.battery)).toBe("number");
+    expect(typeof row1.position).toBe("string");
+    expect(typeof parseFloat(row1.positionAccuracy)).toBe("number");
+    expect(typeof parseFloat(row1.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row1.temperature)).toBe("number");
+    expect(typeof parseFloat(row1.lastMeasuredAt)).toBe("number");
+
+    const row2 = getExportedColums(csv[1]);
+
+    expect(row2.model).toBe("DummyTempPosition");
+    expect(typeof row2.reference).toBe("string");
+    expect(typeof parseFloat(row2.accelerationSensorX)).toBe("number");
+    expect(typeof parseFloat(row2.accelerationSensorY)).toBe("number");
+    expect(typeof parseFloat(row2.accelerationSensorZ)).toBe("number");
+    expect(typeof parseFloat(row2.accelerationSensorAccuracy)).toBe("number");
+    expect(typeof parseFloat(row2.battery)).toBe("number");
+    expect(typeof row2.position).toBe("string");
+    expect(typeof parseFloat(row2.positionAccuracy)).toBe("number");
+    expect(typeof parseFloat(row2.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row2.temperature)).toBe("number");
+    expect(typeof parseFloat(row2.lastMeasuredAt)).toBe("number");
+  });
+});


### PR DESCRIPTION
## What does this PR do ?

Add the list exports for digitalTwins

### How should this be manually tested?

  - Step 1 : Call in `POST` the endpoint `/device-manager/<engineId>/<type>/_export`, with `query` and `sort` in body
  - Step 2 : Call the URL returned by previous request, you should get a CSV file

`<type>` is `assets` or `devices`

### Other changes

Refactor `MeasureExporter` with `AbstractExporter` to mutualize the exports logic
