### PR TITLE
feat/assets migrate tenant

### DIFF
--- a/doc/2/controllers/assets/migrate-tenant/index.md
+++ b/doc/2/controllers/assets/migrate-tenant/index.md
@@ -1,0 +1,59 @@
+---
+code: true
+type: page
+title: migrateTenant
+description: Migrates a list of assets and their attached devices to another tenant
+---
+
+# update
+
+This action allow to migrates a list of assets and their attached devices to another tenant.
+
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/_migrateTenant
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/assets",
+  "action": "migrateTenant",
+  "engineId": "<engineId>",
+  "body": {
+    "assetsList": ["<assetId>"],
+    "newEngineId": "<newEngineId>"
+  }
+}
+```
+
+---
+
+## Arguments
+
+- `engineId`: Engine ID
+
+## Body properties
+
+- `assetsList`: An array containing a list of asset ids to migrate
+- `newEngineId`: The id of the engine you want to migrate the assets to
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/assets",
+  "action": "migrateTenant",
+  "requestId": "<unique request identifier>",
+}
+```

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -283,7 +283,7 @@ export class AssetService {
     return lock(`engine:${engineId}:${newEngineId}`, async () => {
       const recovery = new RecoveryQueue();
 
-      if (user.profileIds.includes("admin")) {
+      if (!user.profileIds.includes("admin")) {
         throw new BadRequestError(
           `User ${user._id} is not authorized to migrate assets`
         );

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -460,6 +460,18 @@ export class AssetService {
             }
           }
         });
+
+        // clear the groups
+        await this.sdk.document.mUpdate<AssetContent>(
+          newEngineId,
+          InternalCollection.ASSETS,
+          assetsList.map((assetId) => ({
+            _id: assetId,
+            body: {
+              groups: [],
+            },
+          }))
+        );
       } catch (error) {
         await recovery.rollback();
         throw new BadRequestError(

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -283,6 +283,12 @@ export class AssetService {
     return lock(`engine:${engineId}:${newEngineId}`, async () => {
       const recovery = new RecoveryQueue();
 
+      if (user.profileIds.includes("admin")) {
+        throw new BadRequestError(
+          `User ${user._id} is not authorized to migrate assets`
+        );
+      }
+
       try {
         // check if tenant destination of the the same group
         const engine = await this.getEngine(engineId);

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -96,6 +96,15 @@ export class AssetsController {
             },
           ],
         },
+        migrateTenant: {
+          handler: this.migrateTenant.bind(this),
+          http: [
+            {
+              path: "device-manager/:engineId/assets/_migrateTenant",
+              verb: "post",
+            },
+          ],
+        },
       },
     };
     /* eslint-enable sort-keys */
@@ -340,5 +349,17 @@ export class AssetsController {
     );
 
     return { link };
+  }
+
+  async migrateTenant(request: KuzzleRequest) {
+    const assetsList = request.getBodyArray("assetsList");
+    const engineId = request.getString("engineId");
+    const newEngineId = request.getBodyString("newEngineId");
+    await this.assetService.migrateTenant(
+      request.getUser(),
+      assetsList,
+      engineId,
+      newEngineId
+    );
   }
 }

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -140,3 +140,14 @@ export interface ApiAssetExportRequest extends AssetsControllerRequest {
 export type ApiAssetExportResult = {
   link: string;
 };
+
+export interface ApiAssetMigrateTenantRequest extends AssetsControllerRequest {
+  action: "migrateTenant";
+  engineId: string;
+  body: {
+    assetsList: string[];
+    newEngineId: string;
+  };
+}
+
+export type ApiAssetMigrateTenantResult = void;

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -21,8 +21,11 @@ import { DeviceContent } from "./types/DeviceContent";
 import { DeviceSerializer } from "./model/DeviceSerializer";
 import {
   AskDeviceUnlinkAsset,
+  AskDeviceDetachEngine,
   EventDeviceUpdateAfter,
   EventDeviceUpdateBefore,
+  AskDeviceAttachEngine,
+  AskDeviceLinkAsset,
 } from "./types/DeviceEvents";
 import { ApiDeviceLinkAssetRequest } from "./types/DeviceApi";
 import { AskPayloadReceiveFormated } from "../decoder/types/PayloadEvents";
@@ -54,11 +57,35 @@ export class DeviceService {
   constructor(plugin: Plugin) {
     this.config = plugin.config as any;
     this.context = plugin.context;
+    this.registerAskEvents();
+  }
+
+  registerAskEvents() {
+    onAsk<AskDeviceLinkAsset>(
+      "ask:device-manager:device:link-asset",
+      async ({ deviceId, engineId, user, assetId, measureNames }) => {
+        await this.linkAsset(user, engineId, deviceId, assetId, measureNames);
+      }
+    );
 
     onAsk<AskDeviceUnlinkAsset>(
       "ask:device-manager:device:unlink-asset",
       async ({ deviceId, user }) => {
         await this.unlinkAsset(user, deviceId);
+      }
+    );
+
+    onAsk<AskDeviceDetachEngine>(
+      "ask:device-manager:device:detach-engine",
+      async ({ deviceId, user }) => {
+        await this.detachEngine(user, deviceId);
+      }
+    );
+
+    onAsk<AskDeviceAttachEngine>(
+      "ask:device-manager:device:attach-engine",
+      async ({ deviceId, engineId, user }) => {
+        await this.attachEngine(user, engineId, deviceId);
       }
     );
   }

--- a/lib/modules/device/types/DeviceEvents.ts
+++ b/lib/modules/device/types/DeviceEvents.ts
@@ -4,6 +4,7 @@ import { KDocument } from "kuzzle-sdk";
 import { Metadata } from "../../../modules/shared";
 
 import { DeviceContent } from "./DeviceContent";
+import { ApiDeviceLinkAssetRequest } from "./DeviceApi";
 
 export type EventDeviceUpdateBefore = {
   name: "device-manager:device:update:before";
@@ -20,10 +21,47 @@ export type EventDeviceUpdateAfter = {
 /**
  * @internal
  */
+export type AskDeviceLinkAsset = {
+  name: "ask:device-manager:device:link-asset";
+
+  payload: {
+    engineId: string;
+    assetId: string;
+    deviceId: string;
+    user: User;
+    measureNames: ApiDeviceLinkAssetRequest["body"]["measureNames"];
+  };
+
+  result: void;
+};
+
 export type AskDeviceUnlinkAsset = {
   name: "ask:device-manager:device:unlink-asset";
 
   payload: {
+    deviceId: string;
+    user: User;
+  };
+
+  result: void;
+};
+
+export type AskDeviceDetachEngine = {
+  name: "ask:device-manager:device:detach-engine";
+
+  payload: {
+    deviceId: string;
+    user: User;
+  };
+
+  result: void;
+};
+
+export type AskDeviceAttachEngine = {
+  name: "ask:device-manager:device:attach-engine";
+
+  payload: {
+    engineId: string;
     deviceId: string;
     user: User;
   };

--- a/lib/modules/shared/utils/recoveryQueue.ts
+++ b/lib/modules/shared/utils/recoveryQueue.ts
@@ -1,0 +1,44 @@
+/**
+ * This recovery queue has been made by the paas team here https://github.com/kuzzleio/paas-console/blob/master/apps/api/lib/api/RecoveryQueue.ts
+ * The RecoveryQueue allows you to store action to perform later and trigger
+ * all of it at once.
+ */
+export class RecoveryQueue {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  private actions: Function[];
+
+  constructor() {
+    this.actions = [];
+  }
+
+  /**
+   * The addRecovery function adds a recovery function to an array of actions.
+   * @param {any} func - The `func` parameter is a function that you want to add to the `actions` array.
+   */
+  addRecovery(func: any) {
+    this.actions.push(func);
+  }
+
+  /**
+   * The "reset" function clears the "actions" array.
+   */
+  reset() {
+    this.actions = [];
+  }
+
+  /**
+   * The `rollback` function iterates through a list of actions in reverse order and attempts to execute
+   * each action, logging any errors encountered.
+   */
+  async rollback() {
+    for (const action of this.actions.reverse()) {
+      try {
+        await action();
+      } catch (error) {
+        global.app.log.error(`
+          Rollback process failed: ${error}
+        `);
+      }
+    }
+  }
+}

--- a/tests/hooks/collections.ts
+++ b/tests/hooks/collections.ts
@@ -41,6 +41,13 @@ export async function beforeEachTruncateCollections(sdk: Kuzzle) {
     truncateCollection(sdk, "engine-ayse", "assets-groups"),
     truncateCollection(sdk, "engine-ayse", "measures"),
     truncateCollection(sdk, "engine-ayse", "devices"),
+
+    truncateCollection(sdk, "engine-other-group", "assets"),
+    truncateCollection(sdk, "engine-other-group", "assets-history"),
+    truncateCollection(sdk, "engine-other-group", "assets-groups"),
+    truncateCollection(sdk, "engine-other-group", "measures"),
+    truncateCollection(sdk, "engine-other-group", "devices"),
+
     deleteModels(sdk),
   ]);
 }

--- a/tests/hooks/engines.ts
+++ b/tests/hooks/engines.ts
@@ -1,6 +1,10 @@
 import { BaseRequest, JSONObject, Kuzzle } from "kuzzle-sdk";
 
-async function createEngineIfNotExists(sdk: Kuzzle, index: string) {
+async function createEngineIfNotExists(
+  sdk: Kuzzle,
+  index: string,
+  group?: string
+) {
   const { result } = await sdk.query<BaseRequest, JSONObject>({
     controller: "device-manager/engine",
     action: "exists",
@@ -15,6 +19,7 @@ async function createEngineIfNotExists(sdk: Kuzzle, index: string) {
     controller: "device-manager/engine",
     action: "create",
     index,
+    group,
   });
 }
 
@@ -22,5 +27,6 @@ export async function beforeAllCreateEngines(sdk: Kuzzle) {
   await Promise.all([
     createEngineIfNotExists(sdk, "engine-ayse"),
     createEngineIfNotExists(sdk, "engine-kuzzle"),
+    createEngineIfNotExists(sdk, "engine-other-group", "other-group"),
   ]);
 }

--- a/tests/scenario/modules/assets/asset-migrate-tenant.test.ts
+++ b/tests/scenario/modules/assets/asset-migrate-tenant.test.ts
@@ -1,0 +1,113 @@
+import { useSdk } from "../../../helpers";
+import { beforeEachTruncateCollections } from "../../../hooks/collections";
+import { beforeAllCreateEngines } from "../../../hooks/engines";
+import { beforeEachLoadFixtures } from "../../../hooks/fixtures";
+
+jest.setTimeout(10000);
+
+describe("AssetsController:migrateTenant", () => {
+  const sdk = useSdk();
+
+  beforeAll(async () => {
+    await sdk.connect();
+
+    await beforeAllCreateEngines(sdk);
+  });
+
+  beforeEach(async () => {
+    await beforeEachTruncateCollections(sdk);
+    await beforeEachLoadFixtures(sdk);
+  });
+
+  afterAll(async () => {
+    sdk.disconnect();
+  });
+
+  it("should fail if the user is not an admin", async () => {
+    await expect(
+      sdk.query({
+        controller: "device-manager/assets",
+        action: "migrateTenant",
+        engineId: "engine-ayse",
+        body: {
+          assetsList: [],
+          newEngineId: "engine-kuzzle",
+        },
+      })
+    ).rejects.toThrow("User -1 is not authorized to migrate assets");
+  });
+
+  it("should fail if both engine does not belong to same group", async () => {
+    // We connect only here to avoid failing the first test
+    // If we do it in the beforeAll hook, the first test will fail
+    // And if we run it each time we might encounter  "Too many login attempts per second"
+    await sdk.auth.login("local", {
+      username: "test-admin",
+      password: "password",
+    });
+
+    await expect(
+      sdk.query({
+        controller: "device-manager/assets",
+        action: "migrateTenant",
+        engineId: "engine-ayse",
+        body: {
+          assetsList: [],
+          newEngineId: "engine-other-group",
+        },
+      })
+    ).rejects.toThrow(
+      "An error occured while migrating assets: BadRequestError: Engine engine-other-group is not in the same group as engine-ayse"
+    );
+  });
+
+  it("should fail if no assets are provided", async () => {
+    await expect(
+      sdk.query({
+        controller: "device-manager/assets",
+        action: "migrateTenant",
+        engineId: "engine-ayse",
+        body: {
+          assetsList: [],
+          newEngineId: "engine-kuzzle",
+        },
+      })
+    ).rejects.toThrow(
+      "An error occured while migrating assets: BadRequestError: No assets to migrate"
+    );
+  });
+
+  it("should copy assets from engine-ayse to engine-kuzzle", async () => {
+    const response = await sdk.query({
+      controller: "device-manager/assets",
+      action: "migrateTenant",
+      engineId: "engine-ayse",
+      body: {
+        assetsList: ["Container-linked1", "Container-linked2"],
+        newEngineId: "engine-kuzzle",
+      },
+    });
+
+    await sdk.collection.refresh("engine-kuzzle", "assets");
+
+    const assets = await sdk.query({
+      controller: "device-manager/assets",
+      action: "search",
+      engineId: "engine-kuzzle",
+      body: { query: { equals: { model: "Container" } } },
+      lang: "koncorde",
+    });
+
+    const devices = await sdk.query({
+      controller: "device-manager/assets",
+      action: "search",
+      engineId: "engine-kuzzle",
+      body: { query: {} },
+      lang: "koncorde",
+    });
+
+    expect(response.status).toBe(200);
+    expect(assets.result.hits).toHaveLength(2);
+    expect(devices.result.hits).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## assets/migrateTenant
The goal here is to provide a way to migrate assets and associated devices to a new tenant easily

### How should this be manually tested?

  - Step 1 : clone and run
  - Step 2 : try the new route
  - Step 3: Check the new doc page

### Other changes
- Adding recoveryQueue from PaaS team to rollback the events
- Adding Ask functions to deviceService
