### PR TITLE
refactor: add BaseService

### DIFF
--- a/lib/modules/asset/AssetHistoryService.ts
+++ b/lib/modules/asset/AssetHistoryService.ts
@@ -1,12 +1,7 @@
-import { PluginContext } from "kuzzle";
 import { mCreateRequest } from "kuzzle-sdk";
 
-import {
-  DeviceManagerConfiguration,
-  DeviceManagerPlugin,
-  InternalCollection,
-} from "../plugin";
-import { onAsk } from "../shared";
+import { DeviceManagerPlugin, InternalCollection } from "../plugin";
+import { onAsk, BaseService } from "../shared";
 
 import { AskAssetHistoryAdd } from "./types/AssetEvents";
 import {
@@ -14,17 +9,9 @@ import {
   AssetHistoryEvent,
 } from "./types/AssetHistoryContent";
 
-export class AssetHistoryService {
-  private context: PluginContext;
-  private config: DeviceManagerConfiguration;
-
-  private get sdk() {
-    return this.context.accessors.sdk;
-  }
-
+export class AssetHistoryService extends BaseService {
   constructor(plugin: DeviceManagerPlugin) {
-    this.context = plugin.context;
-    this.config = plugin.config;
+    super(plugin);
 
     onAsk<AskAssetHistoryAdd<AssetHistoryEvent>>(
       "ask:device-manager:asset:history:add",

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -1,4 +1,4 @@
-import { Backend, BadRequestError, Plugin, PluginContext, User } from "kuzzle";
+import { BadRequestError, User } from "kuzzle";
 import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import {
@@ -7,8 +7,8 @@ import {
   AssetHistoryEventLink,
   AssetHistoryEventUnlink,
 } from "./../asset";
-import { InternalCollection, DeviceManagerConfiguration } from "../plugin";
-import { Metadata, lock, ask, onAsk } from "../shared";
+import { InternalCollection, DeviceManagerPlugin } from "../plugin";
+import { Metadata, lock, ask, onAsk, BaseService } from "../shared";
 import {
   AskModelAssetGet,
   AskModelDeviceGet,
@@ -32,31 +32,10 @@ import { AskPayloadReceiveFormated } from "../decoder/types/PayloadEvents";
 
 type MeasureName = { asset: string; device: string; type: string };
 
-export class DeviceService {
-  private config: DeviceManagerConfiguration;
-  private context: PluginContext;
+export class DeviceService extends BaseService {
+  constructor(plugin: DeviceManagerPlugin) {
+    super(plugin);
 
-  private get sdk() {
-    return this.context.accessors.sdk;
-  }
-
-  private get app(): Backend {
-    return global.app;
-  }
-
-  private get impersonatedSdk() {
-    return (user: User) => {
-      if (user?._id) {
-        return this.sdk.as(user, { checkRights: false });
-      }
-
-      return this.sdk;
-    };
-  }
-
-  constructor(plugin: Plugin) {
-    this.config = plugin.config as any;
-    this.context = plugin.context;
     this.registerAskEvents();
   }
 

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -1,10 +1,4 @@
-import {
-  Backend,
-  BadRequestError,
-  JSONObject,
-  KDocument,
-  PluginContext,
-} from "kuzzle";
+import { BadRequestError, JSONObject, KDocument } from "kuzzle";
 import _ from "lodash";
 
 import {
@@ -16,12 +10,16 @@ import {
   AssetSerializer,
 } from "../asset";
 import { DeviceContent } from "../device";
+import { DeviceManagerPlugin, InternalCollection } from "../plugin";
 import {
-  DeviceManagerConfiguration,
-  DeviceManagerPlugin,
-  InternalCollection,
-} from "../plugin";
-import { ask, keepStack, lock, Metadata, objectDiff, onAsk } from "../shared";
+  ask,
+  BaseService,
+  keepStack,
+  lock,
+  Metadata,
+  objectDiff,
+  onAsk,
+} from "../shared";
 
 import { DecodedMeasurement, MeasureContent } from "./types/MeasureContent";
 import {
@@ -34,21 +32,9 @@ import {
   TenantEventMeasureProcessBefore,
 } from "./types/MeasureEvents";
 
-export class MeasureService {
-  private config: DeviceManagerConfiguration;
-  private context: PluginContext;
-
-  private get sdk() {
-    return this.context.accessors.sdk;
-  }
-
-  private get app(): Backend {
-    return global.app;
-  }
-
+export class MeasureService extends BaseService {
   constructor(plugin: DeviceManagerPlugin) {
-    this.config = plugin.config as any;
-    this.context = plugin.context;
+    super(plugin);
 
     onAsk<AskMeasureIngest>(
       "device-manager:measures:ingest",

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -1,21 +1,15 @@
-import {
-  BadRequestError,
-  Inflector,
-  NotFoundError,
-  PluginContext,
-} from "kuzzle";
+import { BadRequestError, Inflector, NotFoundError } from "kuzzle";
 import { JSONObject, KDocument } from "kuzzle-sdk";
 
 import {
   AskEngineUpdateAll,
-  DeviceManagerConfiguration,
   DeviceManagerPlugin,
   InternalCollection,
 } from "../plugin";
 import { ask, onAsk } from "../shared/utils/ask";
 
 import { AskAssetRefreshModel } from "../asset";
-import { flattenObject } from "../shared/utils/flattenObject";
+import { BaseService, flattenObject } from "../shared";
 import { ModelSerializer } from "./ModelSerializer";
 import {
   AssetModelContent,
@@ -28,17 +22,9 @@ import {
   AskModelMeasureGet,
 } from "./types/ModelEvents";
 
-export class ModelService {
-  private config: DeviceManagerConfiguration;
-  private context: PluginContext;
-
-  private get sdk() {
-    return this.context.accessors.sdk;
-  }
-
+export class ModelService extends BaseService {
   constructor(plugin: DeviceManagerPlugin) {
-    this.config = plugin.config as any;
-    this.context = plugin.context;
+    super(plugin);
 
     this.registerAskEvents();
   }

--- a/lib/modules/shared/services/BaseService.ts
+++ b/lib/modules/shared/services/BaseService.ts
@@ -1,0 +1,29 @@
+import { Backend, EmbeddedSDK, User } from "kuzzle";
+
+import { DeviceManagerPlugin, DeviceManagerConfiguration } from "../../plugin";
+
+export abstract class BaseService {
+  constructor(private plugin: DeviceManagerPlugin) {}
+
+  protected get app(): Backend {
+    return global.app;
+  }
+
+  protected get sdk(): EmbeddedSDK {
+    return this.plugin.context.accessors.sdk;
+  }
+
+  protected get config(): DeviceManagerConfiguration {
+    return this.plugin.config;
+  }
+
+  protected get impersonatedSdk() {
+    return (user: User) => {
+      if (user?._id) {
+        return this.sdk.as(user, { checkRights: false });
+      }
+
+      return this.sdk;
+    };
+  }
+}

--- a/lib/modules/shared/services/index.ts
+++ b/lib/modules/shared/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./AbstractExporter";
+export * from "./BaseService";
 export * from "./DigitalTwinExporter";

--- a/tests/scenario/modules/devices/action-export-measures.test.ts
+++ b/tests/scenario/modules/devices/action-export-measures.test.ts
@@ -91,9 +91,9 @@ describe("DevicesController:exportMeasures", () => {
          * Here we specify a measuredAt, because of a side effect in the decoder.
          * Sometimes the acceleration measurement would be registered earlier than the temperature's one.
          *
-         * The +1sec is to ensure that those two measures will always remain the last ones.
+         * The +10sec is to ensure that those two measures will always remain the last ones.
          */
-        measuredAt: Date.now() + 1000,
+        measuredAt: Date.now() + 10000,
       },
     ]);
     await sdk.collection.refresh("engine-ayse", "measures");


### PR DESCRIPTION
## What does this PR do ?

Refactor services to use the abstract shared class `BaseService`.
This abstract class provide some useful getters like `sdk`, `impersonatedSdk`, `config`.
Also to future, this allows to provide easily other getters or methods shared between services.
