### PR TITLE
Add groupsAsset in measures. Update measures mapping accordingly

### DIFF
--- a/lib/modules/asset/model/AssetSerializer.ts
+++ b/lib/modules/asset/model/AssetSerializer.ts
@@ -27,6 +27,7 @@ export class AssetSerializer {
   ): AssetMeasureContext {
     return {
       _id: asset._id,
+      groups: asset._source.groups,
       measureName,
       metadata: asset._source.metadata,
       model: asset._source.model,

--- a/lib/modules/asset/types/AssetContent.ts
+++ b/lib/modules/asset/types/AssetContent.ts
@@ -55,5 +55,5 @@ export type AssetMeasureContext<TMetadata extends Metadata = Metadata> = {
   measureName: string;
 } & Pick<
   AssetContent<JSONObject, TMetadata>,
-  "model" | "reference" | "metadata"
+  "model" | "reference" | "metadata" | "groups"
 >;

--- a/lib/modules/measure/collections/measuresMappings.ts
+++ b/lib/modules/measure/collections/measuresMappings.ts
@@ -30,6 +30,15 @@ export const measuresMappings = {
             // populated with asset models metadata mappings
           },
         },
+        groups: {
+          properties: {
+            id: {
+              type: "keyword",
+              fields: { text: { type: "text" } },
+            },
+            date: { type: "date" },
+          },
+        },
       },
     },
 

--- a/tests/application/tests/pipes.ts
+++ b/tests/application/tests/pipes.ts
@@ -55,6 +55,7 @@ export function registerTestPipes(app: Backend) {
             const temperatureInt: MeasureContent = {
               asset: {
                 _id: asset._id,
+                groups: asset._source.groups,
                 measureName: "temperatureInt",
                 metadata: asset._source.metadata,
                 model: asset._source.model,
@@ -105,6 +106,7 @@ export function registerTestPipes(app: Backend) {
           measuredAt: Date.now(),
           asset: {
             _id: asset._id,
+            groups: asset._source.groups,
             measureName: "temperatureWeather",
             metadata: asset._source.metadata,
             model: asset._source.model,


### PR DESCRIPTION
Currently, in the asset part of the measure, we do not store the groups of the asset.
We add it, so we will be able to use it in dashboards/widgets.
E.G , we want to display the temperature of the assets inside a specific group.