### PR TITLE
feat(digitalTwin): implement generic document pipes triggers

### DIFF
--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -70,13 +70,13 @@ export class AssetService extends BaseService {
 
   public async get(
     engineId: string,
-    assetId: string
+    assetId: string,
+    request: KuzzleRequest
   ): Promise<KDocument<AssetContent>> {
-    return this.sdk.document.get<AssetContent>(
+    return this.getDocument<AssetContent>(request, assetId, {
+      collection: InternalCollection.ASSETS,
       engineId,
-      InternalCollection.ASSETS,
-      assetId
-    );
+    });
   }
 
   /**
@@ -89,7 +89,7 @@ export class AssetService extends BaseService {
     request: KuzzleRequest
   ): Promise<KDocument<AssetContent>> {
     return lock(`asset:${engineId}:${assetId}`, async () => {
-      const asset = await this.get(engineId, assetId);
+      const asset = await this.get(engineId, assetId, request);
 
       const updatedPayload = await this.app.trigger<EventAssetUpdateBefore>(
         "device-manager:asset:update:before",
@@ -216,7 +216,7 @@ export class AssetService extends BaseService {
     const strict = request.getBoolean("strict");
 
     return lock<void>(`asset:${engineId}:${assetId}`, async () => {
-      const asset = await this.get(engineId, assetId);
+      const asset = await this.get(engineId, assetId, request);
 
       if (strict && asset._source.linkedDevices.length !== 0) {
         throw new BadRequestError(

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -30,6 +30,7 @@ import {
   lock,
   onAsk,
   BaseService,
+  SearchParams,
 } from "../shared";
 
 import { AssetHistoryService } from "./AssetHistoryService";
@@ -239,22 +240,13 @@ export class AssetService extends BaseService {
 
   public async search(
     engineId: string,
-    searchBody: JSONObject,
-    {
-      from,
-      size,
-      scroll,
-      lang,
-    }: { from?: number; size?: number; scroll?: string; lang?: string }
+    searchParams: SearchParams,
+    request: KuzzleRequest
   ): Promise<SearchResult<KHit<AssetContent>>> {
-    const result = await this.sdk.document.search<AssetContent>(
+    return await this.searchDocument<AssetContent>(request, searchParams, {
+      collection: InternalCollection.ASSETS,
       engineId,
-      InternalCollection.ASSETS,
-      searchBody,
-      { from, lang, scroll, size }
-    );
-
-    return result;
+    });
   }
 
   public async migrateTenant(

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -207,11 +207,13 @@ export class AssetService extends BaseService {
   }
 
   public async delete(
-    user: User,
     engineId: string,
     assetId: string,
-    { refresh, strict }: { refresh: any; strict: boolean }
+    request: KuzzleRequest
   ) {
+    const user = request.getUser();
+    const strict = request.getBoolean("strict");
+
     return lock<void>(`asset:${engineId}:${assetId}`, async () => {
       const asset = await this.get(engineId, assetId);
 
@@ -228,14 +230,10 @@ export class AssetService extends BaseService {
         );
       }
 
-      await this.sdk.document.delete(
+      await this.deleteDocument(request, assetId, {
+        collection: InternalCollection.ASSETS,
         engineId,
-        InternalCollection.ASSETS,
-        assetId,
-        {
-          refresh,
-        }
-      );
+      });
     });
   }
 

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -164,13 +164,8 @@ export class AssetsController {
   async delete(request: KuzzleRequest): Promise<ApiAssetDeleteResult> {
     const engineId = request.getString("engineId");
     const assetId = request.getId();
-    const refresh = request.getRefresh();
-    const strict = request.getBoolean("strict");
 
-    await this.assetService.delete(request.getUser(), engineId, assetId, {
-      refresh,
-      strict,
-    });
+    await this.assetService.delete(engineId, assetId, request);
   }
 
   async search(request: KuzzleRequest): Promise<ApiAssetSearchResult> {

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -169,23 +169,11 @@ export class AssetsController {
   }
 
   async search(request: KuzzleRequest): Promise<ApiAssetSearchResult> {
-    const engineId = request.getString("engineId");
-    const {
-      searchBody,
-      from,
-      size,
-      scrollTTL: scroll,
-    } = request.getSearchParams();
-    const lang = request.getLangParam();
-
-    const result = await this.assetService.search(engineId, searchBody, {
-      from,
-      lang,
-      scroll,
-      size,
-    });
-
-    return result;
+    return await this.assetService.search(
+      request.getString("engineId"),
+      request.getSearchParams(),
+      request
+    );
   }
 
   async getMeasures(

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -124,7 +124,7 @@ export class AssetsController {
     const assetId = request.getId();
     const engineId = request.getString("engineId");
 
-    const asset = await this.assetService.get(engineId, assetId);
+    const asset = await this.assetService.get(engineId, assetId, request);
 
     return AssetSerializer.serialize(asset);
   }

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -153,17 +153,13 @@ export class AssetsController {
     const model = request.getBodyString("model");
     const reference = request.getBodyString("reference");
     const metadata = request.getBodyObject("metadata", {});
-    const refresh = request.getRefresh();
 
     const asset = await this.assetService.create(
-      request.getUser(),
       engineId,
       model,
       reference,
       metadata,
-      {
-        refresh,
-      }
+      request
     );
 
     return AssetSerializer.serialize(asset);

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -133,16 +133,12 @@ export class AssetsController {
     const assetId = request.getId();
     const engineId = request.getString("engineId");
     const metadata = request.getBodyObject("metadata");
-    const refresh = request.getRefresh();
 
     const updatedAsset = await this.assetService.update(
-      request.getUser(),
       engineId,
       assetId,
       metadata,
-      {
-        refresh,
-      }
+      request
     );
 
     return AssetSerializer.serialize(updatedAsset);

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, User } from "kuzzle";
+import { BadRequestError, KuzzleRequest } from "kuzzle";
 import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import {
@@ -8,7 +8,14 @@ import {
   AssetHistoryEventUnlink,
 } from "./../asset";
 import { InternalCollection, DeviceManagerPlugin } from "../plugin";
-import { Metadata, lock, ask, onAsk, BaseService } from "../shared";
+import {
+  Metadata,
+  lock,
+  ask,
+  onAsk,
+  BaseService,
+  SearchParams,
+} from "../shared";
 import {
   AskModelAssetGet,
   AskModelDeviceGet,
@@ -43,28 +50,39 @@ export class DeviceService extends BaseService {
     onAsk<AskDeviceLinkAsset>(
       "ask:device-manager:device:link-asset",
       async ({ deviceId, engineId, user, assetId, measureNames }) => {
-        await this.linkAsset(user, engineId, deviceId, assetId, measureNames);
+        const request = new KuzzleRequest({ refresh: "false" }, { user });
+        await this.linkAsset(
+          engineId,
+          deviceId,
+          assetId,
+          measureNames,
+          false,
+          request
+        );
       }
     );
 
     onAsk<AskDeviceUnlinkAsset>(
       "ask:device-manager:device:unlink-asset",
       async ({ deviceId, user }) => {
-        await this.unlinkAsset(user, deviceId);
+        const request = new KuzzleRequest({ refresh: "false" }, { user });
+        await this.unlinkAsset(deviceId, request);
       }
     );
 
     onAsk<AskDeviceDetachEngine>(
       "ask:device-manager:device:detach-engine",
       async ({ deviceId, user }) => {
-        await this.detachEngine(user, deviceId);
+        const request = new KuzzleRequest({ refresh: "false" }, { user });
+        await this.detachEngine(deviceId, request);
       }
     );
 
     onAsk<AskDeviceAttachEngine>(
       "ask:device-manager:device:attach-engine",
       async ({ deviceId, engineId, user }) => {
-        await this.attachEngine(user, engineId, deviceId);
+        const request = new KuzzleRequest({ refresh: "false" }, { user });
+        await this.attachEngine(engineId, deviceId, request);
       }
     );
   }
@@ -77,17 +95,10 @@ export class DeviceService extends BaseService {
    * required as an argument (in part to check the tenant rights)
    */
   async create(
-    user: User,
     model: string,
     reference: string,
     metadata: JSONObject,
-    {
-      engineId,
-      refresh,
-    }: {
-      engineId?: string;
-      refresh?: any;
-    } = {}
+    request: KuzzleRequest
   ): Promise<KDocument<DeviceContent>> {
     let device: KDocument<DeviceContent> = {
       _id: DeviceSerializer.id(model, reference),
@@ -104,6 +115,7 @@ export class DeviceService extends BaseService {
 
     return lock(`device:create:${device._id}`, async () => {
       const deviceModel = await this.getDeviceModel(model);
+      const engineId = request.getString("engineId");
 
       for (const metadataName of Object.keys(
         deviceModel.device.metadataMappings
@@ -116,13 +128,13 @@ export class DeviceService extends BaseService {
         collection: string;
       }> = [];
 
-      const { _source } = await this.impersonatedSdk(
-        user
-      ).document.create<DeviceContent>(
-        this.config.adminIndex,
-        InternalCollection.DEVICES,
-        device._source,
-        device._id
+      const { _source } = await this.createDocument<DeviceContent>(
+        request,
+        device,
+        {
+          collection: InternalCollection.DEVICES,
+          engineId: this.config.adminIndex,
+        }
       );
 
       device._source = _source;
@@ -133,7 +145,7 @@ export class DeviceService extends BaseService {
       });
 
       if (engineId && engineId !== this.config.adminIndex) {
-        device = await this.attachEngine(user, engineId, device._id);
+        device = await this.attachEngine(engineId, device._id, request);
 
         refreshableCollections.push({
           collection: InternalCollection.DEVICES,
@@ -141,7 +153,7 @@ export class DeviceService extends BaseService {
         });
       }
 
-      if (refresh) {
+      if (request.getRefresh() === "wait_for") {
         await Promise.all(
           refreshableCollections.map(({ index, collection }) =>
             this.sdk.collection.refresh(index, collection)
@@ -154,43 +166,40 @@ export class DeviceService extends BaseService {
   }
 
   public async get(
-    index: string,
-    deviceId: string
+    engineId: string,
+    deviceId: string,
+    request: KuzzleRequest
   ): Promise<KDocument<DeviceContent>> {
-    const device = await this.sdk.document.get<DeviceContent>(
-      index,
-      InternalCollection.DEVICES,
-      deviceId
-    );
-
-    return device;
+    return this.getDocument<DeviceContent>(request, deviceId, {
+      collection: InternalCollection.DEVICES,
+      engineId,
+    });
   }
 
   public async update(
-    user: User,
     engineId: string,
     deviceId: string,
     metadata: Metadata,
-    { refresh }: { refresh: any }
+    request: KuzzleRequest
   ): Promise<KDocument<DeviceContent>> {
     return lock<KDocument<DeviceContent>>(
       `device:update:${deviceId}`,
       async () => {
-        const device = await this.get(engineId, deviceId);
+        const device = await this.get(engineId, deviceId, request);
 
         const updatedPayload = await this.app.trigger<EventDeviceUpdateBefore>(
           "device-manager:device:update:before",
           { device, metadata }
         );
 
-        const updatedDevice = await this.impersonatedSdk(
-          user
-        ).document.update<DeviceContent>(
-          engineId,
-          InternalCollection.DEVICES,
-          deviceId,
-          { metadata: updatedPayload.metadata },
-          { refresh, source: true }
+        const updatedDevice = await this.updateDocument<DeviceContent>(
+          request,
+          {
+            _id: deviceId,
+            _source: { metadata: updatedPayload.metadata },
+          },
+          { collection: InternalCollection.DEVICES, engineId },
+          { source: true }
         );
 
         await this.app.trigger<EventDeviceUpdateAfter>(
@@ -207,13 +216,12 @@ export class DeviceService extends BaseService {
   }
 
   public async delete(
-    user: User,
     engineId: string,
     deviceId: string,
-    { refresh }: { refresh: any }
+    request: KuzzleRequest
   ) {
     return lock<void>(`device:delete:${deviceId}`, async () => {
-      const device = await this.get(engineId, deviceId);
+      const device = await this.get(engineId, deviceId, request);
 
       const promises = [];
 
@@ -231,56 +239,51 @@ export class DeviceService extends BaseService {
         promises.push(
           // Potential race condition if someone update the asset linkedDevices
           // at the same time (e.g link or unlink asset)
-          this.impersonatedSdk(user)
-            .document.update<AssetContent>(
-              engineId,
-              InternalCollection.ASSETS,
-              device._source.assetId,
-              { linkedDevices },
-              { refresh }
-            )
-            .then(async (updatedAsset) => {
-              const event: AssetHistoryEventUnlink = {
-                name: "unlink",
-                unlink: {
-                  deviceId,
-                },
-              };
+          this.updateDocument<AssetContent>(
+            request,
+            {
+              _id: device._source.assetId,
+              _source: { linkedDevices },
+            },
+            { collection: InternalCollection.ASSETS, engineId }
+          ).then(async (updatedAsset) => {
+            const event: AssetHistoryEventUnlink = {
+              name: "unlink",
+              unlink: {
+                deviceId,
+              },
+            };
 
-              await ask<AskAssetHistoryAdd<AssetHistoryEventUnlink>>(
-                "ask:device-manager:asset:history:add",
-                {
-                  engineId,
-                  histories: [
-                    {
-                      asset: updatedAsset._source,
-                      event,
-                      id: updatedAsset._id,
-                      timestamp: Date.now(),
-                    },
-                  ],
-                }
-              );
-            })
+            await ask<AskAssetHistoryAdd<AssetHistoryEventUnlink>>(
+              "ask:device-manager:asset:history:add",
+              {
+                engineId,
+                histories: [
+                  {
+                    asset: updatedAsset._source,
+                    event,
+                    id: updatedAsset._id,
+                    timestamp: Date.now(),
+                  },
+                ],
+              }
+            );
+          })
         );
       }
 
       promises.push(
-        this.sdk.document.delete(
-          this.config.adminIndex,
-          InternalCollection.DEVICES,
-          deviceId,
-          { refresh }
-        )
+        this.deleteDocument(request, deviceId, {
+          collection: InternalCollection.DEVICES,
+          engineId: this.config.adminIndex,
+        })
       );
 
       promises.push(
-        this.sdk.document.delete(
+        this.deleteDocument(request, deviceId, {
+          collection: InternalCollection.DEVICES,
           engineId,
-          InternalCollection.DEVICES,
-          deviceId,
-          { refresh }
-        )
+        })
       );
 
       await Promise.all(promises);
@@ -289,22 +292,13 @@ export class DeviceService extends BaseService {
 
   public async search(
     engineId: string,
-    searchBody: JSONObject,
-    {
-      from,
-      size,
-      scroll,
-      lang,
-    }: { from?: number; size?: number; scroll?: string; lang?: string }
+    searchParams: SearchParams,
+    request: KuzzleRequest
   ): Promise<SearchResult<KHit<DeviceContent>>> {
-    const result = await this.sdk.document.search<DeviceContent>(
+    return await this.searchDocument<DeviceContent>(request, searchParams, {
+      collection: InternalCollection.DEVICES,
       engineId,
-      InternalCollection.DEVICES,
-      searchBody,
-      { from, lang, scroll, size }
-    );
-
-    return result;
+    });
   }
 
   /**
@@ -316,13 +310,12 @@ export class DeviceService extends BaseService {
    * @param options.strict If true, throw if an operation isn't possible
    */
   async attachEngine(
-    user: User,
     engineId: string,
     deviceId: string,
-    { refresh }: { refresh?: any } = {}
+    request: KuzzleRequest
   ): Promise<KDocument<DeviceContent>> {
     return lock(`device:attachEngine:${deviceId}`, async () => {
-      const device = await this.get(this.config.adminIndex, deviceId);
+      const device = await this.get(this.config.adminIndex, deviceId, request);
 
       if (device._source.engineId) {
         throw new BadRequestError(
@@ -335,23 +328,18 @@ export class DeviceService extends BaseService {
       device._source.engineId = engineId;
 
       const [updatedDevice] = await Promise.all([
-        this.impersonatedSdk(user).document.update<DeviceContent>(
-          this.config.adminIndex,
-          InternalCollection.DEVICES,
-          device._id,
-          { engineId },
-          { source: true }
-        ),
+        this.updateDocument<DeviceContent>(request, device, {
+          collection: InternalCollection.DEVICES,
+          engineId: this.config.adminIndex,
+        }),
 
-        this.impersonatedSdk(user).document.create<DeviceContent>(
-          device._source.engineId,
-          InternalCollection.DEVICES,
-          device._source,
-          device._id
-        ),
+        this.createDocument<DeviceContent>(request, device, {
+          collection: InternalCollection.DEVICES,
+          engineId,
+        }),
       ]);
 
-      if (refresh) {
+      if (request.getRefresh() === "wait_for") {
         await Promise.all([
           this.sdk.collection.refresh(
             this.config.adminIndex,
@@ -371,29 +359,33 @@ export class DeviceService extends BaseService {
   /**
    * Detach a device from its attached engine
    *
-   * @param deviceId Device id
-   * @param options.refresh Wait for ES indexation
+   * @param {string} deviceId Id of the device
+   * @param {KuzzleRequest} request kuzzle request
    */
   async detachEngine(
-    user: User,
     deviceId: string,
-    { refresh }: { refresh?: any } = {}
+    request: KuzzleRequest
   ): Promise<KDocument<DeviceContent>> {
     return lock(`device:detachEngine:${deviceId}`, async () => {
-      const device = await this.get(this.config.adminIndex, deviceId);
+      const device = await this.get(this.config.adminIndex, deviceId, request);
 
       this.checkAttachedToEngine(device);
 
       if (device._source.assetId) {
-        await this.unlinkAsset(user, deviceId, { refresh });
+        await this.unlinkAsset(deviceId, request);
       }
 
       await Promise.all([
-        this.impersonatedSdk(user).document.update(
-          this.config.adminIndex,
-          InternalCollection.DEVICES,
-          device._id,
-          { engineId: null }
+        this.updateDocument<DeviceContent>(
+          request,
+          {
+            _id: device._id,
+            _source: { engineId: null },
+          },
+          {
+            collection: InternalCollection.DEVICES,
+            engineId: this.config.adminIndex,
+          }
         ),
 
         this.sdk.document.delete(
@@ -403,7 +395,7 @@ export class DeviceService extends BaseService {
         ),
       ]);
 
-      if (refresh) {
+      if (request.getRefresh() === "wait_for") {
         await Promise.all([
           this.sdk.collection.refresh(
             this.config.adminIndex,
@@ -424,21 +416,18 @@ export class DeviceService extends BaseService {
    * Link a device to an asset.
    */
   async linkAsset(
-    user: User,
     engineId: string,
     deviceId: string,
     assetId: string,
     measureNames: ApiDeviceLinkAssetRequest["body"]["measureNames"],
-    {
-      refresh,
-      implicitMeasuresLinking,
-    }: { refresh?: any; implicitMeasuresLinking?: boolean } = {}
+    implicitMeasuresLinking: boolean,
+    request: KuzzleRequest
   ): Promise<{
     asset: KDocument<AssetContent>;
     device: KDocument<DeviceContent>;
   }> {
     return lock(`device:linkAsset:${deviceId}`, async () => {
-      const device = await this.get(this.config.adminIndex, deviceId);
+      const device = await this.get(this.config.adminIndex, deviceId, request);
       const engine = await this.getEngine(engineId);
 
       this.checkAttachedToEngine(device);
@@ -509,26 +498,28 @@ export class DeviceService extends BaseService {
       });
 
       const [updatedDevice, , updatedAsset] = await Promise.all([
-        this.impersonatedSdk(user).document.update<DeviceContent>(
-          this.config.adminIndex,
-          InternalCollection.DEVICES,
-          device._id,
-          { assetId },
+        this.updateDocument<DeviceContent>(
+          request,
+          device,
+          {
+            collection: InternalCollection.DEVICES,
+            engineId: this.config.adminIndex,
+          },
           { source: true }
         ),
 
-        this.impersonatedSdk(user).document.update<DeviceContent>(
-          device._source.engineId,
-          InternalCollection.DEVICES,
-          device._id,
-          { assetId }
-        ),
+        this.updateDocument<DeviceContent>(request, device, {
+          collection: InternalCollection.DEVICES,
+          engineId: device._source.engineId,
+        }),
 
-        this.impersonatedSdk(user).document.update<AssetContent>(
-          device._source.engineId,
-          InternalCollection.ASSETS,
-          asset._id,
-          { linkedDevices: asset._source.linkedDevices },
+        this.updateDocument<AssetContent>(
+          request,
+          asset,
+          {
+            collection: InternalCollection.ASSETS,
+            engineId: device._source.engineId,
+          },
           { source: true }
         ),
       ]);
@@ -554,7 +545,7 @@ export class DeviceService extends BaseService {
         }
       );
 
-      if (refresh) {
+      if (request.getRefresh() === "wait_for") {
         await Promise.all([
           this.sdk.collection.refresh(
             this.config.adminIndex,
@@ -579,9 +570,10 @@ export class DeviceService extends BaseService {
     engineId: string,
     deviceId: string,
     measures: DecodedMeasurement[],
-    payloadUuids: string[]
+    payloadUuids: string[],
+    request: KuzzleRequest
   ) {
-    const device = await this.get(engineId, deviceId);
+    const device = await this.get(engineId, deviceId, request);
     const deviceModel = await this.getDeviceModel(device._source.model);
 
     for (const measure of measures) {
@@ -679,19 +671,18 @@ export class DeviceService extends BaseService {
   /**
    * Unlink a device of an asset
    *
-   * @param deviceId Id of the device
-   * @param options.refresh Wait for ES indexation
+   * @param {string} deviceId Id of the device
+   * @param {KuzzleRequest} request kuzzle request
    */
   async unlinkAsset(
-    user: User,
     deviceId: string,
-    { refresh }: { refresh?: any } = {}
+    request: KuzzleRequest
   ): Promise<{
     asset: KDocument<AssetContent>;
     device: KDocument<DeviceContent>;
   }> {
     return lock(`device:unlinkAsset:${deviceId}`, async () => {
-      const device = await this.get(this.config.adminIndex, deviceId);
+      const device = await this.get(this.config.adminIndex, deviceId, request);
       const engineId = device._source.engineId;
 
       this.checkAttachedToEngine(device);
@@ -713,26 +704,32 @@ export class DeviceService extends BaseService {
       );
 
       const [updatedDevice, , updatedAsset] = await Promise.all([
-        this.impersonatedSdk(user).document.update<DeviceContent>(
-          this.config.adminIndex,
-          InternalCollection.DEVICES,
-          device._id,
-          { assetId: null },
+        this.updateDocument<DeviceContent>(
+          request,
+          { _id: device._id, _source: { assetId: null } },
+          {
+            collection: InternalCollection.DEVICES,
+            engineId: this.config.adminIndex,
+          },
           { source: true }
         ),
 
-        this.impersonatedSdk(user).document.update<DeviceContent>(
-          engineId,
-          InternalCollection.DEVICES,
-          device._id,
-          { assetId: null }
+        this.updateDocument<DeviceContent>(
+          request,
+          { _id: device._id, _source: { assetId: null } },
+          {
+            collection: InternalCollection.DEVICES,
+            engineId,
+          }
         ),
 
-        this.impersonatedSdk(user).document.update<AssetContent>(
-          engineId,
-          InternalCollection.ASSETS,
-          asset._id,
-          { linkedDevices },
+        this.updateDocument<AssetContent>(
+          request,
+          { _id: asset._id, _source: { linkedDevices } },
+          {
+            collection: InternalCollection.ASSETS,
+            engineId,
+          },
           { source: true }
         ),
       ]);
@@ -758,7 +755,7 @@ export class DeviceService extends BaseService {
         }
       );
 
-      if (refresh) {
+      if (request.getRefresh() === "wait_for") {
         await Promise.all([
           this.sdk.collection.refresh(
             this.config.adminIndex,

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -170,7 +170,7 @@ export class DevicesController {
     const deviceId = request.getId();
     const engineId = request.getString("engineId");
 
-    const device = await this.deviceService.get(engineId, deviceId);
+    const device = await this.deviceService.get(engineId, deviceId, request);
 
     return DeviceSerializer.serialize(device);
   }
@@ -179,16 +179,12 @@ export class DevicesController {
     const deviceId = request.getId();
     const engineId = request.getString("engineId");
     const metadata = request.getBodyObject("metadata");
-    const refresh = request.getRefresh();
 
     const updatedDevice = await this.deviceService.update(
-      request.getUser(),
       engineId,
       deviceId,
       metadata,
-      {
-        refresh,
-      }
+      request
     );
 
     return DeviceSerializer.serialize(updatedDevice);
@@ -197,52 +193,31 @@ export class DevicesController {
   async delete(request: KuzzleRequest): Promise<ApiDeviceDeleteResult> {
     const engineId = request.getString("engineId");
     const deviceId = request.getId();
-    const refresh = request.getRefresh();
 
-    await this.deviceService.delete(request.getUser(), engineId, deviceId, {
-      refresh,
-    });
+    await this.deviceService.delete(engineId, deviceId, request);
   }
 
   async search(request: KuzzleRequest): Promise<ApiDeviceSearchResult> {
-    const engineId = request.getString("engineId");
-    const {
-      searchBody,
-      from,
-      size,
-      scrollTTL: scroll,
-    } = request.getSearchParams();
-    const lang = request.getLangParam();
-
-    const result = await this.deviceService.search(engineId, searchBody, {
-      from,
-      lang,
-      scroll,
-      size,
-    });
-
-    return result;
+    return await this.deviceService.search(
+      request.getString("engineId"),
+      request.getSearchParams(),
+      request
+    );
   }
 
   /**
    * Create and provision a new device
    */
   async create(request: KuzzleRequest): Promise<ApiDeviceCreateResult> {
-    const engineId = request.getString("engineId");
     const model = request.getBodyString("model");
     const reference = request.getBodyString("reference");
     const metadata = request.getBodyObject("metadata", {});
-    const refresh = request.getRefresh();
 
     const device = await this.deviceService.create(
-      request.getUser(),
       model,
       reference,
       metadata,
-      {
-        engineId,
-        refresh,
-      }
+      request
     );
 
     return DeviceSerializer.serialize(device);
@@ -256,16 +231,8 @@ export class DevicesController {
   ): Promise<ApiDeviceAttachEngineResult> {
     const engineId = request.getString("engineId");
     const deviceId = request.getId();
-    const refresh = request.getRefresh();
 
-    await this.deviceService.attachEngine(
-      request.getUser(),
-      engineId,
-      deviceId,
-      {
-        refresh,
-      }
-    );
+    await this.deviceService.attachEngine(engineId, deviceId, request);
   }
 
   /**
@@ -275,11 +242,8 @@ export class DevicesController {
     request: KuzzleRequest
   ): Promise<ApiDeviceDetachEngineResult> {
     const deviceId = request.getId();
-    const refresh = request.getRefresh();
 
-    await this.deviceService.detachEngine(request.getUser(), deviceId, {
-      refresh,
-    });
+    await this.deviceService.detachEngine(deviceId, request);
   }
 
   /**
@@ -296,7 +260,6 @@ export class DevicesController {
     const implicitMeasuresLinking = request.getBoolean(
       "implicitMeasuresLinking"
     );
-    const refresh = request.getRefresh();
 
     if (measureNames.length === 0 && !implicitMeasuresLinking) {
       throw new BadRequestError(
@@ -305,12 +268,12 @@ export class DevicesController {
     }
 
     const { asset, device } = await this.deviceService.linkAsset(
-      request.getUser(),
       engineId,
       deviceId,
       assetId,
       measureNames,
-      { implicitMeasuresLinking, refresh }
+      implicitMeasuresLinking,
+      request
     );
 
     return {
@@ -326,14 +289,10 @@ export class DevicesController {
     request: KuzzleRequest
   ): Promise<ApiDeviceUnlinkAssetResult> {
     const deviceId = request.getId();
-    const refresh = request.getRefresh();
 
     const { asset, device } = await this.deviceService.unlinkAsset(
-      request.getUser(),
       deviceId,
-      {
-        refresh,
-      }
+      request
     );
 
     return {
@@ -480,7 +439,8 @@ export class DevicesController {
       engineId,
       deviceId,
       measures,
-      payloadUuids
+      payloadUuids,
+      request
     );
   }
 

--- a/lib/modules/plugin/exports.ts
+++ b/lib/modules/plugin/exports.ts
@@ -1,2 +1,2 @@
-export * from "./types/DeviceManagerConfiguration";
+export * from "./types/exports";
 export * from "./DeviceManagerPlugin";

--- a/lib/modules/plugin/index.ts
+++ b/lib/modules/plugin/index.ts
@@ -1,4 +1,3 @@
-export * from "./types/DeviceManagerConfiguration";
+export * from "./types";
 export * from "./DeviceManagerEngine";
 export * from "./DeviceManagerPlugin";
-export * from "./types/InternalCollection";

--- a/lib/modules/plugin/types/Pipes.ts
+++ b/lib/modules/plugin/types/Pipes.ts
@@ -1,0 +1,22 @@
+import { JSONObject, KDocumentContent, KHit, KuzzleRequest } from "kuzzle";
+
+export interface SearchQueryResult<T extends KDocumentContent> {
+  aggregations?: JSONObject;
+  hits: Array<KHit<T>>;
+  remaining: unknown;
+  scrollId: string;
+  suggest: JSONObject;
+  total: number;
+}
+
+export type EventGenericDocumentBeforeSearch = {
+  name: `generic:document:beforeSearch`;
+  args: [JSONObject, KuzzleRequest];
+};
+
+export type EventGenericDocumentAfterSearch<
+  T extends KDocumentContent = KDocumentContent
+> = {
+  name: `generic:document:afterSearch`;
+  args: [SearchQueryResult<T>, KuzzleRequest];
+};

--- a/lib/modules/plugin/types/exports.ts
+++ b/lib/modules/plugin/types/exports.ts
@@ -1,0 +1,1 @@
+export * from "./DeviceManagerConfiguration";

--- a/lib/modules/plugin/types/index.ts
+++ b/lib/modules/plugin/types/index.ts
@@ -1,0 +1,3 @@
+export * from "./DeviceManagerConfiguration";
+export * from "./InternalCollection";
+export * from "./Pipes";


### PR DESCRIPTION
## What does this PR do ?

Use `BaseService` implemented in #319 to implement sdk methods wrapper to trigger [generic:document](https://docs.kuzzle.io/core/2/framework/events/generic-document) events for internal SCRUD calls for Assets and Devices

### Side notes

Todo add to documentation the events `generic:document:beforeSearch` and `generic:document:afterSearch` which was not yet defined.