### PR TITLE
feat(digitalTwin): allow to modify mapping from application

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "@jest/types";
 
 // Sync object
 const config: Config.InitialOptions = {
+  testTimeout: 20000,
   transform: {
     "^.+\\.tsx?$": ["ts-jest", { tsconfig: "./tests/tsconfig.json" }],
   },

--- a/lib/modules/device/collections/deviceMappings.ts
+++ b/lib/modules/device/collections/deviceMappings.ts
@@ -1,9 +1,11 @@
+import { CollectionMappings } from "kuzzle";
+
 /**
  * Base mappings for the "devices" collection.
  *
  * Those mappings does not contains the `measures` and `metadata` mappings.
  */
-export const devicesMappings = {
+export const devicesMappings: CollectionMappings = {
   dynamic: "strict",
   properties: {
     model: {

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -20,7 +20,7 @@ import {
 
 import { DeviceModule, devicesMappings } from "../device";
 import { MeasureModule } from "../measure";
-import { AssetModule } from "../asset";
+import { AssetModule, assetsMappings } from "../asset";
 import {
   DecoderModule,
   NamedMeasures,
@@ -216,6 +216,14 @@ export class DeviceManagerPlugin extends Plugin {
             properties: {},
           },
           settings: {},
+        },
+        asset: {
+          name: InternalCollection.ASSETS,
+          mappings: assetsMappings,
+        },
+        device: {
+          name: InternalCollection.DEVICES,
+          mappings: devicesMappings,
         },
       },
     };

--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "kuzzle-sdk";
+import { CollectionMappings, JSONObject } from "kuzzle-sdk";
 
 export type DeviceManagerConfiguration = {
   /**
@@ -51,6 +51,14 @@ export type DeviceManagerConfiguration = {
       name: string;
       mappings: JSONObject;
       settings: JSONObject;
+    };
+    asset: {
+      name: string;
+      mappings: CollectionMappings;
+    };
+    device: {
+      name: string;
+      mappings: CollectionMappings;
     };
   };
 };

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -15,6 +15,17 @@ const app = new Backend("kuzzle");
 
 const deviceManager = new DeviceManagerPlugin();
 
+//? Add custom mapping properties
+deviceManager.config.engineCollections.asset.mappings.properties["softTenant"] = {
+  type: "keyword",
+  fields: { text: { type: "text" } },
+};
+deviceManager.config.engineCollections.device.mappings.properties["softTenant"] = {
+  type: "keyword",
+  fields: { text: { type: "text" } },
+};
+
+
 deviceManager.models.registerDevice("DummyTempPosition", {
   decoder: new DummyTempPositionDecoder(),
   metadataMappings: {

--- a/tests/scenario/custom-mapping.test.ts
+++ b/tests/scenario/custom-mapping.test.ts
@@ -1,0 +1,43 @@
+import { JSONObject } from "kuzzle-sdk";
+import { useSdk } from "../helpers";
+import { beforeAllCreateEngines } from "../hooks/engines";
+
+describe("Assets mapping", () => {
+  const sdk = useSdk();
+
+  beforeAll(async () => {
+    await sdk.connect();
+
+    await beforeAllCreateEngines(sdk);
+  });
+
+  afterAll(async () => {
+    sdk.disconnect();
+  });
+
+  it("asset mapping can be customize by application", async () => {
+    const mapping: JSONObject = await sdk.collection.getMapping(
+      "engine-ayse",
+      "assets"
+    );
+
+    expect(mapping.properties?.softTenant).toBeDefined();
+    expect(mapping.properties.softTenant).toMatchObject({
+      type: "keyword",
+      fields: { text: { type: "text" } },
+    });
+  });
+
+  it("device mapping can be customize by application", async () => {
+    const mapping: JSONObject = await sdk.collection.getMapping(
+      "engine-ayse",
+      "devices"
+    );
+
+    expect(mapping.properties?.softTenant).toBeDefined();
+    expect(mapping.properties.softTenant).toMatchObject({
+      type: "keyword",
+      fields: { text: { type: "text" } },
+    });
+  });
+});

--- a/tests/scenario/modules/devices/action-export-measures.test.ts
+++ b/tests/scenario/modules/devices/action-export-measures.test.ts
@@ -80,20 +80,31 @@ describe("DevicesController:exportMeasures", () => {
       { deviceEUI: "linked1", temperature: 38 },
       {
         deviceEUI: "linked1",
-        temperature: 37,
-        acceleration: {
-          x: 1,
-          y: 2.5,
-          z: -1,
-          accuracy: 0.1,
+        temperature: {
+          value: 37,
+          /**
+           * Here we specify a measuredAt, because of a side effect in the decoder.
+           * Sometimes the acceleration measurement would be registered earlier than the temperature's one.
+           *
+           * The +10sec is to ensure that those two measures will always remain the last ones.
+           */
+          measuredAt: Date.now() + 10000,
         },
-        /**
-         * Here we specify a measuredAt, because of a side effect in the decoder.
-         * Sometimes the acceleration measurement would be registered earlier than the temperature's one.
-         *
-         * The +10sec is to ensure that those two measures will always remain the last ones.
-         */
-        measuredAt: Date.now() + 10000,
+        acceleration: {
+          value: {
+            x: 1,
+            y: 2.5,
+            z: -1,
+            accuracy: 0.1,
+          },
+          /**
+           * Here we specify a measuredAt, because of a side effect in the decoder.
+           * Sometimes the battery measurement would be registered earlier than the acceleration's one.
+           *
+           * The +5sec is to ensure that those two measures will always remain the last ones.
+           */
+          measuredAt: Date.now() + 5000,
+        },
       },
     ]);
     await sdk.collection.refresh("engine-ayse", "measures");


### PR DESCRIPTION
## What does this PR do ?

Allow to modify digital twin mapping from application.
These allow to extend mapping properties from application to use custom properties in documents.

This is needed to add `softTenant` property to restrict access to a specific soft tenant, this mapping modification is added from package iot-platform-backend package with plugins setup.
