### PR TITLE
Kzlprd 166 upsert assets

### DIFF
--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -1,4 +1,4 @@
-import { BadRequestError, KuzzleRequest, User } from 'kuzzle';
+import { BadRequestError, KuzzleRequest, User } from "kuzzle";
 import {
   BaseRequest,
   DocumentSearchResult,
@@ -7,21 +7,21 @@ import {
   KHit,
   SearchResult,
   mReplaceResponse,
-} from 'kuzzle-sdk';
-import _ from 'lodash';
+} from "kuzzle-sdk";
+import _ from "lodash";
 
 import {
   AskDeviceAttachEngine,
   AskDeviceDetachEngine,
   AskDeviceLinkAsset,
   AskDeviceUnlinkAsset,
-} from '../device';
-import { AskModelAssetGet, AssetModelContent } from '../model';
+} from "../device";
+import { AskModelAssetGet, AssetModelContent } from "../model";
 import {
   AskEngineList,
   DeviceManagerPlugin,
   InternalCollection,
-} from '../plugin';
+} from "../plugin";
 import {
   EmbeddedMeasure,
   Metadata,
@@ -31,21 +31,21 @@ import {
   onAsk,
   BaseService,
   SearchParams,
-} from '../shared';
+} from "../shared";
 
-import { AssetHistoryService } from './AssetHistoryService';
-import { AssetSerializer } from './model/AssetSerializer';
-import { AssetContent } from './types/AssetContent';
+import { AssetHistoryService } from "./AssetHistoryService";
+import { AssetSerializer } from "./model/AssetSerializer";
+import { AssetContent } from "./types/AssetContent";
 import {
   AskAssetRefreshModel,
   EventAssetUpdateAfter,
   EventAssetUpdateBefore,
-} from './types/AssetEvents';
+} from "./types/AssetEvents";
 import {
   AssetHistoryContent,
   AssetHistoryEventMetadata,
-} from './types/AssetHistoryContent';
-import { ApiAssetMigrateTenantResult } from './types/AssetApi';
+} from "./types/AssetHistoryContent";
+import { ApiAssetMigrateTenantResult } from "./types/AssetApi";
 
 export class AssetService extends BaseService {
   private assetHistoryService: AssetHistoryService;
@@ -63,7 +63,7 @@ export class AssetService extends BaseService {
 
   registerAskEvents() {
     onAsk<AskAssetRefreshModel>(
-      'ask:device-manager:asset:refresh-model',
+      "ask:device-manager:asset:refresh-model",
       this.refreshModel.bind(this)
     );
   }
@@ -92,7 +92,7 @@ export class AssetService extends BaseService {
       const asset = await this.get(engineId, assetId, request);
 
       const updatedPayload = await this.app.trigger<EventAssetUpdateBefore>(
-        'device-manager:asset:update:before',
+        "device-manager:asset:update:before",
         { asset, metadata }
       );
 
@@ -116,7 +116,7 @@ export class AssetService extends BaseService {
             metadata: {
               names: Object.keys(flattenObject(updatedPayload.metadata)),
             },
-            name: 'metadata',
+            name: "metadata",
           },
           id: updatedAsset._id,
           timestamp: Date.now(),
@@ -124,7 +124,7 @@ export class AssetService extends BaseService {
       ]);
 
       await this.app.trigger<EventAssetUpdateAfter>(
-        'device-manager:asset:update:after',
+        "device-manager:asset:update:after",
         {
           asset: updatedAsset,
           metadata: updatedPayload.metadata,
@@ -156,7 +156,7 @@ export class AssetService extends BaseService {
       }
 
       const updatedPayload = await this.app.trigger<EventAssetUpdateBefore>(
-        'device-manager:asset:update:before',
+        "device-manager:asset:update:before",
         { asset, metadata }
       );
 
@@ -180,7 +180,7 @@ export class AssetService extends BaseService {
             metadata: {
               names: Object.keys(flattenObject(updatedPayload.metadata)),
             },
-            name: 'metadata',
+            name: "metadata",
           },
           id: updatedAsset._id,
           timestamp: Date.now(),
@@ -188,7 +188,7 @@ export class AssetService extends BaseService {
       ]);
 
       await this.app.trigger<EventAssetUpdateAfter>(
-        'device-manager:asset:update:after',
+        "device-manager:asset:update:after",
         {
           asset: updatedAsset,
           metadata: updatedPayload.metadata,
@@ -214,7 +214,7 @@ export class AssetService extends BaseService {
     return lock(`asset:${engineId}:${assetId}`, async () => {
       const engine = await this.getEngine(engineId);
       const assetModel = await ask<AskModelAssetGet>(
-        'ask:device-manager:model:asset:get',
+        "ask:device-manager:model:asset:get",
         { engineGroup: engine.group, model }
       );
 
@@ -263,7 +263,7 @@ export class AssetService extends BaseService {
             metadata: {
               names: Object.keys(flattenObject(asset._source.metadata)),
             },
-            name: 'metadata',
+            name: "metadata",
           },
           id: asset._id,
           timestamp: Date.now(),
@@ -283,7 +283,7 @@ export class AssetService extends BaseService {
     request: KuzzleRequest
   ) {
     const user = request.getUser();
-    const strict = request.getBoolean('strict');
+    const strict = request.getBoolean("strict");
 
     return lock<void>(`asset:${engineId}:${assetId}`, async () => {
       const asset = await this.get(engineId, assetId, request);
@@ -296,7 +296,7 @@ export class AssetService extends BaseService {
 
       for (const { _id: deviceId } of asset._source.linkedDevices) {
         await ask<AskDeviceUnlinkAsset>(
-          'ask:device-manager:device:unlink-asset',
+          "ask:device-manager:device:unlink-asset",
           { deviceId, user }
         );
       }
@@ -330,11 +330,11 @@ export class AssetService extends BaseService {
 
     //Sanity check
     if (assetsList.length === 0) {
-      throw new BadRequestError('No assets to migrate');
+      throw new BadRequestError("No assets to migrate");
     }
 
     await lock(`engine:${engineId}:${newEngineId}`, async () => {
-      if (!user.profileIds.includes('admin')) {
+      if (!user.profileIds.includes("admin")) {
         throw new BadRequestError(
           `User ${user._id} is not authorized to migrate assets`
         );
@@ -372,7 +372,7 @@ export class AssetService extends BaseService {
       errors = errors.concat(...assets.errors);
 
       if (assets.successes.length === 0) {
-        this.app.log.error('No assets found to migrate');
+        this.app.log.error("No assets found to migrate");
         return { errors, successes };
       }
 
@@ -422,19 +422,19 @@ export class AssetService extends BaseService {
         for (const device of linkedDevices) {
           // detach linked devices from current tenant (it also unkinks asset)
           await ask<AskDeviceDetachEngine>(
-            'ask:device-manager:device:detach-engine',
+            "ask:device-manager:device:detach-engine",
             { deviceId: device._id, user }
           );
 
           // ... and attach to new tenant
           await ask<AskDeviceAttachEngine>(
-            'ask:device-manager:device:attach-engine',
+            "ask:device-manager:device:attach-engine",
             { deviceId: device._id, engineId: newEngineId, user }
           );
 
           // ... and link this device to the asset in the new tenant
           await ask<AskDeviceLinkAsset>(
-            'ask:device-manager:device:link-asset',
+            "ask:device-manager:device:link-asset",
             {
               assetId: asset._id,
               deviceId: device._id,
@@ -508,7 +508,7 @@ export class AssetService extends BaseService {
           metadata: {
             names: Object.keys(flattenObject(asset._source.metadata)),
           },
-          name: 'metadata',
+          name: "metadata",
         },
         id: asset._id,
         timestamp: Date.now(),
@@ -538,7 +538,7 @@ export class AssetService extends BaseService {
   }: {
     assetModel: AssetModelContent;
   }): Promise<void> {
-    const engines = await ask<AskEngineList>('ask:device-manager:engine:list', {
+    const engines = await ask<AskEngineList>("ask:device-manager:engine:list", {
       group: assetModel.engineGroup,
     });
 
@@ -551,10 +551,10 @@ export class AssetService extends BaseService {
       BaseRequest,
       DocumentSearchResult<AssetContent>
     >({
-      action: 'search',
+      action: "search",
       body: { query: { equals: { model: assetModel.asset.model } } },
-      controller: 'document',
-      lang: 'koncorde',
+      controller: "document",
+      lang: "koncorde",
       targets,
     });
 
@@ -599,7 +599,7 @@ export class AssetService extends BaseService {
     await Promise.all(
       Object.entries(updatedAssetsPerIndex).map(([index, updatedAssets]) =>
         this.mReplaceAndHistorize(index, updatedAssets, removedMetadata, {
-          refresh: 'wait_for',
+          refresh: "wait_for",
         })
       )
     );

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -3,14 +3,14 @@ import {
   HttpStream,
   KuzzleError,
   KuzzleRequest,
-} from "kuzzle";
+} from 'kuzzle';
 
-import { MeasureExporter } from "../measure/";
-import { DeviceManagerPlugin, InternalCollection } from "../plugin";
-import { DigitalTwinExporter } from "../shared";
+import { MeasureExporter } from '../measure/';
+import { DeviceManagerPlugin, InternalCollection } from '../plugin';
+import { DigitalTwinExporter } from '../shared';
 
-import { AssetService } from "./AssetService";
-import { AssetSerializer } from "./model/AssetSerializer";
+import { AssetService } from './AssetService';
+import { AssetSerializer } from './model/AssetSerializer';
 import {
   ApiAssetCreateResult,
   ApiAssetUpsertResult,
@@ -20,7 +20,7 @@ import {
   ApiAssetSearchResult,
   ApiAssetUpdateResult,
   ApiAssetMigrateTenantResult,
-} from "./types/AssetApi";
+} from './types/AssetApi';
 
 export class AssetsController {
   public definition: ControllerDefinition;
@@ -36,45 +36,45 @@ export class AssetsController {
       actions: {
         create: {
           handler: this.create.bind(this),
-          http: [{ path: "device-manager/:engineId/assets", verb: "post" }],
+          http: [{ path: 'device-manager/:engineId/assets', verb: 'post' }],
         },
         upsert: {
           handler: this.upsert.bind(this),
           http: [
-            { path: "device-manager/:engineId/assets/:_id", verb: "post" },
+            { path: 'device-manager/:engineId/assets/:_id', verb: 'post' },
           ],
         },
         delete: {
           handler: this.delete.bind(this),
           http: [
-            { path: "device-manager/:engineId/assets/:_id", verb: "delete" },
+            { path: 'device-manager/:engineId/assets/:_id', verb: 'delete' },
           ],
         },
         get: {
           handler: this.get.bind(this),
-          http: [{ path: "device-manager/:engineId/assets/:_id", verb: "get" }],
+          http: [{ path: 'device-manager/:engineId/assets/:_id', verb: 'get' }],
         },
         search: {
           handler: this.search.bind(this),
           http: [
-            { path: "device-manager/:engineId/assets/_search", verb: "post" },
-            { path: "device-manager/:engineId/assets/_search", verb: "get" },
+            { path: 'device-manager/:engineId/assets/_search', verb: 'post' },
+            { path: 'device-manager/:engineId/assets/_search', verb: 'get' },
           ],
         },
         update: {
           handler: this.update.bind(this),
-          http: [{ path: "device-manager/:engineId/assets/:_id", verb: "put" }],
+          http: [{ path: 'device-manager/:engineId/assets/:_id', verb: 'put' }],
         },
         getMeasures: {
           handler: this.getMeasures.bind(this),
           http: [
             {
-              path: "device-manager/:engineId/assets/:_id/measures",
-              verb: "get",
+              path: 'device-manager/:engineId/assets/:_id/measures',
+              verb: 'get',
             },
             {
-              path: "device-manager/:engineId/assets/:_id/measures",
-              verb: "post",
+              path: 'device-manager/:engineId/assets/:_id/measures',
+              verb: 'post',
             },
           ],
         },
@@ -82,12 +82,12 @@ export class AssetsController {
           handler: this.exportMeasures.bind(this),
           http: [
             {
-              path: "device-manager/:engineId/assets/:_id/measures/_export/:exportId",
-              verb: "get",
+              path: 'device-manager/:engineId/assets/:_id/measures/_export/:exportId',
+              verb: 'get',
             },
             {
-              path: "device-manager/:engineId/assets/:_id/measures/_export",
-              verb: "post",
+              path: 'device-manager/:engineId/assets/:_id/measures/_export',
+              verb: 'post',
             },
           ],
         },
@@ -95,12 +95,12 @@ export class AssetsController {
           handler: this.export.bind(this),
           http: [
             {
-              path: "device-manager/:engineId/assets/_export/:exportId",
-              verb: "get",
+              path: 'device-manager/:engineId/assets/_export/:exportId',
+              verb: 'get',
             },
             {
-              path: "device-manager/:engineId/assets/_export",
-              verb: "post",
+              path: 'device-manager/:engineId/assets/_export',
+              verb: 'post',
             },
           ],
         },
@@ -108,8 +108,8 @@ export class AssetsController {
           handler: this.migrateTenant.bind(this),
           http: [
             {
-              path: "device-manager/:engineId/assets/_migrateTenant",
-              verb: "post",
+              path: 'device-manager/:engineId/assets/_migrateTenant',
+              verb: 'post',
             },
           ],
         },
@@ -129,7 +129,7 @@ export class AssetsController {
 
   async get(request: KuzzleRequest): Promise<ApiAssetGetResult> {
     const assetId = request.getId();
-    const engineId = request.getString("engineId");
+    const engineId = request.getString('engineId');
 
     const asset = await this.assetService.get(engineId, assetId, request);
 
@@ -137,15 +137,13 @@ export class AssetsController {
   }
 
   async upsert(request: KuzzleRequest): Promise<ApiAssetUpsertResult> {
-    const engineId = request.getString("engineId");
-    const assetId = request.getId();
-    const model = request.getBodyString("model");
-    const reference = request.getBodyString("reference");
-    const metadata = request.getBodyObject("metadata");
+    const engineId = request.getString('engineId');
+    const model = request.getBodyString('model');
+    const reference = request.getBodyString('reference');
+    const metadata = request.getBodyObject('metadata');
 
     const upsertAsset = await this.assetService.upsert(
       engineId,
-      assetId,
       model,
       reference,
       metadata,
@@ -157,8 +155,8 @@ export class AssetsController {
 
   async update(request: KuzzleRequest): Promise<ApiAssetUpdateResult> {
     const assetId = request.getId();
-    const engineId = request.getString("engineId");
-    const metadata = request.getBodyObject("metadata");
+    const engineId = request.getString('engineId');
+    const metadata = request.getBodyObject('metadata');
 
     const updatedAsset = await this.assetService.update(
       engineId,
@@ -171,10 +169,10 @@ export class AssetsController {
   }
 
   async create(request: KuzzleRequest): Promise<ApiAssetCreateResult> {
-    const engineId = request.getString("engineId");
-    const model = request.getBodyString("model");
-    const reference = request.getBodyString("reference");
-    const metadata = request.getBodyObject("metadata", {});
+    const engineId = request.getString('engineId');
+    const model = request.getBodyString('model');
+    const reference = request.getBodyString('reference');
+    const metadata = request.getBodyObject('metadata', {});
 
     const asset = await this.assetService.create(
       engineId,
@@ -188,7 +186,7 @@ export class AssetsController {
   }
 
   async delete(request: KuzzleRequest): Promise<ApiAssetDeleteResult> {
-    const engineId = request.getString("engineId");
+    const engineId = request.getString('engineId');
     const assetId = request.getId();
 
     await this.assetService.delete(engineId, assetId, request);
@@ -196,7 +194,7 @@ export class AssetsController {
 
   async search(request: KuzzleRequest): Promise<ApiAssetSearchResult> {
     return await this.assetService.search(
-      request.getString("engineId"),
+      request.getString('engineId'),
       request.getSearchParams(),
       request
     );
@@ -206,13 +204,13 @@ export class AssetsController {
     request: KuzzleRequest
   ): Promise<ApiAssetGetMeasuresResult> {
     const id = request.getId();
-    const engineId = request.getString("engineId");
+    const engineId = request.getString('engineId');
     const size = request.input.args.size;
     const from = request.input.args.from;
     const startAt = request.input.args.startAt
-      ? request.getDate("startAt")
+      ? request.getDate('startAt')
       : null;
-    const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
+    const endAt = request.input.args.endAt ? request.getDate('endAt') : null;
     const query = request.input.body?.query;
     const sort = request.input.body?.sort;
     const type = request.input.args.type;
@@ -239,14 +237,14 @@ export class AssetsController {
   }
 
   async exportMeasures(request: KuzzleRequest) {
-    const engineId = request.getString("engineId");
+    const engineId = request.getString('engineId');
 
     if (
-      request.context.connection.protocol === "http" &&
-      request.context.connection.misc.verb === "GET"
+      request.context.connection.protocol === 'http' &&
+      request.context.connection.misc.verb === 'GET'
     ) {
       try {
-        const exportId = request.getString("exportId");
+        const exportId = request.getString('exportId');
 
         const { id } = await this.measureExporter.getExport(engineId, exportId);
         const stream = await this.measureExporter.sendExport(
@@ -256,8 +254,8 @@ export class AssetsController {
 
         request.response.configure({
           headers: {
-            "Content-Disposition": `attachment; filename="asset-${id}.csv"`,
-            "Content-Type": "text/csv",
+            'Content-Disposition': `attachment; filename="asset-${id}.csv"`,
+            'Content-Type': 'text/csv',
           },
         });
 
@@ -265,9 +263,9 @@ export class AssetsController {
       } catch (error) {
         // ? Like this endpoint is mostly called by browser prefer return raw message for essyier readable error
         request.response.configure({
-          format: "raw",
+          format: 'raw',
           headers: {
-            "Content-Type": "text/plain",
+            'Content-Type': 'text/plain',
           },
           status: (error as KuzzleError).status,
         });
@@ -278,9 +276,9 @@ export class AssetsController {
 
     const id = request.getId();
     const startAt = request.input.args.startAt
-      ? request.getDate("startAt")
+      ? request.getDate('startAt')
       : null;
-    const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
+    const endAt = request.input.args.endAt ? request.getDate('endAt') : null;
     const query = request.input.body?.query;
     const sort = request.input.body?.sort;
     const type = request.input.args.type;
@@ -304,20 +302,20 @@ export class AssetsController {
   }
 
   async export(request: KuzzleRequest) {
-    const engineId = request.getString("engineId");
+    const engineId = request.getString('engineId');
 
     if (
-      request.context.connection.protocol === "http" &&
-      request.context.connection.misc.verb === "GET"
+      request.context.connection.protocol === 'http' &&
+      request.context.connection.misc.verb === 'GET'
     ) {
       try {
-        const exportId = request.getString("exportId");
+        const exportId = request.getString('exportId');
         const stream = await this.exporter.sendExport(engineId, exportId);
 
         request.response.configure({
           headers: {
-            "Content-Disposition": `attachment; filename="${InternalCollection.ASSETS}.csv"`,
-            "Content-Type": "text/csv",
+            'Content-Disposition': `attachment; filename="${InternalCollection.ASSETS}.csv"`,
+            'Content-Type': 'text/csv',
           },
         });
 
@@ -325,9 +323,9 @@ export class AssetsController {
       } catch (error) {
         // ? Like this endpoint is mostly called by browser prefer return raw message for essyier readable error
         request.response.configure({
-          format: "raw",
+          format: 'raw',
           headers: {
-            "Content-Type": "text/plain",
+            'Content-Type': 'text/plain',
           },
           status: (error as KuzzleError).status,
         });
@@ -356,9 +354,9 @@ export class AssetsController {
   async migrateTenant(
     request: KuzzleRequest
   ): Promise<ApiAssetMigrateTenantResult> {
-    const assetsList = request.getBodyArray("assetsList");
-    const engineId = request.getString("engineId");
-    const newEngineId = request.getBodyString("newEngineId");
+    const assetsList = request.getBodyArray('assetsList');
+    const engineId = request.getString('engineId');
+    const newEngineId = request.getBodyString('newEngineId');
 
     const { errors, successes } = await this.assetService.migrateTenant(
       request.getUser(),

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -3,14 +3,14 @@ import {
   HttpStream,
   KuzzleError,
   KuzzleRequest,
-} from 'kuzzle';
+} from "kuzzle";
 
-import { MeasureExporter } from '../measure/';
-import { DeviceManagerPlugin, InternalCollection } from '../plugin';
-import { DigitalTwinExporter } from '../shared';
+import { MeasureExporter } from "../measure/";
+import { DeviceManagerPlugin, InternalCollection } from "../plugin";
+import { DigitalTwinExporter } from "../shared";
 
-import { AssetService } from './AssetService';
-import { AssetSerializer } from './model/AssetSerializer';
+import { AssetService } from "./AssetService";
+import { AssetSerializer } from "./model/AssetSerializer";
 import {
   ApiAssetCreateResult,
   ApiAssetUpsertResult,
@@ -20,7 +20,7 @@ import {
   ApiAssetSearchResult,
   ApiAssetUpdateResult,
   ApiAssetMigrateTenantResult,
-} from './types/AssetApi';
+} from "./types/AssetApi";
 
 export class AssetsController {
   public definition: ControllerDefinition;
@@ -36,45 +36,45 @@ export class AssetsController {
       actions: {
         create: {
           handler: this.create.bind(this),
-          http: [{ path: 'device-manager/:engineId/assets', verb: 'post' }],
+          http: [{ path: "device-manager/:engineId/assets", verb: "post" }],
         },
         upsert: {
           handler: this.upsert.bind(this),
           http: [
-            { path: 'device-manager/:engineId/assets/:_id', verb: 'post' },
+            { path: "device-manager/:engineId/assets/:_id", verb: "post" },
           ],
         },
         delete: {
           handler: this.delete.bind(this),
           http: [
-            { path: 'device-manager/:engineId/assets/:_id', verb: 'delete' },
+            { path: "device-manager/:engineId/assets/:_id", verb: "delete" },
           ],
         },
         get: {
           handler: this.get.bind(this),
-          http: [{ path: 'device-manager/:engineId/assets/:_id', verb: 'get' }],
+          http: [{ path: "device-manager/:engineId/assets/:_id", verb: "get" }],
         },
         search: {
           handler: this.search.bind(this),
           http: [
-            { path: 'device-manager/:engineId/assets/_search', verb: 'post' },
-            { path: 'device-manager/:engineId/assets/_search', verb: 'get' },
+            { path: "device-manager/:engineId/assets/_search", verb: "post" },
+            { path: "device-manager/:engineId/assets/_search", verb: "get" },
           ],
         },
         update: {
           handler: this.update.bind(this),
-          http: [{ path: 'device-manager/:engineId/assets/:_id', verb: 'put' }],
+          http: [{ path: "device-manager/:engineId/assets/:_id", verb: "put" }],
         },
         getMeasures: {
           handler: this.getMeasures.bind(this),
           http: [
             {
-              path: 'device-manager/:engineId/assets/:_id/measures',
-              verb: 'get',
+              path: "device-manager/:engineId/assets/:_id/measures",
+              verb: "get",
             },
             {
-              path: 'device-manager/:engineId/assets/:_id/measures',
-              verb: 'post',
+              path: "device-manager/:engineId/assets/:_id/measures",
+              verb: "post",
             },
           ],
         },
@@ -82,12 +82,12 @@ export class AssetsController {
           handler: this.exportMeasures.bind(this),
           http: [
             {
-              path: 'device-manager/:engineId/assets/:_id/measures/_export/:exportId',
-              verb: 'get',
+              path: "device-manager/:engineId/assets/:_id/measures/_export/:exportId",
+              verb: "get",
             },
             {
-              path: 'device-manager/:engineId/assets/:_id/measures/_export',
-              verb: 'post',
+              path: "device-manager/:engineId/assets/:_id/measures/_export",
+              verb: "post",
             },
           ],
         },
@@ -95,12 +95,12 @@ export class AssetsController {
           handler: this.export.bind(this),
           http: [
             {
-              path: 'device-manager/:engineId/assets/_export/:exportId',
-              verb: 'get',
+              path: "device-manager/:engineId/assets/_export/:exportId",
+              verb: "get",
             },
             {
-              path: 'device-manager/:engineId/assets/_export',
-              verb: 'post',
+              path: "device-manager/:engineId/assets/_export",
+              verb: "post",
             },
           ],
         },
@@ -108,8 +108,8 @@ export class AssetsController {
           handler: this.migrateTenant.bind(this),
           http: [
             {
-              path: 'device-manager/:engineId/assets/_migrateTenant',
-              verb: 'post',
+              path: "device-manager/:engineId/assets/_migrateTenant",
+              verb: "post",
             },
           ],
         },
@@ -129,7 +129,7 @@ export class AssetsController {
 
   async get(request: KuzzleRequest): Promise<ApiAssetGetResult> {
     const assetId = request.getId();
-    const engineId = request.getString('engineId');
+    const engineId = request.getString("engineId");
 
     const asset = await this.assetService.get(engineId, assetId, request);
 
@@ -137,10 +137,10 @@ export class AssetsController {
   }
 
   async upsert(request: KuzzleRequest): Promise<ApiAssetUpsertResult> {
-    const engineId = request.getString('engineId');
-    const model = request.getBodyString('model');
-    const reference = request.getBodyString('reference');
-    const metadata = request.getBodyObject('metadata');
+    const engineId = request.getString("engineId");
+    const model = request.getBodyString("model");
+    const reference = request.getBodyString("reference");
+    const metadata = request.getBodyObject("metadata");
 
     const upsertAsset = await this.assetService.upsert(
       engineId,
@@ -155,8 +155,8 @@ export class AssetsController {
 
   async update(request: KuzzleRequest): Promise<ApiAssetUpdateResult> {
     const assetId = request.getId();
-    const engineId = request.getString('engineId');
-    const metadata = request.getBodyObject('metadata');
+    const engineId = request.getString("engineId");
+    const metadata = request.getBodyObject("metadata");
 
     const updatedAsset = await this.assetService.update(
       engineId,
@@ -169,10 +169,10 @@ export class AssetsController {
   }
 
   async create(request: KuzzleRequest): Promise<ApiAssetCreateResult> {
-    const engineId = request.getString('engineId');
-    const model = request.getBodyString('model');
-    const reference = request.getBodyString('reference');
-    const metadata = request.getBodyObject('metadata', {});
+    const engineId = request.getString("engineId");
+    const model = request.getBodyString("model");
+    const reference = request.getBodyString("reference");
+    const metadata = request.getBodyObject("metadata", {});
 
     const asset = await this.assetService.create(
       engineId,
@@ -186,7 +186,7 @@ export class AssetsController {
   }
 
   async delete(request: KuzzleRequest): Promise<ApiAssetDeleteResult> {
-    const engineId = request.getString('engineId');
+    const engineId = request.getString("engineId");
     const assetId = request.getId();
 
     await this.assetService.delete(engineId, assetId, request);
@@ -194,7 +194,7 @@ export class AssetsController {
 
   async search(request: KuzzleRequest): Promise<ApiAssetSearchResult> {
     return await this.assetService.search(
-      request.getString('engineId'),
+      request.getString("engineId"),
       request.getSearchParams(),
       request
     );
@@ -204,13 +204,13 @@ export class AssetsController {
     request: KuzzleRequest
   ): Promise<ApiAssetGetMeasuresResult> {
     const id = request.getId();
-    const engineId = request.getString('engineId');
+    const engineId = request.getString("engineId");
     const size = request.input.args.size;
     const from = request.input.args.from;
     const startAt = request.input.args.startAt
-      ? request.getDate('startAt')
+      ? request.getDate("startAt")
       : null;
-    const endAt = request.input.args.endAt ? request.getDate('endAt') : null;
+    const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
     const query = request.input.body?.query;
     const sort = request.input.body?.sort;
     const type = request.input.args.type;
@@ -237,14 +237,14 @@ export class AssetsController {
   }
 
   async exportMeasures(request: KuzzleRequest) {
-    const engineId = request.getString('engineId');
+    const engineId = request.getString("engineId");
 
     if (
-      request.context.connection.protocol === 'http' &&
-      request.context.connection.misc.verb === 'GET'
+      request.context.connection.protocol === "http" &&
+      request.context.connection.misc.verb === "GET"
     ) {
       try {
-        const exportId = request.getString('exportId');
+        const exportId = request.getString("exportId");
 
         const { id } = await this.measureExporter.getExport(engineId, exportId);
         const stream = await this.measureExporter.sendExport(
@@ -254,8 +254,8 @@ export class AssetsController {
 
         request.response.configure({
           headers: {
-            'Content-Disposition': `attachment; filename="asset-${id}.csv"`,
-            'Content-Type': 'text/csv',
+            "Content-Disposition": `attachment; filename="asset-${id}.csv"`,
+            "Content-Type": "text/csv",
           },
         });
 
@@ -263,9 +263,9 @@ export class AssetsController {
       } catch (error) {
         // ? Like this endpoint is mostly called by browser prefer return raw message for essyier readable error
         request.response.configure({
-          format: 'raw',
+          format: "raw",
           headers: {
-            'Content-Type': 'text/plain',
+            "Content-Type": "text/plain",
           },
           status: (error as KuzzleError).status,
         });
@@ -276,9 +276,9 @@ export class AssetsController {
 
     const id = request.getId();
     const startAt = request.input.args.startAt
-      ? request.getDate('startAt')
+      ? request.getDate("startAt")
       : null;
-    const endAt = request.input.args.endAt ? request.getDate('endAt') : null;
+    const endAt = request.input.args.endAt ? request.getDate("endAt") : null;
     const query = request.input.body?.query;
     const sort = request.input.body?.sort;
     const type = request.input.args.type;
@@ -302,20 +302,20 @@ export class AssetsController {
   }
 
   async export(request: KuzzleRequest) {
-    const engineId = request.getString('engineId');
+    const engineId = request.getString("engineId");
 
     if (
-      request.context.connection.protocol === 'http' &&
-      request.context.connection.misc.verb === 'GET'
+      request.context.connection.protocol === "http" &&
+      request.context.connection.misc.verb === "GET"
     ) {
       try {
-        const exportId = request.getString('exportId');
+        const exportId = request.getString("exportId");
         const stream = await this.exporter.sendExport(engineId, exportId);
 
         request.response.configure({
           headers: {
-            'Content-Disposition': `attachment; filename="${InternalCollection.ASSETS}.csv"`,
-            'Content-Type': 'text/csv',
+            "Content-Disposition": `attachment; filename="${InternalCollection.ASSETS}.csv"`,
+            "Content-Type": "text/csv",
           },
         });
 
@@ -323,9 +323,9 @@ export class AssetsController {
       } catch (error) {
         // ? Like this endpoint is mostly called by browser prefer return raw message for essyier readable error
         request.response.configure({
-          format: 'raw',
+          format: "raw",
           headers: {
-            'Content-Type': 'text/plain',
+            "Content-Type": "text/plain",
           },
           status: (error as KuzzleError).status,
         });
@@ -354,9 +354,9 @@ export class AssetsController {
   async migrateTenant(
     request: KuzzleRequest
   ): Promise<ApiAssetMigrateTenantResult> {
-    const assetsList = request.getBodyArray('assetsList');
-    const engineId = request.getString('engineId');
-    const newEngineId = request.getBodyString('newEngineId');
+    const assetsList = request.getBodyArray("assetsList");
+    const engineId = request.getString("engineId");
+    const newEngineId = request.getBodyString("newEngineId");
 
     const { errors, successes } = await this.assetService.migrateTenant(
       request.getUser(),

--- a/lib/modules/shared/services/BaseService.ts
+++ b/lib/modules/shared/services/BaseService.ts
@@ -20,7 +20,7 @@ import {
   KuzzleRequest,
   SearchResult,
   User,
-} from 'kuzzle';
+} from "kuzzle";
 
 import {
   DeviceManagerPlugin,
@@ -29,14 +29,14 @@ import {
   EventGenericDocumentBeforeSearch,
   EventGenericDocumentAfterSearch,
   SearchQueryResult,
-} from '../../plugin';
+} from "../../plugin";
 
 interface PayloadRequest {
   collection: InternalCollection;
   engineId: string;
 }
 
-export type SearchParams = ReturnType<KuzzleRequest['getSearchParams']>;
+export type SearchParams = ReturnType<KuzzleRequest["getSearchParams"]>;
 
 export abstract class BaseService {
   constructor(private plugin: DeviceManagerPlugin) {}
@@ -95,7 +95,7 @@ export abstract class BaseService {
     const refresh = kuzzleRequest.getRefresh();
 
     const [{ _id }] = await this.app.trigger<EventGenericDocumentBeforeGet>(
-      'generic:document:beforeGet',
+      "generic:document:beforeGet",
       [{ _id: documentId }],
       kuzzleRequest
     );
@@ -109,7 +109,7 @@ export abstract class BaseService {
 
     const [endDocument] = await this.app.trigger<
       EventGenericDocumentAfterGet<T>
-    >('generic:document:afterGet', [newDocument], kuzzleRequest);
+    >("generic:document:afterGet", [newDocument], kuzzleRequest);
 
     return endDocument;
   }
@@ -138,7 +138,7 @@ export abstract class BaseService {
 
     const [modifiedDocument] = await this.app.trigger<
       EventGenericDocumentBeforeWrite<T>
-    >('generic:document:beforeWrite', [document], kuzzleRequest);
+    >("generic:document:beforeWrite", [document], kuzzleRequest);
 
     const newDocument = await this.impersonatedSdk(user).document.create<T>(
       engineId,
@@ -149,7 +149,7 @@ export abstract class BaseService {
     );
     const [endDocument] = await this.app.trigger<
       EventGenericDocumentAfterWrite<T>
-    >('generic:document:afterWrite', [newDocument], kuzzleRequest);
+    >("generic:document:afterWrite", [newDocument], kuzzleRequest);
 
     return endDocument;
   }
@@ -178,7 +178,7 @@ export abstract class BaseService {
 
     const [modifiedDocument] = await this.app.trigger<
       EventGenericDocumentBeforeUpdate<Partial<T>>
-    >('generic:document:beforeUpdate', [document], kuzzleRequest);
+    >("generic:document:beforeUpdate", [document], kuzzleRequest);
 
     const updatedDocument = await this.impersonatedSdk(user).document.update<T>(
       engineId,
@@ -190,7 +190,7 @@ export abstract class BaseService {
 
     const [endDocument] = await this.app.trigger<
       EventGenericDocumentAfterUpdate<T>
-    >('generic:document:afterUpdate', [updatedDocument], kuzzleRequest);
+    >("generic:document:afterUpdate", [updatedDocument], kuzzleRequest);
 
     return endDocument;
   }
@@ -219,7 +219,7 @@ export abstract class BaseService {
 
     const [modifiedDocument] =
       await this.app.trigger<EventGenericDocumentBeforeDelete>(
-        'generic:document:beforeDelete',
+        "generic:document:beforeDelete",
         [{ _id: documentId }],
         kuzzleRequest
       );
@@ -233,7 +233,7 @@ export abstract class BaseService {
 
     const [endDocument] =
       await this.app.trigger<EventGenericDocumentAfterDelete>(
-        'generic:document:afterDelete',
+        "generic:document:afterDelete",
         [{ _id: deletedDocument }],
         kuzzleRequest
       );
@@ -261,7 +261,7 @@ export abstract class BaseService {
     });
     const {
       protocol,
-      misc: { verb = 'POST' },
+      misc: { verb = "POST" },
     } = kuzzleRequest.context.connection;
 
     const lang = kuzzleRequest.getLangParam();
@@ -269,16 +269,16 @@ export abstract class BaseService {
 
     const modifiedBody =
       await this.app.trigger<EventGenericDocumentBeforeSearch>(
-        'generic:document:beforeSearch',
+        "generic:document:beforeSearch",
         searchBody,
         kuzzleRequest
       );
 
     const query = {
-      action: 'search',
+      action: "search",
       body: null,
       collection,
-      controller: 'document',
+      controller: "document",
       from,
       index: engineId,
       lang,
@@ -288,7 +288,7 @@ export abstract class BaseService {
       verb,
     };
 
-    if (protocol === 'http' && verb === 'GET') {
+    if (protocol === "http" && verb === "GET") {
       query.searchBody = modifiedBody;
     } else {
       query.body = modifiedBody;
@@ -300,7 +300,7 @@ export abstract class BaseService {
 
     const modifiedResult = await this.app.trigger<
       EventGenericDocumentAfterSearch<T>
-    >('generic:document:afterSearch', result, request);
+    >("generic:document:afterSearch", result, request);
 
     return new DocumentSearchResult(global, query, {}, modifiedResult);
   }

--- a/lib/modules/shared/services/BaseService.ts
+++ b/lib/modules/shared/services/BaseService.ts
@@ -2,7 +2,6 @@ import {
   ArgsDocumentControllerCreate,
   ArgsDocumentControllerDelete,
   ArgsDocumentControllerUpdate,
-  ArgsDocumentControllerUpsert,
   Backend,
   BaseRequest,
   DocumentSearchResult,
@@ -21,7 +20,7 @@ import {
   KuzzleRequest,
   SearchResult,
   User,
-} from "kuzzle";
+} from 'kuzzle';
 
 import {
   DeviceManagerPlugin,
@@ -30,14 +29,14 @@ import {
   EventGenericDocumentBeforeSearch,
   EventGenericDocumentAfterSearch,
   SearchQueryResult,
-} from "../../plugin";
+} from '../../plugin';
 
 interface PayloadRequest {
   collection: InternalCollection;
   engineId: string;
 }
 
-export type SearchParams = ReturnType<KuzzleRequest["getSearchParams"]>;
+export type SearchParams = ReturnType<KuzzleRequest['getSearchParams']>;
 
 export abstract class BaseService {
   constructor(private plugin: DeviceManagerPlugin) {}
@@ -96,7 +95,7 @@ export abstract class BaseService {
     const refresh = kuzzleRequest.getRefresh();
 
     const [{ _id }] = await this.app.trigger<EventGenericDocumentBeforeGet>(
-      "generic:document:beforeGet",
+      'generic:document:beforeGet',
       [{ _id: documentId }],
       kuzzleRequest
     );
@@ -110,7 +109,7 @@ export abstract class BaseService {
 
     const [endDocument] = await this.app.trigger<
       EventGenericDocumentAfterGet<T>
-    >("generic:document:afterGet", [newDocument], kuzzleRequest);
+    >('generic:document:afterGet', [newDocument], kuzzleRequest);
 
     return endDocument;
   }
@@ -139,7 +138,7 @@ export abstract class BaseService {
 
     const [modifiedDocument] = await this.app.trigger<
       EventGenericDocumentBeforeWrite<T>
-    >("generic:document:beforeWrite", [document], kuzzleRequest);
+    >('generic:document:beforeWrite', [document], kuzzleRequest);
 
     const newDocument = await this.impersonatedSdk(user).document.create<T>(
       engineId,
@@ -150,7 +149,7 @@ export abstract class BaseService {
     );
     const [endDocument] = await this.app.trigger<
       EventGenericDocumentAfterWrite<T>
-    >("generic:document:afterWrite", [newDocument], kuzzleRequest);
+    >('generic:document:afterWrite', [newDocument], kuzzleRequest);
 
     return endDocument;
   }
@@ -179,7 +178,7 @@ export abstract class BaseService {
 
     const [modifiedDocument] = await this.app.trigger<
       EventGenericDocumentBeforeUpdate<Partial<T>>
-    >("generic:document:beforeUpdate", [document], kuzzleRequest);
+    >('generic:document:beforeUpdate', [document], kuzzleRequest);
 
     const updatedDocument = await this.impersonatedSdk(user).document.update<T>(
       engineId,
@@ -191,7 +190,7 @@ export abstract class BaseService {
 
     const [endDocument] = await this.app.trigger<
       EventGenericDocumentAfterUpdate<T>
-    >("generic:document:afterUpdate", [updatedDocument], kuzzleRequest);
+    >('generic:document:afterUpdate', [updatedDocument], kuzzleRequest);
 
     return endDocument;
   }
@@ -220,7 +219,7 @@ export abstract class BaseService {
 
     const [modifiedDocument] =
       await this.app.trigger<EventGenericDocumentBeforeDelete>(
-        "generic:document:beforeDelete",
+        'generic:document:beforeDelete',
         [{ _id: documentId }],
         kuzzleRequest
       );
@@ -234,7 +233,7 @@ export abstract class BaseService {
 
     const [endDocument] =
       await this.app.trigger<EventGenericDocumentAfterDelete>(
-        "generic:document:afterDelete",
+        'generic:document:afterDelete',
         [{ _id: deletedDocument }],
         kuzzleRequest
       );
@@ -262,7 +261,7 @@ export abstract class BaseService {
     });
     const {
       protocol,
-      misc: { verb = "POST" },
+      misc: { verb = 'POST' },
     } = kuzzleRequest.context.connection;
 
     const lang = kuzzleRequest.getLangParam();
@@ -270,16 +269,16 @@ export abstract class BaseService {
 
     const modifiedBody =
       await this.app.trigger<EventGenericDocumentBeforeSearch>(
-        "generic:document:beforeSearch",
+        'generic:document:beforeSearch',
         searchBody,
         kuzzleRequest
       );
 
     const query = {
-      action: "search",
+      action: 'search',
       body: null,
       collection,
-      controller: "document",
+      controller: 'document',
       from,
       index: engineId,
       lang,
@@ -289,7 +288,7 @@ export abstract class BaseService {
       verb,
     };
 
-    if (protocol === "http" && verb === "GET") {
+    if (protocol === 'http' && verb === 'GET') {
       query.searchBody = modifiedBody;
     } else {
       query.body = modifiedBody;
@@ -301,7 +300,7 @@ export abstract class BaseService {
 
     const modifiedResult = await this.app.trigger<
       EventGenericDocumentAfterSearch<T>
-    >("generic:document:afterSearch", result, request);
+    >('generic:document:afterSearch', result, request);
 
     return new DocumentSearchResult(global, query, {}, modifiedResult);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2848,13 +2848,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.38.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.38.0.tgz",
-      "integrity": "sha512-/F63giJGLDr0ms1Cr8utDAxP2SPiglaD6V+pCOcG35P2jCqdfR7uuEhz1GIC3oy4hkUF8xA1XSXmd9hOh/a5EA==",
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.38.0",
-        "@typescript-eslint/types": "5.38.0",
-        "@typescript-eslint/typescript-estree": "5.38.0",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2871,6 +2871,76 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {


### PR DESCRIPTION
## What does this PR do ?

This PR is an update of the previous one, the assetId has been removed to prevent displaying the _id in the API action. With this update, you can now perform updates or creations using only the model and reference.
example :
```
{
  "controller": "device-manager/assets",
  "action": "upsert",
  "engineId": "engine-ayse",
  "body": {
    "model": "Container",
    "reference": "linked1",
    "metadata": {
      "weight": 12,
      "height": 11
    }
  }
}
```

### How should this be manually tested?

see above the api example
