### PR TITLE
Fix(migrate_tenant_sanity_check) : raise an error

### DIFF
--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -364,6 +364,13 @@ export class AssetService extends BaseService {
       const assetsCheckedList = assetsList.filter(
         (id) => !assetsCheckedIdExisting.includes(id),
       );
+
+      if (assetsCheckedList.length === 0) {
+        throw new BadRequestError(
+          "All assets to migrate already exists in destination tenant.",
+        );
+      }
+
       const assets = await this.sdk.document.mGet<AssetContent>(
         engineId,
         InternalCollection.ASSETS,

--- a/tests/scenario/modules/assets/asset-migrate-tenant.test.ts
+++ b/tests/scenario/modules/assets/asset-migrate-tenant.test.ts
@@ -95,7 +95,9 @@ describe("AssetsController:migrateTenant", () => {
           newEngineId: "engine-kuzzle",
         },
       }),
-    ).rejects.toThrow("All assets to migrate already exist in new tenant");
+    ).rejects.toThrow(
+      "All assets to migrate already exists in destination tenant.",
+    );
   });
 
   it("should copy 1 of 2 assets from engine-ayse to engine-kuzzle", async () => {


### PR DESCRIPTION
Raise an error if all assets to migrate tenants already exists in tenant destination