### PR TITLE
feat(configuration): allow to specify Elasticsearch index settings

### DIFF
--- a/doc/2/concepts/configuration/index.md
+++ b/doc/2/concepts/configuration/index.md
@@ -53,7 +53,7 @@ The following collections are used by the plugin. They're automatically created 
 The following collections are used by the plugin. They're automatically created when the plugin is started and are specific to each engine:
 
 - `config`: The collection that stores the engine configuration.
-- `devices`: The collection that stores the devices.
+- `device`: The collection that stores the devices.
 - `measures`: The collection that stores the measures once extracted by the decoders.
 - `asset`: The collection that stores the assets.
 - `assetGroups`: The collection that stores the assets groups.

--- a/doc/2/concepts/configuration/index.md
+++ b/doc/2/concepts/configuration/index.md
@@ -1,0 +1,198 @@
+---
+code: false
+type: page
+title: Configuration
+description: Plugin configuration
+---
+
+# Configuration
+
+You can customize the behavior of the Device Manager plugin by providing a configuration object in the `plugins` section using the Kuzzle configuration file ([`kuzzlerc`](https://docs.kuzzle.io/core/2/guides/advanced/configuration/)).
+
+
+```js
+{
+  "plugins": {
+    "device-manager": {
+      // Configuration options
+    }
+  }
+}
+```
+
+# Options
+
+## Global
+
+The following global options are available:
+
+| Name                  | Type    | Default          | Description                                                                                        |
+| --------------------- | ------- | ---------------- | -------------------------------------------------------------------------------------------------- |
+| `ignoreStartupErrors` | boolean | `false`          | If `true`, the plugin will not throw an error if the engine is not reachable at startup.           |
+| `engine.autoUpdate`   | boolean | `true`           | If `true`, the plugin will automatically update the engine collections when the plugin is started. |
+| `adminIndex`          | string  | `device-manager` | The index name where the plugin stores its configuration and devices.                              |
+
+## Collections
+
+In order to customize the collections used by the plugin, you can provide a configuration object for each collection. All of these support the following properties:
+
+- `name`: The name of the collection.
+- `mappings`: The mappings of the collection (according to the [Elasticsearch mapping specification](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html)).
+- `settings`: The settings of the collection (according to the [Elasticsearch settings specification](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html)). This property is optional but can be useful to define the number of shards and replicas of the Elasticsearch index or use custom analyzers.
+
+### Admin collections 
+
+The following collections are used by the plugin. They're automatically created when the plugin is started and shared accross all the engines.
+
+- `devices`: The collection that stores the devices.
+- `config`: The collection that stores the plugin configuration.
+- `payloads`: The collection that stores the raw payloads before they are processed and decoded by the plugin.
+
+### Engine collections
+
+The following collections are used by the plugin. They're automatically created when the plugin is started and are specific to each engine:
+
+- `config`: The collection that stores the engine configuration.
+- `devices`: The collection that stores the devices.
+- `measures`: The collection that stores the measures once extracted by the decoders.
+- `assets`: The collection that stores the assets.
+- `assets`: The collection that stores the assets groups.
+- `assetHistory`: The collection that stores the assets history.
+
+# Example
+
+```js
+{
+  "plugins": {
+    "device-manager": {
+      "ignoreStartupErrors": false,
+      "engine": {
+        "autoUpdate": true
+      },
+      "adminIndex": "device-manager",
+      "adminCollections": {
+        "devices": {
+          "name": "devices",
+          "mappings": {
+            "properties": {
+              "name": { "type": "keyword" },
+              "description": { "type": "text" },
+              "type": { "type": "keyword" },
+              "status": { "type": "keyword" },
+              "lastSeen": { "type": "date" }
+            }
+          },
+          "settings": {
+            "index": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            }
+          }
+        },
+        "config": {
+          "name": "config",
+          "mappings": {
+            "properties": {
+              "name": { "type": "keyword" },
+              "value": { "type": "text" }
+            }
+          },
+          "settings": {
+            "index": {
+              "number_of_shards": 1,
+              "number_of_replicas": 1
+            }
+          }
+        },
+        "payloads": {
+          "name": "payloads",
+          "mappings": {
+            "properties": {
+              "payload": { "type": "text" }
+            }
+          }
+        }
+      },
+      "engineCollections": {
+        "config": {
+          "name": "config",
+          "mappings": {
+            "properties": {
+              "name": { "type": "keyword" },
+              "value": { "type": "text" }
+            }
+          }
+        },
+        "devices": {
+          "name": "devices",
+          "mappings": {
+            "properties": {
+              "name": { "type": "keyword" },
+              "description": { "type": "text" },
+              "type": { "type": "keyword" },
+              "status": { "type": "keyword" },
+              "lastSeen": { "type": "date" }
+            }
+          }
+        },
+        "measures": {
+          "name": "measures",
+          "mappings": {
+            "properties": {
+              "deviceId": { "type": "keyword" },
+              "timestamp": { "type": "date" },
+              "measures": { "type": "object" }
+            }
+          }
+        },
+        "assets": {
+          "name": "assets",
+          "mappings": {
+            "properties": {
+              "name": { "type": "keyword" },
+              "description": { 
+                "type": "text",
+                "analyzer": "description" 
+              },
+              "type": { "type": "keyword" },
+              "status": { "type": "keyword" }
+            }
+          },
+          "settings": {
+            // Custom analyzer definition
+            "analysis": {
+              "analyzer": {
+                "description": {
+                  "type": "custom",
+                  "tokenizer": "whitespace"
+                }
+              }
+            }
+          }
+        },
+        "assetGroups": {
+          "name": "assetGroups",
+          "mappings": {
+            "properties": {
+              "name": { "type": "keyword" },
+              "description": { "type": "text" },
+              "type": { "type": "keyword" },
+              "status": { "type": "keyword" }
+            }
+          }
+        },
+        "assetHistory": {
+          "name": "assetHistory",
+          "mappings": {
+            "properties": {
+              "assetId": { "type": "keyword" },
+              "timestamp": { "type": "date" },
+              "status": { "type": "keyword" }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/doc/2/concepts/configuration/index.md
+++ b/doc/2/concepts/configuration/index.md
@@ -55,8 +55,8 @@ The following collections are used by the plugin. They're automatically created 
 - `config`: The collection that stores the engine configuration.
 - `devices`: The collection that stores the devices.
 - `measures`: The collection that stores the measures once extracted by the decoders.
-- `assets`: The collection that stores the assets.
-- `assets`: The collection that stores the assets groups.
+- `asset`: The collection that stores the assets.
+- `assetGroups`: The collection that stores the assets groups.
 - `assetHistory`: The collection that stores the assets history.
 
 # Example
@@ -145,7 +145,7 @@ The following collections are used by the plugin. They're automatically created 
             }
           }
         },
-        "assets": {
+        "asset": {
           "name": "assets",
           "mappings": {
             "properties": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - esdata01:/usr/share/elasticsearch/data
 
   kuzzle:
-    image: kuzzleio/kuzzle-runner:18
+    image: kuzzleio/kuzzle-runner:20
     restart: unless-stopped
     command: "bash /docker/start-backend.sh"
     profiles: ["backend"]

--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -320,7 +320,7 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
       "asset",
       engineGroup,
     );
-    const settings = this.config.engineCollections.assets.settings;
+    const settings = this.config.engineCollections.asset.settings;
 
     await this.tryCreateCollection(engineId, InternalCollection.ASSETS, {
       mappings,

--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -325,7 +325,8 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
       engineId,
       InternalCollection.ASSETS,
       mappings,
-    );
+      settings,
+    });
 
     return InternalCollection.ASSETS;
   }
@@ -352,7 +353,10 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
     await this.tryCreateCollection(
       engineId,
       InternalCollection.ASSETS_HISTORY,
-      mappings,
+      {
+        mappings,
+        settings,
+      },
     );
 
     return InternalCollection.ASSETS_HISTORY;

--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -320,10 +320,9 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
       "asset",
       engineGroup,
     );
+    const settings = this.config.engineCollections.assets.settings;
 
-    await this.tryCreateCollection(
-      engineId,
-      InternalCollection.ASSETS,
+    await this.tryCreateCollection(engineId, InternalCollection.ASSETS, {
       mappings,
       settings,
     });
@@ -350,6 +349,8 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
     _.merge(mappings.properties.asset, assetsMappings);
 
+    const settings = this.config.engineCollections.assetHistory.settings;
+
     await this.tryCreateCollection(
       engineId,
       InternalCollection.ASSETS_HISTORY,
@@ -371,8 +372,11 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
    * @throws If it failed during the assets groups collection creation
    */
   async createAssetsGroupsCollection(engineId: string) {
+    const settings = this.config.engineCollections.assetGroups.settings;
+
     await this.tryCreateCollection(engineId, InternalCollection.ASSETS_GROUPS, {
       mappings: assetGroupsMappings,
+      settings,
     });
 
     return InternalCollection.ASSETS_GROUPS;
@@ -389,12 +393,12 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   async createDevicesCollection(engineId: string) {
     const mappings =
       await this.getDigitalTwinMappingsFromDB<DeviceModelContent>("device");
+    const settings = this.config.engineCollections.devices.settings;
 
-    await this.tryCreateCollection(
-      engineId,
-      InternalCollection.DEVICES,
+    await this.tryCreateCollection(engineId, InternalCollection.DEVICES, {
       mappings,
-    );
+      settings,
+    });
 
     return InternalCollection.DEVICES;
   }
@@ -409,12 +413,12 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
    */
   async createMeasuresCollection(engineId: string, engineGroup: string) {
     const mappings = await this.getMeasuresMappingsFromDB(engineGroup);
+    const settings = this.config.engineCollections.measures.settings;
 
-    await this.tryCreateCollection(
-      engineId,
-      InternalCollection.MEASURES,
+    await this.tryCreateCollection(engineId, InternalCollection.MEASURES, {
       mappings,
-    );
+      settings,
+    });
 
     return InternalCollection.MEASURES;
   }
@@ -431,7 +435,7 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   private async tryCreateCollection(
     engineIndex: string,
     collection: string,
-    mappings:
+    options:
       | CollectionMappings
       | {
           mappings?: CollectionMappings;
@@ -439,7 +443,7 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
         },
   ) {
     try {
-      await this.sdk.collection.create(engineIndex, collection, mappings);
+      await this.sdk.collection.create(engineIndex, collection, options);
     } catch (error) {
       throw new InternalError(
         `Failed to create the collection [${collection}] for engine [${engineIndex}]: ${error.message}`,

--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -393,7 +393,7 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   async createDevicesCollection(engineId: string) {
     const mappings =
       await this.getDigitalTwinMappingsFromDB<DeviceModelContent>("device");
-    const settings = this.config.engineCollections.devices.settings;
+    const settings = this.config.engineCollections.device.settings;
 
     await this.tryCreateCollection(engineId, InternalCollection.DEVICES, {
       mappings,

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -280,17 +280,17 @@ export class DeviceManagerPlugin extends Plugin {
             properties: {},
           },
         },
-        asset: {
+        assets: {
           name: InternalCollection.ASSETS,
           mappings: assetsMappings,
         },
-        assetGroup: {
+        assetGroups: {
           name: InternalCollection.ASSETS_GROUPS,
         },
         assetHistory: {
           name: InternalCollection.ASSETS_HISTORY,
         },
-        device: {
+        devices: {
           name: InternalCollection.DEVICES,
           mappings: devicesMappings,
         },
@@ -448,7 +448,10 @@ export class DeviceManagerPlugin extends Plugin {
         });
 
       await this.sdk.collection
-        .create(this.config.adminIndex, "payloads", this.getPayloadsMappings())
+        .create(this.config.adminIndex, "payloads", {
+          mappings: this.getPayloadsMappings(),
+          settings: this.config.adminCollections.payloads.settings,
+        })
         .catch((error) => {
           throw keepStack(
             error,

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -290,7 +290,7 @@ export class DeviceManagerPlugin extends Plugin {
         assetHistory: {
           name: InternalCollection.ASSETS_HISTORY,
         },
-        devices: {
+        device: {
           name: InternalCollection.DEVICES,
           mappings: devicesMappings,
         },

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -262,17 +262,14 @@ export class DeviceManagerPlugin extends Plugin {
             dynamic: "strict",
             properties: {},
           },
-          settings: {},
         },
         devices: {
           name: "devices",
           mappings: devicesMappings,
-          settings: {},
         },
         payloads: {
           name: "payloads",
           mappings: payloadsMappings,
-          settings: {},
         },
       },
       engineCollections: {
@@ -282,15 +279,23 @@ export class DeviceManagerPlugin extends Plugin {
             dynamic: "strict",
             properties: {},
           },
-          settings: {},
         },
         asset: {
           name: InternalCollection.ASSETS,
           mappings: assetsMappings,
         },
+        assetGroup: {
+          name: InternalCollection.ASSETS_GROUPS,
+        },
+        assetHistory: {
+          name: InternalCollection.ASSETS_HISTORY,
+        },
         device: {
           name: InternalCollection.DEVICES,
           mappings: devicesMappings,
+        },
+        measures: {
+          name: InternalCollection.MEASURES,
         },
       },
     };

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -280,7 +280,7 @@ export class DeviceManagerPlugin extends Plugin {
             properties: {},
           },
         },
-        assets: {
+        asset: {
           name: InternalCollection.ASSETS,
           mappings: assetsMappings,
         },

--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -52,7 +52,7 @@ export type DeviceManagerConfiguration = {
       mappings: JSONObject;
       settings?: JSONObject;
     };
-    assets: {
+    asset: {
       name: string;
       mappings: CollectionMappings;
       settings?: JSONObject;

--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -52,6 +52,7 @@ export type DeviceManagerConfiguration = {
       mappings: JSONObject;
       settings?: JSONObject;
     };
+    // ! TODO next major release: pluralize the collection name
     asset: {
       name: string;
       mappings: CollectionMappings;
@@ -65,7 +66,8 @@ export type DeviceManagerConfiguration = {
       name: string;
       settings?: JSONObject;
     };
-    devices: {
+    // ! TODO next major release: pluralize the collection name
+    device: {
       name: string;
       mappings: CollectionMappings;
       settings?: JSONObject;

--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -52,12 +52,12 @@ export type DeviceManagerConfiguration = {
       mappings: JSONObject;
       settings?: JSONObject;
     };
-    asset: {
+    assets: {
       name: string;
       mappings: CollectionMappings;
       settings?: JSONObject;
     };
-    assetGroup: {
+    assetGroups: {
       name: string;
       settings?: JSONObject;
     };
@@ -65,7 +65,7 @@ export type DeviceManagerConfiguration = {
       name: string;
       settings?: JSONObject;
     };
-    device: {
+    devices: {
       name: string;
       mappings: CollectionMappings;
       settings?: JSONObject;

--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -30,19 +30,19 @@ export type DeviceManagerConfiguration = {
     config: {
       name: string;
       mappings: JSONObject;
-      settings: JSONObject;
+      settings?: JSONObject;
     };
 
     devices: {
       name: string;
       mappings: JSONObject;
-      settings: JSONObject;
+      settings?: JSONObject;
     };
 
     payloads: {
       name: string;
       mappings: JSONObject;
-      settings: JSONObject;
+      settings?: JSONObject;
     };
   };
 
@@ -50,15 +50,29 @@ export type DeviceManagerConfiguration = {
     config: {
       name: string;
       mappings: JSONObject;
-      settings: JSONObject;
+      settings?: JSONObject;
     };
     asset: {
       name: string;
       mappings: CollectionMappings;
+      settings?: JSONObject;
+    };
+    assetGroup: {
+      name: string;
+      settings?: JSONObject;
+    };
+    assetHistory: {
+      name: string;
+      settings?: JSONObject;
     };
     device: {
       name: string;
       mappings: CollectionMappings;
+      settings?: JSONObject;
+    };
+    measures: {
+      name: string;
+      settings?: JSONObject;
     };
   };
 };


### PR DESCRIPTION
<!--- This template is optional. -->

## What does this PR do ?

It add missing `settings` fields in the plugin configuration and make sure to use it during indices creation


## How to test it?

Using the kuzzlerc file, you can now set the desired index settings. For example the following configuration:
```js
{
  "plugins": {
    "device-manager": {
      "engineCollections": {
        "config": {
          "settings": {
            "number_of_shards": 3
          }
        },
        "asset": {
          "settings": {
            "number_of_shards": 4
          }
        },
        "assetGroup": {
          "settings": {
            "number_of_shards": 1
          }
        },
        "assetHistory": {
          "settings": {
            "number_of_shards": 3
          }
        },
        "device": {
          "settings": {
            "number_of_shards": 2
          }
        },
        "measures": {
          "settings": {
            "number_of_shards": 7
          }
        }
      }
    }
  }
}
```

gives you the following index configuration when you create a tenant:
<img width="1885" alt="image" src="https://github.com/kuzzleio/kuzzle-device-manager/assets/7868838/b3bf4e6b-0a96-4cf3-832c-381288abd470">

### Boyscout

Add a complete documentation about the plugin configuration usage
