### PR TITLE
fix: catch errors when updating the mappings on startup

### DIFF
--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -162,11 +162,18 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
       engineGroup,
     );
 
-    await this.sdk.collection.create(
-      engineId,
-      InternalCollection.ASSETS,
-      mappings,
-    );
+    try {
+      await this.sdk.collection.create(
+        engineId,
+        InternalCollection.ASSETS,
+        mappings,
+      );
+    } catch (error) {
+      throw new InternalError(
+        `Failed to create the assets collection "${InternalCollection.ASSETS}" for engine "${engineId}": ${error.message}`,
+        error,
+      );
+    }
 
     return InternalCollection.ASSETS;
   }
@@ -182,21 +189,35 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
     _.merge(mappings.properties.asset, assetsCollectionMappings);
 
-    await this.sdk.collection.create(
-      engineId,
-      InternalCollection.ASSETS_HISTORY,
-      mappings,
-    );
+    try {
+      await this.sdk.collection.create(
+        engineId,
+        InternalCollection.ASSETS_HISTORY,
+        mappings,
+      );
+    } catch (error) {
+      throw new InternalError(
+        `Failed to create the assets history collection "${InternalCollection.ASSETS_HISTORY}" for engine "${engineId}": ${error.message}`,
+        error,
+      );
+    }
 
     return InternalCollection.ASSETS_HISTORY;
   }
 
   async createAssetsGroupsCollection(engineId: string) {
-    await this.sdk.collection.create(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      { mappings: assetGroupsMappings },
-    );
+    try {
+      await this.sdk.collection.create(
+        engineId,
+        InternalCollection.ASSETS_GROUPS,
+        { mappings: assetGroupsMappings },
+      );
+    } catch (error) {
+      throw new InternalError(
+        `Failed to create the assets groups collection "${InternalCollection.ASSETS_GROUPS}" for engine "${engineId}": ${error.message}`,
+        error,
+      );
+    }
 
     return InternalCollection.ASSETS_GROUPS;
   }
@@ -260,11 +281,18 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
     const mappings =
       await this.getDigitalTwinMappings<DeviceModelContent>("device");
 
-    await this.sdk.collection.create(
-      engineId,
-      InternalCollection.DEVICES,
-      mappings,
-    );
+    try {
+      await this.sdk.collection.create(
+        engineId,
+        InternalCollection.DEVICES,
+        mappings,
+      );
+    } catch (error) {
+      throw new InternalError(
+        `Failed to create the devices collection "${InternalCollection.DEVICES}" for engine "${engineId}": ${error.message}`,
+        error,
+      );
+    }
 
     return InternalCollection.DEVICES;
   }
@@ -272,11 +300,18 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   async createMeasuresCollection(engineId: string, engineGroup: string) {
     const mappings = await this.getMeasuresMappings(engineGroup);
 
-    await this.sdk.collection.create(
-      engineId,
-      InternalCollection.MEASURES,
-      mappings,
-    );
+    try {
+      await this.sdk.collection.create(
+        engineId,
+        InternalCollection.MEASURES,
+        mappings,
+      );
+    } catch (error) {
+      throw new InternalError(
+        `Failed to create the measures collection "${InternalCollection.MEASURES}" for engine "${engineId}": ${error.message}`,
+        error,
+      );
+    }
 
     return InternalCollection.MEASURES;
   }

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -456,7 +456,13 @@ export class DeviceManagerPlugin extends Plugin {
       await this.initializeConfig();
 
       if (this.config.engine.autoUpdate) {
-        await this.deviceManagerEngine.updateEngines();
+        try {
+          await this.deviceManagerEngine.updateEngines();
+        } catch (error) {
+          this.context.log.error(
+            `An error occured while updating the engines during startup: ${error}`,
+          );
+        }
       }
     });
   }


### PR DESCRIPTION
## What does this PR do ?

Currently, KDM crashes the Kuzzle instance on startup when it fails to update the mapping of an engine collection to match the models that are stored in the database, making it impossible for someone to fix the models without connecting directly to the Elasticsearch database.

This fixes this crash by adding a try-catch block when the engines are updated on startup to notify the user that a problem occurred instead. Various try-catch blocks were also added on the collection creation methods to provide more context on where the error occurred.

This is associated with JIRA ticket KZLPRD-220.