### PR TITLE
feat: add log in decoders

### DIFF
--- a/lib/modules/decoder/Decoder.ts
+++ b/lib/modules/decoder/Decoder.ts
@@ -1,4 +1,9 @@
-import { HttpRoute, KuzzleRequest, PreconditionError } from "kuzzle";
+import {
+  HttpRoute,
+  InternalLogger,
+  KuzzleRequest,
+  PreconditionError,
+} from "kuzzle";
 import _ from "lodash";
 import { JSONObject } from "kuzzle-sdk";
 
@@ -26,6 +31,11 @@ export type NamedMeasures = Array<{
  */
 export abstract class Decoder {
   private _http?: HttpRoute[];
+
+  /**
+   * Internal logger.
+  */
+  public logger?: InternalLogger;
 
   /**
    * Device model name.

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -27,14 +27,14 @@ deviceManager.config.engineCollections.device.mappings.properties["softTenant"] 
 
 
 deviceManager.models.registerDevice("DummyTempPosition", {
-  decoder: new DummyTempPositionDecoder(),
+  decoder: new DummyTempPositionDecoder(app.log),
   metadataMappings: {
     serial: { type: "keyword" },
   },
 });
 
 deviceManager.models.registerDevice("DummyTemp", {
-  decoder: new DummyTempDecoder(),
+  decoder: new DummyTempDecoder(app.log),
   metadataMappings: {
     color: { type: "keyword" },
   },

--- a/tests/application/decoders/DummyTempDecoder.ts
+++ b/tests/application/decoders/DummyTempDecoder.ts
@@ -1,4 +1,4 @@
-import { PreconditionError } from "kuzzle";
+import { InternalLogger, PreconditionError } from "kuzzle";
 import { JSONObject } from "kuzzle-sdk";
 
 import {
@@ -17,8 +17,9 @@ export class DummyTempDecoder extends Decoder {
     { name: "battery", type: "battery" },
   ] as const;
 
-  constructor() {
+  constructor(logger: InternalLogger = undefined) {
     super();
+    this.logger = logger;
 
     this.payloadsMappings = {
       deviceEUI: { type: "keyword" },

--- a/tests/application/decoders/DummyTempPositionDecoder.ts
+++ b/tests/application/decoders/DummyTempPositionDecoder.ts
@@ -1,4 +1,4 @@
-import { PreconditionError } from "kuzzle";
+import { InternalLogger, PreconditionError } from "kuzzle";
 import { JSONObject } from "kuzzle-sdk";
 
 import {
@@ -16,6 +16,11 @@ export class DummyTempPositionDecoder extends Decoder {
     { name: "battery", type: "battery" },
     { name: "position", type: "position" },
   ] as const;
+
+  constructor(logger: InternalLogger = undefined) {
+    super();
+    this.logger = logger;
+  }
 
   async validate(payload: JSONObject) {
     if (payload.deviceEUI === undefined) {


### PR DESCRIPTION
## What does this PR do ?

This pr adds a logger variable in the decoders so we can pass and store in the decoder the kuzzle InternalLogger


### How should this be manually tested?

  - Step 1 : Create an new decoder
  - Step 2 : pass the logger in the constructor
  - Step 3 : try to log in the decoder using this.logger.info etc
