### PR TITLE
Kzlprd 323 asset metadata

### DIFF
--- a/doc/2/controllers/assets/replace-metadata/index.md
+++ b/doc/2/controllers/assets/replace-metadata/index.md
@@ -15,7 +15,7 @@ Replace `metadata` of an asset. It will replace only the fields specified in the
 
 ```http
 URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/metadata
-Method: PUT
+Method: PATCH
 ```
 
 ### Other protocols

--- a/doc/2/controllers/assets/replace-metadata/index.md
+++ b/doc/2/controllers/assets/replace-metadata/index.md
@@ -45,7 +45,7 @@ Method: PATCH
 
 ## Response
 
-```json
+```js
 {
     "action": "replaceMetadata",
     "collection": "assets",

--- a/doc/2/controllers/assets/replace-metadata/index.md
+++ b/doc/2/controllers/assets/replace-metadata/index.md
@@ -1,0 +1,80 @@
+---
+code: true
+type: page
+title: replaceMetadata
+description: Replace asset metadata
+---
+
+# replaceMetadata
+
+Replace `metadata` of an asset. It will replace only the fields specified in the request body.
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/metadata
+Method: PUT
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/assets",
+  "action": "replaceMetadata",
+  "engineId": "<engineId>",
+  "_id": "<assetId>",
+  "body": {
+    "metadata": {
+      "<metadata name>": "<metadata value>"
+    }
+  }
+}
+```
+
+## Arguments
+
+- `engineId`: Engine ID
+- `_id`: Asset ID
+
+## Body properties
+
+- `metadata`: Object containing metadata
+
+## Response
+
+```json
+{
+    "action": "replaceMetadata",
+    "collection": "assets",
+    "controller": "device-manager/assets",
+    "error": null,
+    "headers": {},
+    "index": /** index */,
+    "node": /** node */,
+    "requestId": /** request id */,
+    "result": {
+        "_id": /** asset id */,
+        "_source": {
+            "groups": [],
+            "lastMeasuredAt": null,
+            "linkedDevices": [],
+            "measures": {
+                /** mesures */
+            },
+            "metadata": {
+                /** REPLACED METADATA */
+            },
+            "model": /** asset model */,
+            "reference": /** asset reference */,
+            "_kuzzle_info": {
+                /** data management info */
+            }
+        }
+    },
+    "status": 200,
+    "volatile": null
+}
+```

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -27,6 +27,7 @@ import {
   BaseService,
   EmbeddedMeasure,
   Metadata,
+  MetadataValue,
   SearchParams,
   flattenObject,
   lock,
@@ -132,6 +133,52 @@ export class AssetService extends BaseService {
 
       return updatedAsset;
     });
+  }
+
+  public async replaceMetadata(engineId: string, assetId: string, metadata: Metadata, request: KuzzleRequest,): Promise<KDocument<AssetContent>> {
+    const asset = await this.get(engineId, assetId, request);
+
+    Object.keys(metadata).forEach(key => {
+      if(key in asset._source.metadata) {
+        asset._source.metadata[key] = metadata[key]
+      }
+    })
+
+    const updatedPayload = await this.app.trigger<EventAssetUpdateBefore>(
+      "device-manager:asset:update:before",
+      { asset, metadata },
+    );
+    
+    const updatedAsset = await this.sdk.document.replace<AssetContent>(
+      engineId,
+      InternalCollection.ASSETS,
+      assetId,
+      updatedPayload.asset._source
+    )
+
+    await this.assetHistoryService.add<AssetHistoryEventMetadata>(engineId, [
+      {
+        asset: updatedAsset._source,
+        event: {
+          metadata: {
+            names: Object.keys(flattenObject(updatedPayload.metadata)),
+          },
+          name: "metadata",
+        },
+        id: updatedAsset._id,
+        timestamp: Date.now(),
+      }
+    ]);
+
+    await this.app.trigger<EventAssetUpdateAfter>(
+      "device-manager:asset:update:after",
+      {
+        asset: updatedAsset,
+        metadata: updatedPayload.metadata,
+      },
+    );
+
+    return updatedAsset;
   }
 
   /**

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -134,6 +134,9 @@ export class AssetService extends BaseService {
     });
   }
 
+  /**
+   * Replace an asset metadata
+   */
   public async replaceMetadata(
     engineId: string,
     assetId: string,

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -20,7 +20,7 @@ import {
   ApiAssetSearchResult,
   ApiAssetUpdateResult,
   ApiAssetMigrateTenantResult,
-  ApiAssetReplaceMetadataResult,
+  ApiAssetMetadataReplaceResult,
 } from "./types/AssetApi";
 
 export class AssetsController {
@@ -175,7 +175,7 @@ export class AssetsController {
     return AssetSerializer.serialize(updatedAsset);
   }
 
-  async replaceMetadata(request: KuzzleRequest): Promise<ApiAssetReplaceMetadataResult> {
+  async replaceMetadata(request: KuzzleRequest): Promise<ApiAssetMetadataReplaceResult> {
     const assetId = request.getId();
     const engineId = request.getString("engineId");
     const metadata = request.getBodyObject("metadata");

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -20,6 +20,7 @@ import {
   ApiAssetSearchResult,
   ApiAssetUpdateResult,
   ApiAssetMigrateTenantResult,
+  ApiAssetReplaceMetadataResult,
 } from "./types/AssetApi";
 
 export class AssetsController {
@@ -64,6 +65,12 @@ export class AssetsController {
         update: {
           handler: this.update.bind(this),
           http: [{ path: "device-manager/:engineId/assets/:_id", verb: "put" }],
+        },
+        replaceMetadata: {
+          handler: this.replaceMetadata.bind(this),
+          http: [
+            { path: "device-manager/:engineId/assets/:_id/metadata", verb: "put"}
+          ]
         },
         getMeasures: {
           handler: this.getMeasures.bind(this),
@@ -159,6 +166,21 @@ export class AssetsController {
     const metadata = request.getBodyObject("metadata");
 
     const updatedAsset = await this.assetService.update(
+      engineId,
+      assetId,
+      metadata,
+      request,
+    );
+
+    return AssetSerializer.serialize(updatedAsset);
+  }
+
+  async replaceMetadata(request: KuzzleRequest): Promise<ApiAssetReplaceMetadataResult> {
+    const assetId = request.getId();
+    const engineId = request.getString("engineId");
+    const metadata = request.getBodyObject("metadata");
+
+    const updatedAsset = await this.assetService.replaceMetadata(
       engineId,
       assetId,
       metadata,

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -69,8 +69,11 @@ export class AssetsController {
         replaceMetadata: {
           handler: this.replaceMetadata.bind(this),
           http: [
-            { path: "device-manager/:engineId/assets/:_id/metadata", verb: "put"}
-          ]
+            {
+              path: "device-manager/:engineId/assets/:_id/metadata",
+              verb: "put",
+            },
+          ],
         },
         getMeasures: {
           handler: this.getMeasures.bind(this),
@@ -175,7 +178,9 @@ export class AssetsController {
     return AssetSerializer.serialize(updatedAsset);
   }
 
-  async replaceMetadata(request: KuzzleRequest): Promise<ApiAssetMetadataReplaceResult> {
+  async replaceMetadata(
+    request: KuzzleRequest,
+  ): Promise<ApiAssetMetadataReplaceResult> {
     const assetId = request.getId();
     const engineId = request.getString("engineId");
     const metadata = request.getBodyObject("metadata");

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -71,7 +71,7 @@ export class AssetsController {
           http: [
             {
               path: "device-manager/:engineId/assets/:_id/metadata",
-              verb: "put",
+              verb: "patch",
             },
           ],
         },

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -31,6 +31,19 @@ export interface ApiAssetUpdateRequest extends AssetsControllerRequest {
 }
 export type ApiAssetUpdateResult = KDocument<AssetContent>;
 
+export interface ApiAssetReplaceMetadataRequest extends AssetsControllerRequest {
+  action: "replaceMetadata";
+
+  _id: string;
+
+  refresh?: string;
+
+  body: {
+    metadata: Metadata;
+  };
+}
+export type ApiAssetReplaceMetadataResult = KDocument<AssetContent>;
+
 export interface ApiAssetUpsertRequest extends AssetsControllerRequest {
   action: "upsert";
 

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -31,7 +31,7 @@ export interface ApiAssetUpdateRequest extends AssetsControllerRequest {
 }
 export type ApiAssetUpdateResult = KDocument<AssetContent>;
 
-export interface ApiAssetReplaceMetadataRequest extends AssetsControllerRequest {
+export interface ApiAssetMetadataReplaceRequest extends AssetsControllerRequest {
   action: "replaceMetadata";
 
   _id: string;
@@ -42,7 +42,7 @@ export interface ApiAssetReplaceMetadataRequest extends AssetsControllerRequest 
     metadata: Metadata;
   };
 }
-export type ApiAssetReplaceMetadataResult = KDocument<AssetContent>;
+export type ApiAssetMetadataReplaceResult = KDocument<AssetContent>;
 
 export interface ApiAssetUpsertRequest extends AssetsControllerRequest {
   action: "upsert";

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -31,7 +31,8 @@ export interface ApiAssetUpdateRequest extends AssetsControllerRequest {
 }
 export type ApiAssetUpdateResult = KDocument<AssetContent>;
 
-export interface ApiAssetMetadataReplaceRequest extends AssetsControllerRequest {
+export interface ApiAssetMetadataReplaceRequest
+  extends AssetsControllerRequest {
   action: "replaceMetadata";
 
   _id: string;

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -13,6 +13,7 @@ export interface MeasureModelContent extends KDocumentContent {
 }
 interface MetadataProperty {
   type: string;
+  strategy?: string;
 }
 
 export interface MetadataMappings {

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -14,6 +14,7 @@ export interface MeasureModelContent extends KDocumentContent {
 interface MetadataProperty {
   type: string;
   strategy?: string;
+  format?: string;
 }
 
 export interface MetadataMappings {


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?
It will add two fields ('strategy' et 'format') in MetadataProperty to allow geoshape circle and date format according to ES documentation.

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/geo-shape.html#_circle
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/mapping-date-format.html

It implements a replace metadata endpoint for an asset. The issue was some fields cannot be removed when using basic update metadata endpoint. Some ES type needs strict typing like geo_shape polygon and it sends an error if there is additional field (basic updating polygon over circle is wrongly keeping radius field).

<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->

Types tests can pass successfully instead of putting typescript ignores.
'format' field included to store an already formatted date

https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#:~:text=a%20nanosecond%20resolution.-,Examples%3A%20yyyy%2DMM%2Ddd'T'HH%3A,or%20yyyy%2DMM%2Ddd%20.&text=A%20basic%20formatter%20for%20a,digit%20day%20of%20month%3A%20yyyyMMdd%20