### PR TITLE
build(types): use semantic-release for types package

### DIFF
--- a/.github/workflows/push_branches.workflow.yaml
+++ b/.github/workflows/push_branches.workflow.yaml
@@ -38,14 +38,6 @@ jobs:
           SEMANTIC_RELEASE_SLACK_WEBHOOK: ${{ secrets.SEMANTIC_RELEASE_SLACK_WEBHOOK }}
         run: npx semantic-release
 
-      - name: Build type package
-        run: npm -prefix ./types run build
-
-      - name: Publish package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: cd types && npm publish
-
   documentation_deploy:
     needs: [release-device-manager]
     name: Documentation - Deploy

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,20 @@
+const config = require("semantic-release-config-kuzzle");
+
+// ? Plugins are trigger in the order of definition, so ensure `releaseTypes.mjs` is inserted before `@semantic-release/git`
+config.plugins.splice(config.plugins.indexOf("@semantic-release/git"), 0, [
+  "./releaseTypes.mjs",
+  { npmPublish: process.env.SEMANTIC_RELEASE_NPM_PUBLISH === "true" },
+]);
+
+module.exports = {
+  plugins: config.plugins,
+  branches: [
+    {
+      name: "master",
+    },
+    {
+      name: "beta",
+      prerelease: true,
+    },
+  ],
+};

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["semantic-release-config-kuzzle"],
-  "branches": [
-    "master",
-    { "name": "beta", "prerelease": true }
-  ]
-}

--- a/releaseTypes.mjs
+++ b/releaseTypes.mjs
@@ -1,0 +1,177 @@
+import path from "node:path";
+import AggregateError from "aggregate-error";
+import { temporaryFile } from "tempy";
+import SemanticReleaseError from "@semantic-release/error";
+import verifyNpmConfig from "@semantic-release/npm/lib/verify-config.js";
+import getPkg from "@semantic-release/npm/lib/get-pkg.js";
+import verifyNpmAuth from "@semantic-release/npm/lib/verify-auth.js";
+import addChannelNpm from "@semantic-release/npm/lib/add-channel.js";
+import prepareNpm from "@semantic-release/npm/lib/prepare.js";
+import publishNpm from "@semantic-release/npm/lib/publish.js";
+import { add } from "@semantic-release/git/lib/git.js";
+
+/**
+ * @typedef {Object} OptionsContext
+ * @prop {import("semantic-release").GlobalConfig} options
+ */
+
+/**
+ * @typedef {Object} PluginConfig
+ * @prop {boolean} [npmPublish] Define if the package should be published on npm repository.
+ */
+
+let verified = false;
+let prepared = false;
+const typesPath = path.resolve(process.cwd(), "types");
+
+const npmrc = temporaryFile({ name: ".npmrc" });
+
+/**
+ * @param {T} context
+ * @template T
+ * @returns {T}
+ */
+function typeContext(context) {
+  context.cwd = typesPath;
+  return context;
+}
+
+/**
+ * Verify the npm configuration and plugin setup:
+ * - The plugin should be define before the plugin `@semantic-release/git` if it's defined.
+ *
+ * @param {PluginConfig} pluginConfig The plugin configuration.
+ * @param {import("semantic-release").VerifyConditionsContext & OptionsContext} ctx semantic-release context.
+ */
+export async function verifyConditions(pluginConfig, ctx) {
+  const context = typeContext(ctx);
+  const errors = verifyNpmConfig(pluginConfig);
+
+  const pluginsList = context.options.plugins.map((plugin) =>
+    Array.isArray(plugin) ? plugin[0] : plugin
+  );
+  const gitPluginIndex = pluginsList.indexOf("@semantic-release/git");
+
+  if (gitPluginIndex !== -1) {
+    const pluginIndex = pluginsList.findIndex((plugin) =>
+      plugin.includes(path.basename(import.meta.url))
+    );
+    if (pluginIndex > gitPluginIndex) {
+      errors.push(
+        new SemanticReleaseError(
+          "This plugin should be defined before plugin `@semantic-release/git`",
+          "EINVALIDSETUP"
+        )
+      );
+    }
+  }
+
+  try {
+    const pkg = await getPkg(pluginConfig, context);
+
+    if (pluginConfig.npmPublish !== false) {
+      await verifyNpmAuth(npmrc, pkg, context);
+    }
+  } catch (error) {
+    errors.push(...error.errors);
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
+
+  verified = true;
+}
+
+/**
+ * Prepare the npm package for release
+ *
+ * @param {PluginConfig} pluginConfig The plugin configuration.
+ * @param {import("semantic-release").PrepareContext & OptionsContext} ctx semantic-release context.
+ */
+export async function prepare(pluginConfig, ctx) {
+  const context = typeContext(ctx);
+  const { env, cwd } = context;
+  await prepareNpm(npmrc, pluginConfig, context);
+
+  // ? Can't modify assets configuration in a plugin, so manually add modified `package.json` in git index
+  // ? `@semantic-release/git` make release commit with the other assets files after, this is why this plugin should be defined before him
+  await add([path.join(typesPath, "package.json")], { cwd, env });
+
+  prepared = true;
+}
+
+/**
+ * Publish the npm package to the registry
+ *
+ * @param {PluginConfig} pluginConfig The plugin configuration.
+ * @param {import("semantic-release").PublishContext & OptionsContext} ctx semantic-release context.
+ */
+export async function publish(pluginConfig, ctx) {
+  const context = typeContext(ctx);
+  if (pluginConfig.npmPublish === false) {
+    context.logger.log(
+      `Skip publishing to npm registry as npmPublish is false`
+    );
+    return false;
+  }
+
+  let pkg;
+  const errors = verified ? [] : verifyNpmConfig(pluginConfig);
+
+  try {
+    // Reload package.json in case a previous external step updated it
+    pkg = await getPkg(pluginConfig, context);
+    if (
+      !verified &&
+      pluginConfig.npmPublish !== false &&
+      pkg.private !== true
+    ) {
+      await verifyNpmAuth(npmrc, pkg, context);
+    }
+  } catch (error) {
+    errors.push(...error.errors);
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
+
+  if (!prepared) {
+    await prepare(pluginConfig, context);
+  }
+
+  return publishNpm(npmrc, pluginConfig, pkg, context);
+}
+
+/**
+ * Tag npm published version with release channel (eg: `beta`) or `latest` for main releases
+ *
+ * @param {PluginConfig} pluginConfig The plugin configuration.
+ * @param {import("semantic-release").AddChannelContext & OptionsContext} ctx semantic-release context.
+ */
+export async function addChannel(pluginConfig, ctx) {
+  const context = typeContext(ctx);
+  let pkg;
+  const errors = verified ? [] : verifyNpmConfig(pluginConfig);
+
+  try {
+    // Reload package.json in case a previous external step updated it
+    pkg = await getPkg(pluginConfig, context);
+    if (
+      !verified &&
+      pluginConfig.npmPublish !== false &&
+      pkg.private !== true
+    ) {
+      await verifyNpmAuth(npmrc, pkg, context);
+    }
+  } catch (error) {
+    errors.push(...error.errors);
+  }
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors);
+  }
+
+  return addChannelNpm(npmrc, pluginConfig, pkg, context);
+}

--- a/types/package.json
+++ b/types/package.json
@@ -7,7 +7,8 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kuzzleio/kuzzle-plugin-device-manager.git"
+    "url": "git+https://github.com/kuzzleio/kuzzle-plugin-device-manager.git",
+    "directory": "types"
   },
   "scripts": {
     "prepack": "npm run build",

--- a/types/package.json
+++ b/types/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "prepack": "npm run build",
-    "build": "./copy-types.sh && node scripts/copy-version.js"
+    "build": "./copy-types.sh"
   },
   "license": "Apache-2.0",
   "files": [

--- a/types/scripts/copy-version.js
+++ b/types/scripts/copy-version.js
@@ -1,9 +1,0 @@
-const fs = require('fs');
-
-const packageVersion = JSON.parse(fs.readFileSync('../package.json', 'utf-8')).version;
-
-const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
-
-packageJson.version = packageVersion;
-
-fs.writeFileSync("./package.json", `${JSON.stringify(packageJson, null, 2)}\n`);


### PR DESCRIPTION
## What does this PR do ?

Create `semantic-release` plugin to release the type package instead of having to do it manually.
Also improve type package release delivery by handle beta release tag (not handled actually), that avoid to use `latest` tag when release a beta.
