### PR TITLE
feat(metadata): add support nested metadata object

### DIFF
--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -15,10 +15,14 @@ interface MetadataProperty {
   type: string;
 }
 
+interface MetadataObject {
+  properties: {
+    [key: string]: MetadataProperty | MetadataObject;
+  };
+}
+
 export interface MetadataMappings {
-  [key: string]:
-    | MetadataProperty
-    | { properties: { [key: string]: MetadataProperty } };
+  [key: string]: MetadataProperty | MetadataObject;
 }
 
 interface LocaleDetails {


### PR DESCRIPTION
## What does this PR do ?

Simply add support nested metadata object, for below example, currently the `level2` can't have a `properties` field for nested object, the new type defines circular for `MetadataObject` to support it.

```ts
export const SampleDeviceDefinition: DeviceModelDefinition = {
  decoder: new SampleDeviceDecoder(),
  defaultMetadata: {},
  metadataMappings: {
    level1: {
      properties: {
        level2: {
          properties: {
            level3: { type: 'text' },
          },
        },
      },
    },
  },
};
```
