### PR TITLE
fix(device): correct device HTTP API

### DIFF
--- a/doc/2/controllers/assets/delete/index.md
+++ b/doc/2/controllers/assets/delete/index.md
@@ -14,7 +14,7 @@ Deletes an asset.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:assetId
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id
 Method: DELETE
 ```
 

--- a/doc/2/controllers/devices/delete/index.md
+++ b/doc/2/controllers/devices/delete/index.md
@@ -14,7 +14,7 @@ Deletes a device.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/:engineId/devices/:deviceId
+URL: http://kuzzle:7512/_/device-manager/:engineId/devices/:_id
 Method: DELETE
 ```
 

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -53,7 +53,7 @@ export class DevicesController {
         update: {
           handler: this.update.bind(this),
           http: [
-            { path: "device-manager/:engineId/device/:deviceId", verb: "post" },
+            { path: "device-manager/:engineId/devices/:_id", verb: "put" },
           ],
         },
         search: {
@@ -66,7 +66,7 @@ export class DevicesController {
           handler: this.delete.bind(this),
           http: [
             {
-              path: "device-manager/:engineId/device/:deviceId",
+              path: "device-manager/:engineId/devices/:_id",
               verb: "delete",
             },
           ],

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "npm run test:functional && npm run test:types",
     "test:functional": "jest --runInBand",
     "test:types": "tsc --noEmit",
-    "lint": "eslint ./lib ./tests --ext .ts --config .eslintrc.json",
-    "lint:fix": "eslint ./lib ./tests --ext .ts --config .eslintrc.json --fix",
+    "lint": "eslint ./lib ./tests --ext .ts",
+    "lint:fix": "eslint ./lib ./tests --ext .ts --fix",
     "prettier": "prettier lib/ tests/ --write",
     "build": "tsc --build tsconfig.json",
     "prepack": "npm run build"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -7,7 +7,7 @@
   "include": [
     "lib/**/*.ts",
     "scripts/**/*.mjs",
-    "tests/application/**/*.ts",
+    "tests/**/*.ts",
     ".eslintrc.cjs",
     "index.ts",
     "releaseTypes.mjs"


### PR DESCRIPTION
## What does this PR do ?

Simply correct HTTP API for device controller, according to documentation, and homogenize compared to assets API.

### Previous

Update device should use `POST:/_/device-manager/<tenantId>/device/<useless>?_id=<deviceId>`
Delete device should use `DELETE:/_/device-manager/<tenantId>/device/<useless>?_id=<deviceId>`

### After


Update device should use `PUT:/_/device-manager/<tenantId>/devices/<deviceId>`
Delete device should use `DELETE:/_/device-manager/<tenantId>/devices/<deviceId>`