### PR TITLE
feat(measure): add device metadata to origin

### DIFF
--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -387,6 +387,7 @@ export class MeasureService extends BaseService {
         measuredAt: measurement.measuredAt,
         origin: {
           _id: device._id,
+          deviceMetadata: device._source.metadata,
           deviceModel: device._source.model,
           measureName: measurement.measureName,
           payloadUuids,

--- a/lib/modules/measure/collections/measuresMappings.ts
+++ b/lib/modules/measure/collections/measuresMappings.ts
@@ -51,6 +51,12 @@ export const measuresMappings = {
 
         measureName: { type: "keyword" },
 
+        deviceMetadata: {
+          properties: {
+            // populated with device models metadata mappings
+          },
+        },
+
         payloadUuids: { type: "keyword" },
 
         deviceModel: { type: "keyword" },

--- a/lib/modules/measure/types/MeasureContent.ts
+++ b/lib/modules/measure/types/MeasureContent.ts
@@ -15,6 +15,11 @@ export type MeasureOriginDevice = {
   measureName: string;
 
   /**
+   * Origin device metadata
+   */
+  deviceMetadata?: Metadata;
+
+  /**
    * Payload uuids that were used to create this measure.
    */
   payloadUuids: Array<string>;

--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -132,29 +132,35 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
         );
 
         const results = await this.getEngines();
+        const engineGroups = results.map((elt) => elt.engine.group);
+        const groups = [undefined, ...engineGroups];
 
-        for (const document of results) {
+        for (const group of groups) {
           if (payload.twin) {
             const twinModels = await this.getModels<TwinModelContent>(
               this.config.adminIndex,
               payload.twin.type,
-              document.engine.group,
+              group,
             );
 
-            return this.doesTwinUpdateConflicts(
+            const conflicts = await this.doesTwinUpdateConflicts(
               payload.twin.type,
               twinModels,
               payload.twin.models,
               measureModels,
             );
-          }
 
-          if (payload.measuresModels) {
-            return this.doesMeasuresUpdateConflicts(
-              measureModels,
-              payload.measuresModels,
-            );
+            if (conflicts.length > 0) {
+              return conflicts;
+            }
           }
+        }
+
+        if (payload.measuresModels) {
+          return this.doesMeasuresUpdateConflicts(
+            measureModels,
+            payload.measuresModels,
+          );
         }
 
         return [];
@@ -548,7 +554,9 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
       engineGroup,
     );
 
-    return this.getMeasuresMappings(models, assetsMappings);
+    const deviceMappings = await this.getDigitalTwinMappingsFromDB("device");
+
+    return this.getMeasuresMappings(models, assetsMappings, deviceMappings);
   }
 
   /**
@@ -561,6 +569,7 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   private async getMeasuresMappings(
     models: MeasureModelContent[],
     assetsMappings: any,
+    deviceMappings: any,
   ) {
     const mappings = JSON.parse(JSON.stringify(measuresMappings));
 
@@ -573,6 +582,9 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
     mappings.properties.asset.properties.metadata.properties =
       assetsMappings.properties.metadata.properties;
+
+    mappings.properties.origin.properties.deviceMetadata.properties =
+      deviceMappings.properties.metadata.properties;
 
     return mappings;
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?
This PR add a step to the measure ingestion pipeline, the goal is to add the origin device metadata to the measure origin
<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### How should this be manually tested?

<!--
  Please describe your test configuration, the tests ran to verify your changes
  And give us instructions on how to reproduce them.
-->
  - Step 1 : Create a device with metadata
  - Step 2 : Push a payload through it
  - Step 3 : Check the measure document origin

### Other changes

<!--
  Please outline any changes not directly linked to the main issue, but made because of it.
  For instance: on-the-fly fixes, dependencies updates and so on.
-->

Conflict would not update for `commons` group
Return conflicts only when there is at least one
