### PR TITLE
feat(assets admin role): add link and unlink device actions to assets admin role

### DIFF
--- a/lib/modules/asset/roles/RoleAssetsAdmin.ts
+++ b/lib/modules/asset/roles/RoleAssetsAdmin.ts
@@ -40,6 +40,9 @@ export const RoleAssetsAdmin: KuzzleRole = {
           listMeasures: true,
         },
       },
+      "device-manager/devices": {
+        actions: { linkAsset: true, unlinkAsset: true },
+      },
     },
   },
 };


### PR DESCRIPTION

## What does this PR do ?

This PR adds the actions link device and unlink device actions to the  assets.admin role as requested in [this ticket](https://kuzzle.atlassian.net/browse/KZLPRD-477)

Those actions would be shared by assets.admin and devices.admin as it regards both assets and devices.

