### PR TITLE
feat: remove asset historization when receiving a measure

### DIFF
--- a/doc/1/guides/assets/index.md
+++ b/doc/1/guides/assets/index.md
@@ -85,3 +85,28 @@ By default, for each measurement type the following information are copied in ad
 ```
 
 It is possible to override the [Decoder.copyToAsset](/official-plugins/device-manager/1/classes/decoder/copy-to-asset) method to choose what to copy into the asset.
+
+## Historization
+
+Assets are historized in the `asset-history` collection when a new measure is received.
+
+Before historization, the `engine:<engine-index>:asset:measure:new` event is emitted.
+
+The payload contain the asset updated content and the types of the new added measures.
+
+At the end of the processing, the asset will be updated and historized with the content of the `request.result.asset._source`.
+
+```js
+app.pipe.register(`engine:<engine-index>:asset:measures:new`, async (request: KuzzleRequest) => {
+  const asset = request.result.asset;
+  const measureTypes = request.result.measureTypes;
+
+  if (measureTypes.includes('position')) {
+    request.result.asset._source.metadata = {
+      city: 'Adrasan',
+    };
+  }
+
+  return request;
+});
+```

--- a/doc/1/guides/assets/index.md
+++ b/doc/1/guides/assets/index.md
@@ -85,28 +85,3 @@ By default, for each measurement type the following information are copied in ad
 ```
 
 It is possible to override the [Decoder.copyToAsset](/official-plugins/device-manager/1/classes/decoder/copy-to-asset) method to choose what to copy into the asset.
-
-## Historization
-
-Assets are historized in the `asset-history` collection when a new measure is received.
-
-Before historization, the `engine:<engine-index>:asset:measure:new` event is emitted.
-
-The payload contain the asset updated content and the types of the new added measures.
-
-At the end of the processing, the asset will be updated and historized with the content of the `request.result.asset._source`.
-
-```js
-app.pipe.register(`engine:<engine-index>:asset:measures:new`, async (request: KuzzleRequest) => {
-  const asset = request.result.asset;
-  const measureTypes = request.result.measureTypes;
-
-  if (measureTypes.includes('position')) {
-    request.result.asset._source.metadata = {
-      city: 'Adrasan',
-    };
-  }
-
-  return request;
-});
-```

--- a/doc/2/concepts/digital-twins-devices-assets/index.md
+++ b/doc/2/concepts/digital-twins-devices-assets/index.md
@@ -114,9 +114,7 @@ The API action [device-manager/devices:linkAsset](/official-plugins/device-manag
 
 The successive states of the assets are systematically logged in the Kuzzle IoT Platform.
 
-Each reception of a measurement by a device linked to an asset leads to a change in the state of the asset which will be logged.
-
-It is the same for the modification of the metadata of an asset.
+Each modification of the metadata of an asset (either directly or through a received measure) is saved in the asset state history.
 
 The state history entries contain all the necessary information:
 
@@ -127,7 +125,6 @@ The state history entries contain all the necessary information:
 
 The different types of state changes are:
 
-- receipt of a new measurement
 - modification of a metadata
 - associate a new device
 - dissociate from a device

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -43,7 +43,6 @@ export interface AssetHistoryContent<
   /**
    * Name of the event who caused the historization
    *
-   *  - `measure` a new measure has been received
    *  - `metadata` the asset metadata has been updated
    *  - `link` a device has been linked or unlinked to the asset
    *  - `unlink` a device has been unlinked from the asset
@@ -63,7 +62,6 @@ export interface AssetHistoryContent<
   /**
    * Timestamp of the event according to its type
    *
-   *  - `measure`: the date of measure (`measuredAt`)
    *  - `metadata`: the current date of the event
    *  - `link`: the current date of the event
    *  - `unlink`: the current date of the event

--- a/lib/modules/asset/types/AssetHistoryContent.ts
+++ b/lib/modules/asset/types/AssetHistoryContent.ts
@@ -8,14 +8,6 @@ export type AssetHistoryMetadata = {
   names: string[];
 };
 
-export type AssetHistoryEventMeasure = {
-  name: "measure";
-  measure: {
-    names: string[];
-  };
-  metadata?: AssetHistoryMetadata;
-};
-
 export type AssetHistoryEventMetadata = {
   name: "metadata";
   metadata: AssetHistoryMetadata;
@@ -36,7 +28,6 @@ export type AssetHistoryEventUnlink = {
 };
 
 export type AssetHistoryEvent =
-  | AssetHistoryEventMeasure
   | AssetHistoryEventMetadata
   | AssetHistoryEventLink
   | AssetHistoryEventUnlink;

--- a/tests/scenario/migrated/asset-history.test.ts
+++ b/tests/scenario/migrated/asset-history.test.ts
@@ -66,10 +66,7 @@ describe("features/Asset/History", () => {
   });
 
   it("Historize asset after being linked and unlinked", async () => {
-    let response;
-    let promise;
-
-    response = await sdk.query({
+    let response = await sdk.query({
       controller: "device-manager/devices",
       action: "linkAsset",
       _id: "DummyTemp-unlinked1",
@@ -131,45 +128,8 @@ describe("features/Asset/History", () => {
     });
   });
 
-  it("Historize asset after receiving a new measure", async () => {
-    let response;
-    let promise;
-
-    response = await sendPayloads(sdk, "dummy-temp", [
-      { deviceEUI: "linked1", temperature: 42.2 },
-    ]);
-
-    await sdk.collection.refresh("engine-ayse", "assets-history");
-
-    response = await sdk.query({
-      controller: "document",
-      action: "search",
-      index: "engine-ayse",
-      collection: "assets-history",
-      body: { sort: { "_kuzzle_info.createdAt": "desc" } },
-    });
-
-    expect(response.result).toMatchObject({
-      hits: {
-        "0": {
-          _source: {
-            id: "Container-linked1",
-            event: { name: "measure", measure: { names: ["temperatureExt"] } },
-            asset: {
-              measures: { temperatureExt: { values: { temperature: 42.2 } } },
-            },
-          },
-        },
-        length: 1,
-      },
-    });
-  });
-
   it("Historize asset when metadata have been updated when receiving a measure", async () => {
-    let response;
-    let promise;
-
-    response = await sendPayloads(sdk, "dummy-temp", [
+    let response = await sendPayloads(sdk, "dummy-temp", [
       {
         deviceEUI: "linked1",
         temperature: 42.2,
@@ -193,8 +153,7 @@ describe("features/Asset/History", () => {
           _source: {
             id: "Container-linked1",
             event: {
-              name: "measure",
-              measure: { names: ["temperatureExt"] },
+              name: "metadata",
               metadata: { names: ["weight", "trailer.capacity"] },
             },
             asset: {

--- a/tests/scenario/migrated/decoder-payload-controller.test.ts
+++ b/tests/scenario/migrated/decoder-payload-controller.test.ts
@@ -24,10 +24,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Register a DummyTemp payload", async () => {
-    let response;
-    let promise;
-
-    response = await sendPayloads(sdk, "dummy-temp", [
+    await sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: "12345", temperature: 21 },
       { deviceEUI: "12345", temperature: 42 },
     ]);
@@ -48,10 +45,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Reject if measuredAt is not unix timestamp", async () => {
-    let response;
-    let promise;
-
-    promise = sendPayloads(sdk, "dummy-temp", [
+    const promise = sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: "12345", temperature: 21, measuredAt: 1671007889 },
     ]);
 
@@ -62,10 +56,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Reject with error a DummyTemp payload", async () => {
-    let response;
-    let promise;
-
-    promise = sendPayloads(sdk, "dummy-temp", [
+    const promise = sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: null, temperature: 21 },
     ]);
 
@@ -75,10 +66,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Reject a DummyTemp payload", async () => {
-    let response;
-    let promise;
-
-    response = await sendPayloads(sdk, "dummy-temp", [
+    const response = await sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: "12345", temperature: 21, invalid: true },
     ]);
 
@@ -180,24 +168,6 @@ describe("features/Decoder/PayloadController", () => {
       },
     });
 
-    await sdk.collection.refresh("engine-ayse", "assets-history");
-
-    const assetHistory = await sdk.query({
-      controller: "document",
-      action: "search",
-      index: "engine-ayse",
-      collection: "assets-history",
-      body: { sort: { "_kuzzle_info.createdAt": "desc" } },
-    });
-
-    expect(assetHistory.result.hits[0]._source).toMatchObject({
-      id: "Container-linked2",
-      event: {
-        name: "measure",
-        measure: { names: ["temperatureExt", "position"] },
-      },
-    });
-
     await sdk.collection.refresh("device-manager", "payloads");
     let exceptedResult = await sdk.document.search(
       "device-manager",
@@ -220,10 +190,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Historize the measures with device and asset context", async () => {
-    let response;
-    let promise;
-
-    response = await sendPayloads(sdk, "dummy-temp", [
+    let response = await sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: "linked1", temperature: 42.2 },
     ]);
 
@@ -256,10 +223,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Decode Device metadata from payload", async () => {
-    let response;
-    let promise;
-
-    response = await sendPayloads(sdk, "dummy-temp", [
+    await sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: "12345", temperature: 21.1, metadata: { color: "RED" } },
     ]);
 
@@ -275,17 +239,14 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Throw an error when decoding unknown measure name", async () => {
-    let response;
-    let promise;
-
-    response = await sdk.query({
+    await sdk.query({
       controller: "device-manager/devices",
       action: "create",
       engineId: "device-manager",
       body: { model: "DummyTemp", reference: "test" },
     });
 
-    promise = sendPayloads(sdk, "dummy-temp", [
+    const promise = sendPayloads(sdk, "dummy-temp", [
       { deviceEUI: "12345", temperature: 21.1, unknownMeasure: 42 },
     ]);
 
@@ -301,10 +262,7 @@ describe("features/Decoder/PayloadController", () => {
   });
 
   it("Receive a payload from unknown device", async () => {
-    let response;
-    let promise;
-
-    response = await sdk.query({
+    await sdk.query({
       controller: "device-manager/payloads",
       action: "receiveUnknown",
       deviceModel: "Abeeway",

--- a/tests/scenario/modules/assets/asset-history.test.ts
+++ b/tests/scenario/modules/assets/asset-history.test.ts
@@ -7,102 +7,6 @@ jest.setTimeout(10000);
 describe("DeviceController: receiveMeasure", () => {
   const sdk = setupHooks();
 
-  it("should save asset history when measure is received", async () => {
-    await sendDummyTempPayloads(sdk, [
-      {
-        deviceEUI: "linked1",
-        temperature: 21,
-      },
-    ]);
-    await sdk.collection.refresh("engine-ayse", "assets-history");
-
-    const result = await sdk.document.search<AssetHistoryContent>(
-      "engine-ayse",
-      "assets-history",
-      {
-        sort: { "_kuzzle_info.createdAt": "desc" },
-      },
-    );
-    expect(result.hits[0]._source).toMatchObject({
-      id: "Container-linked1",
-      event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
-      },
-    });
-    expect(result.hits[0]._source.event.metadata).toBeUndefined();
-  });
-
-  it("should historize asset for each measurements of the same measure received in non-chronological order", async () => {
-    await sendDummyTempPayloads(sdk, [
-      {
-        measurements: [
-          {
-            deviceEUI: "linked1",
-            temperature: 13.27,
-            measuredAt: 1680096420000, // 13:27:00 UTC
-          },
-          {
-            deviceEUI: "linked1",
-            temperature: 13.25,
-            measuredAt: 1680096300000, // 13:25:00 UTC
-          },
-          {
-            deviceEUI: "linked1",
-            temperature: 13.26,
-            measuredAt: 1680096360000, // 13:26:00 UTC
-          },
-        ],
-      },
-    ]);
-    await sdk.collection.refresh("engine-ayse", "assets-history");
-
-    const result = await sdk.document.search<AssetHistoryContent>(
-      "engine-ayse",
-      "assets-history",
-    );
-
-    expect(result.hits).toHaveLength(3);
-    expect(result.hits[0]._source).toMatchObject({
-      id: "Container-linked1",
-      event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
-      },
-      asset: {
-        measures: { temperatureExt: { values: { temperature: 13.27 } } },
-      },
-    });
-    expect(result.hits[1]._source).toMatchObject({
-      id: "Container-linked1",
-      event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
-      },
-      asset: {
-        measures: { temperatureExt: { values: { temperature: 13.26 } } },
-      },
-    });
-    expect(result.hits[2]._source).toMatchObject({
-      id: "Container-linked1",
-      event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
-      },
-      asset: {
-        measures: { temperatureExt: { values: { temperature: 13.25 } } },
-      },
-    });
-  });
-
   it("should add a metadata event to the history entry", async () => {
     await sendDummyTempPayloads(sdk, [
       {
@@ -128,10 +32,7 @@ describe("DeviceController: receiveMeasure", () => {
     expect(result.hits[0]._source).toMatchObject({
       id: "Container-linked1",
       event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
+        name: "metadata",
         metadata: {
           names: ["weight", "trailer.capacity"],
         },
@@ -297,14 +198,11 @@ describe("DeviceController: receiveMeasure", () => {
       "assets-history",
     );
 
-    expect(result.hits).toHaveLength(2);
+    expect(result.hits).toHaveLength(1);
     expect(result.hits[0]._source).toMatchObject({
       id: "Container-linked1",
       event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
+        name: "metadata",
         metadata: {
           names: ["weight", "trailer.capacity"],
         },
@@ -312,19 +210,6 @@ describe("DeviceController: receiveMeasure", () => {
       asset: {
         measures: { temperatureExt: { values: { temperature: 13.27 } } },
         metadata: { weight: 42042, trailer: { capacity: 2048 } },
-      },
-    });
-    expect(result.hits[1]._source).toMatchObject({
-      id: "Container-linked1",
-      event: {
-        name: "measure",
-        measure: {
-          names: ["temperatureExt"],
-        },
-      },
-      asset: {
-        measures: { temperatureExt: { values: { temperature: 13.26 } } },
-        metadata: { weight: 10, trailer: { capacity: 1024 } },
       },
     });
   });


### PR DESCRIPTION
## What does this PR do ?

This removes writes to the `asset-history` collection when a new measure comes in. An history entry might still be created when receiving a measure if the measure updates the asset metadata.

Part of [KZLPRD-438](https://kuzzle.atlassian.net/browse/KZLPRD-438).

### Boyscout

- Edited test files were clean up a little
- Fixed flaky tests that were writing to the `person` metadata in `Container` assets, which didn't contain such metadata in its metadata mappings

[KZLPRD-438]: https://kuzzle.atlassian.net/browse/KZLPRD-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ