### PR TITLE
feat: add search actions for the models

### DIFF
--- a/doc/2/controllers/models/search-assets/index.md
+++ b/doc/2/controllers/models/search-assets/index.md
@@ -1,0 +1,81 @@
+---
+code: true
+type: page
+title: searchAssets
+description: Searches for asset models
+---
+
+# searchAssets
+
+Searches for asset models.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/assets/_search
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "searchAssets",
+  "engineGroup": "<engineGroup>",
+  "body": {
+    "query": {
+      // ...
+    },
+    "sort": [
+      // ...
+    ]
+  },
+
+  // optional:
+  "from": "<starting offset>",
+  "size": "<page size>",
+}
+```
+
+---
+
+## Arguments
+
+- `engineGroup`: name of the engine group
+- `from`: paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
+- `size`: set the maximum number of documents returned per result page
+
+## Body properties
+
+- `query`: the search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html).
+- `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance.
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "searchAssets",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "hits": [
+      {
+        "_id": "<assetModelId>",
+        "_source": {
+          // Asset model content
+        },
+      },
+    ],
+    "total": 42
+  }
+}
+```

--- a/doc/2/controllers/models/search-assets/index.md
+++ b/doc/2/controllers/models/search-assets/index.md
@@ -38,7 +38,7 @@ Method: POST
 
   // optional:
   "from": "<starting offset>",
-  "size": "<page size>",
+  "size": "<page size>"
 }
 ```
 

--- a/doc/2/controllers/models/search-devices/index.md
+++ b/doc/2/controllers/models/search-devices/index.md
@@ -1,0 +1,79 @@
+---
+code: true
+type: page
+title: searchDevices
+description: Searches for device models
+---
+
+# searchDevices
+
+Searches for device models.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/devices/_search
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "searchDevices",
+  "body": {
+    "query": {
+      // ...
+    },
+    "sort": [
+      // ...
+    ]
+  },
+
+  // optional:
+  "from": "<starting offset>",
+  "size": "<page size>",
+}
+```
+
+---
+
+## Arguments
+
+- `from`: paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
+- `size`: set the maximum number of documents returned per result page
+
+## Body properties
+
+- `query`: the search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html).
+- `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance.
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "searchDevices",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "hits": [
+      {
+        "_id": "<deviceModelId>",
+        "_source": {
+          // Device model content
+        },
+      },
+    ],
+    "total": 42
+  }
+}
+```

--- a/doc/2/controllers/models/search-devices/index.md
+++ b/doc/2/controllers/models/search-devices/index.md
@@ -37,7 +37,7 @@ Method: POST
 
   // optional:
   "from": "<starting offset>",
-  "size": "<page size>",
+  "size": "<page size>"
 }
 ```
 

--- a/doc/2/controllers/models/search-measures/index.md
+++ b/doc/2/controllers/models/search-measures/index.md
@@ -1,0 +1,79 @@
+---
+code: true
+type: page
+title: searchMeasures
+description: Searches for measure models
+---
+
+# searchMeasures
+
+Searches for measure models.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/measures/_search
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "searchMeasures",
+  "body": {
+    "query": {
+      // ...
+    },
+    "sort": [
+      // ...
+    ]
+  },
+
+  // optional:
+  "from": "<starting offset>",
+  "size": "<page size>",
+}
+```
+
+---
+
+## Arguments
+
+- `from`: paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
+- `size`: set the maximum number of documents returned per result page
+
+## Body properties
+
+- `query`: the search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html).
+- `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance.
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "searchMeasures",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "hits": [
+      {
+        "_id": "<measureModelId>",
+        "_source": {
+          // Measure model content
+        },
+      },
+    ],
+    "total": 42
+  }
+}
+```

--- a/doc/2/controllers/models/search-measures/index.md
+++ b/doc/2/controllers/models/search-measures/index.md
@@ -37,7 +37,7 @@ Method: POST
 
   // optional:
   "from": "<starting offset>",
-  "size": "<page size>",
+  "size": "<page size>"
 }
 ```
 

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -9,7 +9,7 @@ import {
   NotFoundError,
 } from "kuzzle";
 import { ask, onAsk } from "kuzzle-plugin-commons";
-import { JSONObject, KDocument } from "kuzzle-sdk";
+import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import {
   AskEngineUpdateAll,
@@ -19,7 +19,7 @@ import {
 } from "../plugin";
 
 import { AskAssetRefreshModel } from "../asset";
-import { BaseService, flattenObject } from "../shared";
+import { BaseService, SearchParams, flattenObject } from "../shared";
 import { ModelSerializer } from "./ModelSerializer";
 import {
   AssetModelContent,
@@ -387,60 +387,116 @@ export class ModelService extends BaseService {
   async listAsset(
     engineGroup: string,
   ): Promise<KDocument<AssetModelContent>[]> {
-    const query = {
-      and: [
-        { equals: { type: "asset" } },
-        {
-          or: [
-            { equals: { engineGroup } },
-            { equals: { engineGroup: "commons" } },
-          ],
-        },
-      ],
-    };
-
-    const sort = { "asset.model": "asc" };
-
-    const result = await this.sdk.document.search<AssetModelContent>(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-      { query, sort },
-      { lang: "koncorde", size: 5000 },
-    );
+    const result = await this.searchAssets(engineGroup, {
+      searchBody: {
+        sort: { "asset.model": "asc" },
+      },
+      size: 5000,
+    });
 
     return result.hits;
   }
 
   async listDevices(): Promise<KDocument<DeviceModelContent>[]> {
-    const query = {
-      and: [{ equals: { type: "device" } }],
-    };
-    const sort = { "device.model": "asc" };
-
-    const result = await this.sdk.document.search<DeviceModelContent>(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-      { query, sort },
-      { lang: "koncorde", size: 5000 },
-    );
+    const result = await this.searchDevices({
+      searchBody: {
+        sort: { "device.model": "asc" },
+      },
+      size: 5000,
+    });
 
     return result.hits;
   }
 
   async listMeasures(): Promise<KDocument<MeasureModelContent>[]> {
-    const query = {
-      and: [{ equals: { type: "measure" } }],
-    };
-    const sort = { "measure.type": "asc" };
-
-    const result = await this.sdk.document.search<MeasureModelContent>(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-      { query, sort },
-      { lang: "koncorde", size: 5000 },
-    );
+    const result = await this.searchMeasures({
+      searchBody: {
+        sort: { "measure.type": "asc" },
+      },
+      size: 5000,
+    });
 
     return result.hits;
+  }
+
+  async searchAssets(
+    engineGroup: string,
+    searchParams: Partial<SearchParams>,
+  ): Promise<SearchResult<KHit<AssetModelContent>>> {
+    const query = {
+      bool: {
+        must: [searchParams.searchBody.query, { match: { type: "asset" } }],
+        should: [
+          { match: { engineGroup } },
+          { match: { engineGroup: "commons" } },
+        ],
+      },
+    };
+
+    return this.sdk.document.search<AssetModelContent>(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+      {
+        ...searchParams.searchBody,
+        query,
+      },
+      {
+        from: searchParams.from,
+        lang: "elasticsearch",
+        scroll: searchParams.scrollTTL,
+        size: searchParams.size,
+      },
+    );
+  }
+
+  async searchDevices(
+    searchParams: Partial<SearchParams>,
+  ): Promise<SearchResult<KHit<DeviceModelContent>>> {
+    const query = {
+      bool: {
+        must: [searchParams.searchBody.query, { match: { type: "device" } }],
+      },
+    };
+
+    return this.sdk.document.search<DeviceModelContent>(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+      {
+        ...searchParams.searchBody,
+        query,
+      },
+      {
+        from: searchParams.from,
+        lang: "elasticsearch",
+        scroll: searchParams.scrollTTL,
+        size: searchParams.size,
+      },
+    );
+  }
+
+  async searchMeasures(
+    searchParams: Partial<SearchParams>,
+  ): Promise<SearchResult<KHit<MeasureModelContent>>> {
+    const query = {
+      bool: {
+        must: [searchParams.searchBody.query, { match: { type: "measure" } }],
+      },
+    };
+
+    return this.sdk.document.search<MeasureModelContent>(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+      {
+        ...searchParams.searchBody,
+        query,
+      },
+      {
+        from: searchParams.from,
+        lang: "elasticsearch",
+        scroll: searchParams.scrollTTL,
+        size: searchParams.size,
+      },
+    );
   }
 
   async assetExists(model: string): Promise<boolean> {

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -15,6 +15,9 @@ import {
   ApiModelGetAssetResult,
   ApiModelGetDeviceResult,
   ApiModelGetMeasureResult,
+  ApiModelSearchAssetsResult,
+  ApiModelSearchDevicesResult,
+  ApiModelSearchMeasuresResult,
 } from "./types/ModelApi";
 
 export class ModelsController {
@@ -64,6 +67,24 @@ export class ModelsController {
         listMeasures: {
           handler: this.listMeasures.bind(this),
           http: [{ path: "device-manager/models/measures", verb: "get" }],
+        },
+        searchAssets: {
+          handler: this.searchAssets.bind(this),
+          http: [
+            { path: "device-manager/models/assets/_search", verb: "post" },
+          ],
+        },
+        searchDevices: {
+          handler: this.searchDevices.bind(this),
+          http: [
+            { path: "device-manager/models/devices/_search", verb: "post" },
+          ],
+        },
+        searchMeasures: {
+          handler: this.searchMeasures.bind(this),
+          http: [
+            { path: "device-manager/models/measures/_search", verb: "post" },
+          ],
         },
         updateAsset: {
           handler: this.updateAsset.bind(this),
@@ -224,6 +245,27 @@ export class ModelsController {
       models,
       total: models.length,
     };
+  }
+
+  async searchAssets(
+    request: KuzzleRequest,
+  ): Promise<ApiModelSearchAssetsResult> {
+    return this.modelService.searchAssets(
+      request.getString("engineGroup"),
+      request.getSearchParams(),
+    );
+  }
+
+  async searchDevices(
+    request: KuzzleRequest,
+  ): Promise<ApiModelSearchDevicesResult> {
+    return this.modelService.searchDevices(request.getSearchParams());
+  }
+
+  async searchMeasures(
+    request: KuzzleRequest,
+  ): Promise<ApiModelSearchMeasuresResult> {
+    return this.modelService.searchMeasures(request.getSearchParams());
   }
 
   async updateAsset(

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -1,4 +1,4 @@
-import { JSONObject, KDocument } from "kuzzle-sdk";
+import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import {
   AssetModelContent,
@@ -138,3 +138,24 @@ export type ApiModelListMeasuresResult = {
   models: KDocument<MeasureModelContent>[];
   total: number;
 };
+
+export interface ApiModelSearchAssetsRequest extends ModelsControllerRequest {
+  action: "searchAssets";
+
+  engineGroup: string;
+}
+export type ApiModelSearchAssetsResult = SearchResult<KHit<AssetModelContent>>;
+
+export interface ApiModelSearchDevicesRequest extends ModelsControllerRequest {
+  action: "searchDevices";
+}
+export type ApiModelSearchDevicesResult = SearchResult<
+  KHit<DeviceModelContent>
+>;
+
+export interface ApiModelSearchMeasuresRequest extends ModelsControllerRequest {
+  action: "searchMeasures";
+}
+export type ApiModelSearchMeasuresResult = SearchResult<
+  KHit<MeasureModelContent>
+>;

--- a/tests/hooks/collections.ts
+++ b/tests/hooks/collections.ts
@@ -19,6 +19,7 @@ async function deleteModels(sdk: Kuzzle) {
           "model-asset-plane",
           "model-asset-AdvancedPlane",
           "model-device-Zigbee",
+          "model-device-Bluetooth",
           "model-device-Enginko",
           "model-asset-TestHouse",
           "model-asset-AdvancedWarehouse",

--- a/tests/scenario/modules/models/device-model.test.ts
+++ b/tests/scenario/modules/models/device-model.test.ts
@@ -121,6 +121,53 @@ describe("ModelsController:devices", () => {
     });
   });
 
+  it("Write and Search a Device model", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeDevice",
+      body: {
+        model: "Zigbee",
+        measures: [{ type: "battery", name: "battery" }],
+        metadataMappings: { network: { type: "keyword" } },
+      },
+    });
+
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeDevice",
+      body: {
+        model: "Bluetooth",
+        measures: [
+          { type: "battery", name: "battery" },
+          { type: "temperature", name: "temperature" },
+        ],
+        metadataMappings: {
+          network: { type: "keyword" },
+          network2: { type: "keyword" },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const searchDevices = await sdk.query({
+      controller: "device-manager/models",
+      action: "searchDevices",
+      body: {
+        query: {
+          match: {
+            "device.model": "Zigbee",
+          },
+        },
+      },
+    });
+
+    expect(searchDevices.result).toMatchObject({
+      total: 1,
+      hits: [{ _id: "model-device-Zigbee" }],
+    });
+  });
+
   it("Error if the model name is not PascalCase", async () => {
     const badModelName = sdk.query({
       controller: "device-manager/models",

--- a/tests/scenario/modules/models/measures-model.test.ts
+++ b/tests/scenario/modules/models/measures-model.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../lib/modules/model";
 import { setupSdK } from "../../../helpers";
 
-jest.setTimeout(10000);
+jest.setTimeout(20000);
 
 describe("ModelsController:measures", () => {
   const sdk = setupSdK();
@@ -181,6 +181,47 @@ describe("ModelsController:measures", () => {
     expect(getMeasure.result).toMatchObject({
       _id: "model-measure-battery",
       _source: { measure: { type: "battery" } },
+    });
+  });
+
+  it("Write and Search a Measure model", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeMeasure",
+      body: {
+        type: "presence",
+        valuesMappings: { presence: { type: "boolean" } },
+      },
+    });
+
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeMeasure",
+      body: {
+        type: "movement",
+        valuesMappings: {
+          movement: { type: "boolean" },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const searchMeasures = await sdk.query({
+      controller: "device-manager/models",
+      action: "searchMeasures",
+      body: {
+        query: {
+          match: {
+            "measure.type": "presence",
+          },
+        },
+      },
+    });
+
+    expect(searchMeasures.result).toMatchObject({
+      total: 1,
+      hits: [{ _id: "model-measure-presence" }],
     });
   });
 


### PR DESCRIPTION
## What does this PR do ?

This adds three actions on the `device-manager/models` controller to search for asset, device and measure models using the Elasticsearch query DSL.