### PR TITLE
fix: only list asset models for the requested engine group

### DIFF
--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -425,10 +425,17 @@ export class ModelService extends BaseService {
   ): Promise<SearchResult<KHit<AssetModelContent>>> {
     const query = {
       bool: {
-        must: [searchParams.searchBody.query, { match: { type: "asset" } }],
-        should: [
-          { match: { engineGroup } },
-          { match: { engineGroup: "commons" } },
+        must: [
+          searchParams.searchBody.query,
+          { match: { type: "asset" } },
+          {
+            bool: {
+              should: [
+                { match: { engineGroup } },
+                { match: { engineGroup: "commons" } },
+              ],
+            },
+          },
         ],
       },
     };

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -12,6 +12,10 @@ import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
 import { TestsController } from "./tests/controller";
 import { registerTestPipes } from "./tests/pipes";
 import { accelerationMeasureDefinition } from "./measures/AccelerationMeasure";
+import { brightnessMeasureDefinition } from "./measures/BrightnessMeasure";
+import { co2MeasureDefinition } from "./measures/CO2Measure";
+import { illuminanceMeasureDefinition } from "./measures/IlluminanceMeasure";
+import { powerConsumptionMeasureDefinition } from "./measures/PowerConsumptionMeasure";
 
 const app = new Backend("kuzzle");
 
@@ -73,6 +77,10 @@ deviceManager.models.registerAsset(
 );
 
 deviceManager.models.registerMeasure("acceleration", accelerationMeasureDefinition);
+deviceManager.models.registerMeasure("brightness", brightnessMeasureDefinition);
+deviceManager.models.registerMeasure("co2", co2MeasureDefinition);
+deviceManager.models.registerMeasure("illuminance", illuminanceMeasureDefinition);
+deviceManager.models.registerMeasure("powerConsumption", powerConsumptionMeasureDefinition);
 
 registerTestPipes(app);
 

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -5,6 +5,8 @@ import { Backend, KuzzleRequest } from "kuzzle";
 import { DeviceManagerPlugin } from "../../index";
 
 import { containerAssetDefinition } from "./assets/Container";
+import { roomAssetDefinition } from "./assets/Room";
+import { streetLampAssetDefinition } from "./assets/StreetLamp";
 import { warehouseAssetDefinition } from "./assets/Warehouse";
 import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
 import { TestsController } from "./tests/controller";
@@ -26,7 +28,7 @@ deviceManager.config.engineCollections.device.mappings.properties["softTenant"] 
 };
 
 
-deviceManager.models.registerDevice("DummyTempPosition", 
+deviceManager.models.registerDevice("DummyTempPosition",
   {
     decoder: new DummyTempPositionDecoder(),
     metadataMappings: {
@@ -35,8 +37,8 @@ deviceManager.models.registerDevice("DummyTempPosition",
   }
 );
 
-deviceManager.models.registerDevice("DummyTemp", 
-  { 
+deviceManager.models.registerDevice("DummyTemp",
+  {
     decoder: new DummyTempDecoder(),
     metadataMappings: {
       color: { type: "keyword" },
@@ -44,8 +46,7 @@ deviceManager.models.registerDevice("DummyTemp",
   }
 );
 
-// Register an asset for the "commons" group
-
+// Register assets for the "commons" group
 deviceManager.models.registerAsset(
   "commons",
   "Container",
@@ -56,6 +57,19 @@ deviceManager.models.registerAsset(
   "commons",
   "Warehouse",
   warehouseAssetDefinition
+);
+
+// Register assets for specialized groups
+deviceManager.models.registerAsset(
+  "air_quality",
+  "Room",
+  roomAssetDefinition
+);
+
+deviceManager.models.registerAsset(
+  "public_lighting",
+  "StreetLamp",
+  streetLampAssetDefinition
 );
 
 deviceManager.models.registerMeasure("acceleration", accelerationMeasureDefinition);

--- a/tests/application/assets/Room.ts
+++ b/tests/application/assets/Room.ts
@@ -1,0 +1,18 @@
+import { AssetModelDefinition } from "../../../index";
+
+export const roomAssetDefinition: AssetModelDefinition = {
+  measures: [
+    {
+      name: "temperature",
+      type: "temperature",
+    },
+    {
+      name: "humidity",
+      type: "humidity",
+    },
+  ],
+  metadataMappings: {
+    floor: { type: "integer" },
+    width: { type: "integer" },
+  },
+};

--- a/tests/application/assets/Room.ts
+++ b/tests/application/assets/Room.ts
@@ -10,6 +10,14 @@ export const roomAssetDefinition: AssetModelDefinition = {
       name: "humidity",
       type: "humidity",
     },
+    {
+      name: "co2",
+      type: "co2",
+    },
+    {
+      name: "illuminance",
+      type: "illuminance",
+    },
   ],
   metadataMappings: {
     floor: { type: "integer" },

--- a/tests/application/assets/StreetLamp.ts
+++ b/tests/application/assets/StreetLamp.ts
@@ -1,0 +1,13 @@
+import { AssetModelDefinition } from "../../../index";
+
+export const streetLampAssetDefinition: AssetModelDefinition = {
+  measures: [
+    {
+      name: "position",
+      type: "position",
+    },
+  ],
+  metadataMappings: {
+    street: { type: "keyword" },
+  },
+};

--- a/tests/application/assets/StreetLamp.ts
+++ b/tests/application/assets/StreetLamp.ts
@@ -3,11 +3,16 @@ import { AssetModelDefinition } from "../../../index";
 export const streetLampAssetDefinition: AssetModelDefinition = {
   measures: [
     {
-      name: "position",
-      type: "position",
+      name: "brightness",
+      type: "brightness",
+    },
+    {
+      name: "powerConsumption",
+      type: "powerConsumption",
     },
   ],
   metadataMappings: {
+    position: { type: "geo_point" },
     street: { type: "keyword" },
   },
 };

--- a/tests/application/measures/BrightnessMeasure.ts
+++ b/tests/application/measures/BrightnessMeasure.ts
@@ -1,0 +1,5 @@
+import { MeasureDefinition } from "lib/modules/measure";
+
+export const brightnessMeasureDefinition: MeasureDefinition = {
+  valuesMappings: { lumens: { type: "float" } },
+};

--- a/tests/application/measures/CO2Measure.ts
+++ b/tests/application/measures/CO2Measure.ts
@@ -1,0 +1,5 @@
+import { MeasureDefinition } from "lib/modules/measure";
+
+export const co2MeasureDefinition: MeasureDefinition = {
+  valuesMappings: { co2: { type: "float" } },
+};

--- a/tests/application/measures/IlluminanceMeasure.ts
+++ b/tests/application/measures/IlluminanceMeasure.ts
@@ -1,0 +1,5 @@
+import { MeasureDefinition } from "lib/modules/measure";
+
+export const illuminanceMeasureDefinition: MeasureDefinition = {
+  valuesMappings: { illuminance: { type: "float" } },
+};

--- a/tests/application/measures/PowerConsumptionMeasure.ts
+++ b/tests/application/measures/PowerConsumptionMeasure.ts
@@ -1,0 +1,5 @@
+import { MeasureDefinition } from "lib/modules/measure";
+
+export const powerConsumptionMeasureDefinition: MeasureDefinition = {
+  valuesMappings: { watt: { type: "float" } },
+};

--- a/tests/hooks/collections.ts
+++ b/tests/hooks/collections.ts
@@ -11,22 +11,29 @@ export async function truncateCollection(
 
 async function deleteModels(sdk: Kuzzle) {
   await sdk.collection.refresh("device-manager", "models");
-  await sdk.document.deleteByQuery("device-manager", "models", {
-    query: {
-      ids: {
-        values: [
-          "model-measure-presence",
-          "model-asset-plane",
-          "model-asset-AdvancedPlane",
-          "model-device-Zigbee",
-          "model-device-Bluetooth",
-          "model-device-Enginko",
-          "model-asset-TestHouse",
-          "model-asset-AdvancedWarehouse",
-        ],
+  await sdk.document.deleteByQuery(
+    "device-manager",
+    "models",
+    {
+      query: {
+        ids: {
+          values: [
+            "model-measure-presence",
+            "model-asset-Plane",
+            "model-asset-AdvancedPlane",
+            "model-device-Zigbee",
+            "model-device-Bluetooth",
+            "model-device-Enginko",
+            "model-asset-TestHouse",
+            "model-asset-AdvancedWarehouse",
+          ],
+        },
       },
     },
-  });
+    {
+      refresh: "wait_for",
+    },
+  );
 }
 
 export async function beforeEachTruncateCollections(sdk: Kuzzle) {

--- a/tests/scenario/modules/assets/action-export.test.ts
+++ b/tests/scenario/modules/assets/action-export.test.ts
@@ -16,14 +16,16 @@ function getExportedColums(row) {
   return {
     model: parsedRow[0],
     reference: parsedRow[1],
-    position: parsedRow[2],
-    positionAccuracy: parsedRow[3],
-    positionAltitude: parsedRow[4],
-    temperatureExt: parsedRow[5],
-    temperatureInt: parsedRow[6],
-    temperatureWeather: parsedRow[7],
-    lastMeasuredAt: parsedRow[8],
-    lastMeasuredAtISO: parsedRow[9],
+    humidity: parsedRow[2],
+    position: parsedRow[3],
+    positionAccuracy: parsedRow[4],
+    positionAltitude: parsedRow[5],
+    temperature: parsedRow[6],
+    temperatureExt: parsedRow[7],
+    temperatureInt: parsedRow[8],
+    temperatureWeather: parsedRow[9],
+    lastMeasuredAt: parsedRow[10],
+    lastMeasuredAtISO: parsedRow[11],
   };
 }
 
@@ -79,7 +81,7 @@ describe("AssetsController:exportMeasures", () => {
     writeFileSync("./assets.csv", csv.join(""));
 
     expect(csv[0]).toBe(
-      "Model,Reference,position,position.accuracy,position.altitude,temperatureExt,temperatureInt,temperatureWeather,lastMeasuredAt,lastMeasuredAtISO\n",
+      "Model,Reference,humidity,position,position.accuracy,position.altitude,temperature,temperatureExt,temperatureInt,temperatureWeather,lastMeasuredAt,lastMeasuredAtISO\n",
     );
 
     expect(csv).toHaveLength(assetCount + 1);
@@ -88,9 +90,11 @@ describe("AssetsController:exportMeasures", () => {
 
     expect(row1.model).toBe("Container");
     expect(typeof row1.reference).toBe("string");
+    expect(typeof parseFloat(row1.humidity)).toBe("number");
     expect(typeof row1.position).toBe("string");
     expect(typeof parseFloat(row1.positionAccuracy)).toBe("number");
     expect(typeof parseFloat(row1.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row1.temperature)).toBe("number");
     expect(typeof parseFloat(row1.temperatureExt)).toBe("number");
     expect(typeof parseFloat(row1.temperatureInt)).toBe("number");
     expect(typeof parseFloat(row1.temperatureWeather)).toBe("number");
@@ -101,9 +105,11 @@ describe("AssetsController:exportMeasures", () => {
 
     expect(row2.model).toBe("Warehouse");
     expect(typeof row2.reference).toBe("string");
+    expect(typeof parseFloat(row2.humidity)).toBe("number");
     expect(typeof row2.position).toBe("string");
     expect(typeof parseFloat(row2.positionAccuracy)).toBe("number");
     expect(typeof parseFloat(row2.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row2.temperature)).toBe("number");
     expect(typeof parseFloat(row2.temperatureExt)).toBe("number");
     expect(typeof parseFloat(row2.temperatureInt)).toBe("number");
     expect(typeof parseFloat(row2.temperatureWeather)).toBe("number");

--- a/tests/scenario/modules/assets/action-export.test.ts
+++ b/tests/scenario/modules/assets/action-export.test.ts
@@ -16,16 +16,20 @@ function getExportedColums(row) {
   return {
     model: parsedRow[0],
     reference: parsedRow[1],
-    humidity: parsedRow[2],
-    position: parsedRow[3],
-    positionAccuracy: parsedRow[4],
-    positionAltitude: parsedRow[5],
-    temperature: parsedRow[6],
-    temperatureExt: parsedRow[7],
-    temperatureInt: parsedRow[8],
-    temperatureWeather: parsedRow[9],
-    lastMeasuredAt: parsedRow[10],
-    lastMeasuredAtISO: parsedRow[11],
+    brightnessLumens: parsedRow[2],
+    co2: parsedRow[3],
+    humidity: parsedRow[4],
+    illuminance: parsedRow[5],
+    position: parsedRow[6],
+    positionAccuracy: parsedRow[7],
+    positionAltitude: parsedRow[8],
+    powerConsumptionWatt: parsedRow[9],
+    temperature: parsedRow[10],
+    temperatureExt: parsedRow[11],
+    temperatureInt: parsedRow[12],
+    temperatureWeather: parsedRow[13],
+    lastMeasuredAt: parsedRow[14],
+    lastMeasuredAtISO: parsedRow[15],
   };
 }
 
@@ -81,7 +85,7 @@ describe("AssetsController:exportMeasures", () => {
     writeFileSync("./assets.csv", csv.join(""));
 
     expect(csv[0]).toBe(
-      "Model,Reference,humidity,position,position.accuracy,position.altitude,temperature,temperatureExt,temperatureInt,temperatureWeather,lastMeasuredAt,lastMeasuredAtISO\n",
+      "Model,Reference,brightness.lumens,co2,humidity,illuminance,position,position.accuracy,position.altitude,powerConsumption.watt,temperature,temperatureExt,temperatureInt,temperatureWeather,lastMeasuredAt,lastMeasuredAtISO\n",
     );
 
     expect(csv).toHaveLength(assetCount + 1);
@@ -90,10 +94,14 @@ describe("AssetsController:exportMeasures", () => {
 
     expect(row1.model).toBe("Container");
     expect(typeof row1.reference).toBe("string");
+    expect(typeof parseFloat(row1.brightnessLumens)).toBe("number");
+    expect(typeof parseFloat(row1.co2)).toBe("number");
     expect(typeof parseFloat(row1.humidity)).toBe("number");
+    expect(typeof parseFloat(row1.illuminance)).toBe("number");
     expect(typeof row1.position).toBe("string");
     expect(typeof parseFloat(row1.positionAccuracy)).toBe("number");
     expect(typeof parseFloat(row1.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row1.powerConsumptionWatt)).toBe("number");
     expect(typeof parseFloat(row1.temperature)).toBe("number");
     expect(typeof parseFloat(row1.temperatureExt)).toBe("number");
     expect(typeof parseFloat(row1.temperatureInt)).toBe("number");
@@ -105,10 +113,14 @@ describe("AssetsController:exportMeasures", () => {
 
     expect(row2.model).toBe("Warehouse");
     expect(typeof row2.reference).toBe("string");
+    expect(typeof parseFloat(row2.brightnessLumens)).toBe("number");
+    expect(typeof parseFloat(row2.co2)).toBe("number");
     expect(typeof parseFloat(row2.humidity)).toBe("number");
+    expect(typeof parseFloat(row2.illuminance)).toBe("number");
     expect(typeof row2.position).toBe("string");
     expect(typeof parseFloat(row2.positionAccuracy)).toBe("number");
     expect(typeof parseFloat(row2.positionAltitude)).toBe("number");
+    expect(typeof parseFloat(row2.powerConsumptionWatt)).toBe("number");
     expect(typeof parseFloat(row2.temperature)).toBe("number");
     expect(typeof parseFloat(row2.temperatureExt)).toBe("number");
     expect(typeof parseFloat(row2.temperatureInt)).toBe("number");

--- a/tests/scenario/modules/models/asset-model.test.ts
+++ b/tests/scenario/modules/models/asset-model.test.ts
@@ -1,9 +1,9 @@
-import { setupSdK } from "../../../helpers";
+import { setupHooks } from "../../../helpers";
 
 jest.setTimeout(10000);
 
 describe("ModelsController:assets", () => {
-  const sdk = setupSdK();
+  const sdk = setupHooks();
 
   it("Write and List an Asset model", async () => {
     await sdk.query({
@@ -107,6 +107,23 @@ describe("ModelsController:assets", () => {
     await expect(getAssetNotExist).rejects.toMatchObject({ status: 404 });
   });
 
+  it("List asset models only from the requested engine group and the common ones", async () => {
+    const listAssets = await sdk.query({
+      controller: "device-manager/models",
+      action: "listAssets",
+      engineGroup: "air_quality",
+    });
+
+    expect(listAssets.result).toMatchObject({
+      total: 3,
+      models: [
+        { _id: "model-asset-Container" },
+        { _id: "model-asset-Room" },
+        { _id: "model-asset-Warehouse" },
+      ],
+    });
+  });
+
   it("Write and Search an Asset model", async () => {
     await sdk.query({
       controller: "device-manager/models",
@@ -154,6 +171,62 @@ describe("ModelsController:assets", () => {
     expect(searchAssets.result).toMatchObject({
       total: 1,
       hits: [{ _id: "model-asset-Plane" }],
+    });
+  });
+
+  it("Search asset models only from the requested engine group and the common ones", async () => {
+    let searchAssets = await sdk.query({
+      controller: "device-manager/models",
+      action: "searchAssets",
+      engineGroup: "air_quality",
+      body: {
+        query: {
+          match: {
+            "asset.model": "Warehouse",
+          },
+        },
+      },
+    });
+
+    expect(searchAssets.result).toMatchObject({
+      total: 1,
+      hits: [{ _id: "model-asset-Warehouse" }],
+    });
+
+    searchAssets = await sdk.query({
+      controller: "device-manager/models",
+      action: "searchAssets",
+      engineGroup: "air_quality",
+      body: {
+        query: {
+          match: {
+            "asset.model": "Room",
+          },
+        },
+      },
+    });
+
+    expect(searchAssets.result).toMatchObject({
+      total: 1,
+      hits: [{ _id: "model-asset-Room" }],
+    });
+
+    searchAssets = await sdk.query({
+      controller: "device-manager/models",
+      action: "searchAssets",
+      engineGroup: "air_quality",
+      body: {
+        query: {
+          match: {
+            "asset.model": "StreetLamp",
+          },
+        },
+      },
+    });
+
+    expect(searchAssets.result).toMatchObject({
+      total: 0,
+      hits: [],
     });
   });
 
@@ -211,33 +284,6 @@ describe("ModelsController:assets", () => {
         metadataMappings: { surface: { type: "integer" } },
         measures: [{ name: "position", type: "position" }],
       },
-    });
-  });
-
-  it("List on an engine is also returning commons assets models", async () => {
-    await sdk.query({
-      controller: "device-manager/models",
-      action: "writeAsset",
-      body: {
-        engineGroup: "other-group",
-        model: "Car",
-      },
-    });
-
-    const listAssets = await sdk.query({
-      controller: "device-manager/models",
-      action: "listAssets",
-      engineGroup: "other-group",
-    });
-
-    expect(listAssets.result).toMatchObject({
-      total: 4,
-      models: [
-        { _id: "model-asset-Car" },
-        { _id: "model-asset-Container" },
-        { _id: "model-asset-Plane" },
-        { _id: "model-asset-Warehouse" },
-      ],
     });
   });
 

--- a/tests/scenario/modules/models/measures-model.test.ts
+++ b/tests/scenario/modules/models/measures-model.test.ts
@@ -87,10 +87,14 @@ describe("ModelsController:measures", () => {
           accuracy: { type: "float" },
           altitude: { type: "float" },
           battery: { type: "integer" },
+          co2: { type: "float" },
           humidity: { type: "float" },
+          illuminance: { type: "float" },
+          lumens: { type: "float" },
           movement: { type: "boolean" },
           position: { type: "geo_point" },
           temperature: { type: "float" },
+          watt: { type: "float" },
         },
       },
     });
@@ -161,13 +165,17 @@ describe("ModelsController:measures", () => {
       action: "listMeasures",
     });
 
-    expect(listMeasures.result.total).toBe(7);
+    expect(listMeasures.result.total).toBe(11);
     expect(listMeasures.result.models).toMatchObject([
       { _id: "model-measure-acceleration" },
       { _id: "model-measure-battery" },
+      { _id: "model-measure-brightness" },
+      { _id: "model-measure-co2" },
       { _id: "model-measure-humidity" },
+      { _id: "model-measure-illuminance" },
       { _id: "model-measure-movement" },
       { _id: "model-measure-position" },
+      { _id: "model-measure-powerConsumption" },
       { _id: "model-measure-presence" },
       { _id: "model-measure-temperature" },
     ]);


### PR DESCRIPTION
## What does this PR do ?

This fixes a regression introduced in #362 on the `listAssets` (and by extension, `searchAssets`) actions of the `device-manager/models` controller that wasn't correctly taking into account the requested engine group and was returning the models for every group instead.

The problematic Elasticsearch query has been fixed.

## Other changes

Two new asset models, `Room` and `StreetLamp`, were added in the test application, respectively to the `air_quality` and `public_lighting` engine groups.

Tests were added to avoid this regression in the future.

## Boyscout

To avoid an inconsistent list of asset models, the asset models are now reset before each test of the `asset-model.test.ts` file.