### PR TITLE
feat: embed measure slots in asset and device documents

### DIFF
--- a/doc/2/controllers/models/update-asset/index.md
+++ b/doc/2/controllers/models/update-asset/index.md
@@ -22,7 +22,7 @@ Method: PUT
 
 ```js
 {
-  "controller": "device-manager/assets",
+  "controller": "device-manager/models",
   "action": "updateAsset",
   "engineGroup": "<engine group>",
   "model": "<asset model>",

--- a/doc/2/controllers/models/write-asset/index.md
+++ b/doc/2/controllers/models/write-asset/index.md
@@ -24,7 +24,7 @@ Method: POST
 
 ```js
 {
-  "controller": "device-manager/assets",
+  "controller": "device-manager/models",
   "action": "writeAsset",
   "body": {
     "engineGroup": "<engine group>",
@@ -164,4 +164,3 @@ Method: POST
 | ------------------------------------------------------------------------------ | ------- | --------------------------------------------------- |
 | [ MappingsConflictsError ](../../../errors/mappings-conflicts/index.md)        | **409** | Writing an asset with conflicting metadata mappings |
 | [ MeasuresNamesDuplicatesError ](../../../errors/measures-duplicates/index.md) | **400** | Defining a measure name more than once              |
-

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -646,6 +646,8 @@ export class AssetService extends DigitalTwinService {
             ...assetMetadata,
           };
 
+          asset._source.measureSlots = assetModel.asset.measures;
+
           acc[asset.index].push(asset as KDocument<AssetContent>);
 
           return acc;

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -298,6 +298,7 @@ export class AssetService extends DigitalTwinService {
             groups: [],
             lastMeasuredAt: null,
             linkedDevices: [],
+            measureSlots: assetModel.asset.measures,
             measures,
             metadata: { ...assetMetadata, ...metadata },
             model,

--- a/lib/modules/asset/collections/assetsMappings.ts
+++ b/lib/modules/asset/collections/assetsMappings.ts
@@ -52,5 +52,12 @@ export const assetsMappings: CollectionMappings = {
         },
       },
     },
+
+    measureSlots: {
+      properties: {
+        name: { type: "keyword" },
+        type: { type: "keyword" },
+      },
+    },
   },
 };

--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { DeviceContent, DeviceSerializer } from "../device";
 import { AskMeasureIngest, DecodedMeasurement } from "../measure";
+import { AskModelDeviceGet } from "../model";
 import { DeviceManagerPlugin, InternalCollection } from "../plugin";
 import { BaseService } from "../shared";
 
@@ -218,6 +219,13 @@ export class PayloadService extends BaseService {
     deviceIds: string[],
     { refresh }: { refresh: any },
   ): Promise<KDocument<DeviceContent>[]> {
+    const deviceModelContent = await ask<AskModelDeviceGet>(
+      "ask:device-manager:model:device:get",
+      {
+        model: deviceModel,
+      },
+    );
+
     const newDevices = deviceIds.map((deviceId) => {
       // Reference may contains a "-"
       const [, ...rest] = deviceId.split("-");
@@ -227,6 +235,7 @@ export class PayloadService extends BaseService {
         assetId: null,
         engineId: null,
         lastMeasuredAt: 0,
+        measureSlots: deviceModelContent.device.measures,
         measures: {},
         metadata: {},
         model: deviceModel,

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -1,6 +1,13 @@
 import { BadRequestError, KuzzleRequest } from "kuzzle";
 import { ask, onAsk } from "kuzzle-plugin-commons";
-import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
+import {
+  BaseRequest,
+  DocumentSearchResult,
+  JSONObject,
+  KDocument,
+  KHit,
+  SearchResult,
+} from "kuzzle-sdk";
 
 import { DecodedMeasurement } from "../measure";
 import {
@@ -9,7 +16,11 @@ import {
   AssetModelContent,
   DeviceModelContent,
 } from "../model";
-import { DeviceManagerPlugin, InternalCollection } from "../plugin";
+import {
+  AskEngineList,
+  DeviceManagerPlugin,
+  InternalCollection,
+} from "../plugin";
 import { DigitalTwinService, Metadata, SearchParams, lock } from "../shared";
 import {
   AskAssetHistoryAdd,
@@ -26,6 +37,7 @@ import {
   AskDeviceAttachEngine,
   AskDeviceDetachEngine,
   AskDeviceLinkAsset,
+  AskDeviceRefreshModel,
   AskDeviceUnlinkAsset,
   EventDeviceUpdateAfter,
   EventDeviceUpdateBefore,
@@ -79,6 +91,11 @@ export class DeviceService extends DigitalTwinService {
         const request = new KuzzleRequest({ refresh: "false" }, { user });
         await this.attachEngine(engineId, deviceId, request);
       },
+    );
+
+    onAsk<AskDeviceRefreshModel>(
+      "ask:device-manager:device:refresh-model",
+      this.refreshModel.bind(this),
     );
   }
 
@@ -935,5 +952,65 @@ export class DeviceService extends DigitalTwinService {
       engineGroup,
       model,
     });
+  }
+
+  private async refreshModel({
+    deviceModel,
+  }: {
+    deviceModel: DeviceModelContent;
+  }): Promise<void> {
+    const engines = await ask<AskEngineList>("ask:device-manager:engine:list", {
+      group: null,
+    });
+
+    const targets = engines.map((engine) => ({
+      collections: [InternalCollection.DEVICES],
+      index: engine.index,
+    }));
+
+    const devices = await this.sdk.query<
+      BaseRequest,
+      DocumentSearchResult<DeviceContent>
+    >({
+      action: "search",
+      body: { query: { equals: { model: deviceModel.device.model } } },
+      controller: "document",
+      lang: "koncorde",
+      targets,
+    });
+
+    const updatedDevicesPerIndex: Record<string, KDocument<DeviceContent>[]> =
+      devices.result.hits.reduce(
+        (
+          acc: Record<string, KDocument<DeviceContent>[]>,
+          device: JSONObject,
+        ) => {
+          device._source.measureSlots = deviceModel.device.measures;
+
+          acc[device.index].push(device as KDocument<DeviceContent>);
+
+          return acc;
+        },
+        Object.fromEntries(
+          engines.map((engine) => [
+            engine.index,
+            [] as KDocument<DeviceContent>[],
+          ]),
+        ),
+      );
+
+    await Promise.all(
+      Object.entries(updatedDevicesPerIndex).map(([index, updatedDevices]) =>
+        this.sdk.document.mReplace<DeviceContent>(
+          index,
+          InternalCollection.DEVICES,
+          updatedDevices.map((device) => ({
+            _id: device._id,
+            body: device._source,
+          })),
+          { refresh: "wait_for" },
+        ),
+      ),
+    );
   }
 }

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -101,6 +101,7 @@ export class DeviceService extends DigitalTwinService {
         assetId: null,
         engineId: null,
         lastMeasuredAt: 0,
+        measureSlots: [],
         measures: {},
         metadata,
         model,
@@ -111,6 +112,8 @@ export class DeviceService extends DigitalTwinService {
     return lock(`device:create:${device._id}`, async () => {
       const deviceModel = await this.getDeviceModel(model);
       const engineId = request.getString("engineId");
+
+      device._source.measureSlots = deviceModel.device.measures;
 
       for (const metadataName of Object.keys(
         deviceModel.device.metadataMappings,

--- a/lib/modules/device/collections/deviceMappings.ts
+++ b/lib/modules/device/collections/deviceMappings.ts
@@ -35,5 +35,11 @@ export const devicesMappings: CollectionMappings = {
       },
     },
     lastMeasuredAt: { type: "date" },
+    measureSlots: {
+      properties: {
+        name: { type: "keyword" },
+        type: { type: "keyword" },
+      },
+    },
   },
 };

--- a/lib/modules/device/types/DeviceEvents.ts
+++ b/lib/modules/device/types/DeviceEvents.ts
@@ -1,6 +1,7 @@
 import { User } from "kuzzle";
 import { KDocument } from "kuzzle-sdk";
 
+import { DeviceModelContent } from "../../../modules/model";
 import { Metadata } from "../../../modules/shared";
 
 import { DeviceContent } from "./DeviceContent";
@@ -64,6 +65,16 @@ export type AskDeviceAttachEngine = {
     engineId: string;
     deviceId: string;
     user: User;
+  };
+
+  result: void;
+};
+
+export type AskDeviceRefreshModel = {
+  name: "ask:device-manager:device:refresh-model";
+
+  payload: {
+    deviceModel: DeviceModelContent;
   };
 
   result: void;

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -44,6 +44,7 @@ import { MeasureValuesDetails } from "../measure";
 import { NamedMeasures } from "../decoder";
 import { getNamedMeasuresDuplicates } from "./MeasuresDuplicates";
 import { MeasuresNamesDuplicatesError } from "./MeasuresNamesDuplicatesError";
+import { AskDeviceRefreshModel } from "../device";
 
 export class ModelService extends BaseService {
   constructor(plugin: DeviceManagerPlugin) {
@@ -360,6 +361,13 @@ export class ModelService extends BaseService {
       InternalCollection.MODELS,
     );
     await ask<AskEngineUpdateAll>("ask:device-manager:engine:updateAll");
+
+    await ask<AskDeviceRefreshModel>(
+      "ask:device-manager:device:refresh-model",
+      {
+        deviceModel: modelContent,
+      },
+    );
 
     return deviceModel;
   }
@@ -746,15 +754,21 @@ export class ModelService extends BaseService {
       { source: true },
     );
 
-    await this.sdk.collection.refresh(
-      this.config.adminIndex,
-      InternalCollection.MODELS,
-    );
-    await ask<AskEngineUpdateAll>("ask:device-manager:engine:updateAll");
+    // ? Only update engines and refresh asset models when necessary
+    if (Object.keys(metadataMappings).length > 0 || measures.length > 0) {
+      await this.sdk.collection.refresh(
+        this.config.adminIndex,
+        InternalCollection.MODELS,
+      );
 
-    await ask<AskAssetRefreshModel>("ask:device-manager:asset:refresh-model", {
-      assetModel: assetModelContent,
-    });
+      await ask<AskEngineUpdateAll>("ask:device-manager:engine:updateAll");
+      await ask<AskAssetRefreshModel>(
+        "ask:device-manager:asset:refresh-model",
+        {
+          assetModel: endDocument._source,
+        },
+      );
+    }
 
     return endDocument;
   }

--- a/lib/modules/shared/types/DigitalTwinContent.ts
+++ b/lib/modules/shared/types/DigitalTwinContent.ts
@@ -1,5 +1,6 @@
 import { JSONObject, KDocumentContent } from "kuzzle-sdk";
 
+import { NamedMeasures } from "../../decoder";
 import { Metadata } from "./Metadata";
 import { DigitalTwinMeasures } from "./DigitalTwinMeasures";
 
@@ -16,4 +17,6 @@ export interface DigitalTwinContent<
   measures: DigitalTwinMeasures<TMeasures>;
 
   lastMeasuredAt: number;
+
+  measureSlots: NamedMeasures;
 }

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -4,10 +4,7 @@ import { Backend, KuzzleRequest } from "kuzzle";
 
 import { DeviceManagerPlugin } from "../../index";
 
-import { containerAssetDefinition } from "./assets/Container";
-import { roomAssetDefinition } from "./assets/Room";
-import { streetLampAssetDefinition } from "./assets/StreetLamp";
-import { warehouseAssetDefinition } from "./assets/Warehouse";
+import { containerAssetDefinition, roomAssetDefinition, streetLampAssetDefinition, warehouseAssetDefinition } from "./assets";
 import { DummyTempDecoder, DummyTempPositionDecoder } from "./decoders";
 import { TestsController } from "./tests/controller";
 import { registerTestPipes } from "./tests/pipes";

--- a/tests/application/assets/Container.ts
+++ b/tests/application/assets/Container.ts
@@ -180,6 +180,7 @@ function neverCalled() {
     linkedDevices: [],
     groups: [],
     reference: "",
+    measureSlots: containerAssetDefinition.measures,
     metadata: undefined,
     measures,
     lastMeasuredAt: 0

--- a/tests/application/assets/index.ts
+++ b/tests/application/assets/index.ts
@@ -1,0 +1,4 @@
+export * from "./Container";
+export * from "./Room";
+export * from "./StreetLamp";
+export * from "./Warehouse";

--- a/tests/application/decoders/DummyTempDecoder.ts
+++ b/tests/application/decoders/DummyTempDecoder.ts
@@ -10,12 +10,14 @@ import {
 import { AccelerationMeasurement } from "../measures/AccelerationMeasure";
 import { isMeasureDated } from "../../helpers/payloads";
 
+export const dummyTempDeviceMeasures = [
+  { name: "temperature", type: "temperature" },
+  { name: "accelerationSensor", type: "acceleration" },
+  { name: "battery", type: "battery" },
+] as const;
+
 export class DummyTempDecoder extends Decoder {
-  public measures = [
-    { name: "temperature", type: "temperature" },
-    { name: "accelerationSensor", type: "acceleration" },
-    { name: "battery", type: "battery" },
-  ] as const;
+  public measures = dummyTempDeviceMeasures;
 
   constructor() {
     super();

--- a/tests/application/decoders/DummyTempPositionDecoder.ts
+++ b/tests/application/decoders/DummyTempPositionDecoder.ts
@@ -10,12 +10,14 @@ import {
 } from "../../../index";
 import { isMeasureDated } from "../../helpers/payloads";
 
+export const dummyTempPositionDeviceMeasures = [
+  { name: "temperature", type: "temperature" },
+  { name: "battery", type: "battery" },
+  { name: "position", type: "position" },
+] as const;
+
 export class DummyTempPositionDecoder extends Decoder {
-  public measures = [
-    { name: "temperature", type: "temperature" },
-    { name: "battery", type: "battery" },
-    { name: "position", type: "position" },
-  ] as const;
+  public measures = dummyTempPositionDeviceMeasures;
 
   constructor() {
     super();

--- a/tests/fixtures/fixtures.ts
+++ b/tests/fixtures/fixtures.ts
@@ -1,8 +1,18 @@
+import {
+  containerAssetDefinition,
+  warehouseAssetDefinition,
+} from "../application/assets";
+import {
+  dummyTempDeviceMeasures,
+  dummyTempPositionDeviceMeasures,
+} from "../application/decoders";
+
 import { assetGroupFixtures } from "./assetsGroups";
 
 const deviceDetached1 = {
   model: "DummyTemp",
   reference: "detached1",
+  measureSlots: dummyTempDeviceMeasures,
   metadata: {},
   measures: {},
 };
@@ -11,6 +21,7 @@ const deviceDetached1Id = `${deviceDetached1.model}-${deviceDetached1.reference}
 const deviceAyseLinked1 = {
   model: "DummyTemp",
   reference: "linked1",
+  measureSlots: dummyTempDeviceMeasures,
   metadata: {},
   measures: {},
   engineId: "engine-ayse",
@@ -21,6 +32,7 @@ const deviceAyseLinked1Id = `${deviceAyseLinked1.model}-${deviceAyseLinked1.refe
 const deviceAyseLinked2 = {
   model: "DummyTempPosition",
   reference: "linked2",
+  measureSlots: dummyTempPositionDeviceMeasures,
   metadata: {},
   measures: {},
   engineId: "engine-ayse",
@@ -31,6 +43,7 @@ const deviceAyseLinked2Id = `${deviceAyseLinked2.model}-${deviceAyseLinked2.refe
 const deviceAyseUnlinked1 = {
   model: "DummyTemp",
   reference: "unlinked1",
+  measureSlots: dummyTempDeviceMeasures,
   metadata: {},
   measures: {},
   engineId: "engine-ayse",
@@ -41,6 +54,7 @@ const deviceAyseUnlinked1Id = `${deviceAyseUnlinked1.model}-${deviceAyseUnlinked
 const deviceAyseUnlinked2 = {
   model: "DummyTemp",
   reference: "unlinked2",
+  measureSlots: dummyTempDeviceMeasures,
   metadata: {},
   measures: {},
   engineId: "engine-ayse",
@@ -51,6 +65,7 @@ const deviceAyseUnlinked2Id = `${deviceAyseUnlinked2.model}-${deviceAyseUnlinked
 const deviceAyseUnlinked3 = {
   model: "DummyTempPosition",
   reference: "unlinked3",
+  measureSlots: dummyTempPositionDeviceMeasures,
   metadata: {},
   measures: {},
   engineId: "engine-ayse",
@@ -61,6 +76,7 @@ const deviceAyseUnlinked3Id = `${deviceAyseUnlinked3.model}-${deviceAyseUnlinked
 const deviceAyseWarehouse = {
   model: "DummyTempPosition",
   reference: "warehouse",
+  measureSlots: dummyTempPositionDeviceMeasures,
   metadata: {},
   measures: {},
   engineId: "engine-ayse",
@@ -71,6 +87,7 @@ const deviceAyseWarehouseId = `${deviceAyseWarehouse.model}-${deviceAyseWarehous
 const assetAyseWarehouseLinked = {
   model: "Warehouse",
   reference: "linked",
+  measureSlots: warehouseAssetDefinition.measures,
   metadata: {
     surface: 512,
   },
@@ -86,6 +103,7 @@ const assetAyseWarehouseLinkedId = `${assetAyseWarehouseLinked.model}-${assetAys
 const assetAyseLinked1 = {
   model: "Container",
   reference: "linked1",
+  measureSlots: containerAssetDefinition.measures,
   metadata: {
     weight: 10,
     height: 11,
@@ -106,6 +124,7 @@ const assetAyseLinked1Id = `${assetAyseLinked1.model}-${assetAyseLinked1.referen
 const assetAyseLinked2 = {
   model: "Container",
   reference: "linked2",
+  measureSlots: containerAssetDefinition.measures,
   metadata: {
     weight: 42,
     height: 21,
@@ -125,6 +144,7 @@ const assetAyseLinked2Id = `${assetAyseLinked2.model}-${assetAyseLinked2.referen
 const assetAyseUnlinked = {
   model: "Container",
   reference: "unlinked1",
+  measureSlots: containerAssetDefinition.measures,
   metadata: {
     weight: 20,
     height: 22,
@@ -136,6 +156,7 @@ const assetAyseUnlinkedId = `${assetAyseUnlinked.model}-${assetAyseUnlinked.refe
 const assetAyseGrouped = {
   model: "Container",
   reference: "grouped",
+  measureSlots: containerAssetDefinition.measures,
   metadata: {
     weight: 20,
     height: 22,
@@ -157,6 +178,7 @@ const assetAyseGroupedId = `${assetAyseGrouped.model}-${assetAyseGrouped.referen
 const assetAyseGrouped2 = {
   model: "Container",
   reference: "grouped2",
+  measureSlots: containerAssetDefinition.measures,
   metadata: {
     weight: 20,
     height: 22,

--- a/tests/scenario/migrated/asset-controller.test.ts
+++ b/tests/scenario/migrated/asset-controller.test.ts
@@ -39,6 +39,24 @@ describe("features/Asset/Controller", () => {
     ).resolves.toMatchObject({
       _source: {
         metadata: { height: 5, weight: null },
+        measureSlots: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+          {
+            name: "temperatureInt",
+            type: "temperature",
+          },
+          {
+            name: "position",
+            type: "position",
+          },
+          {
+            name: "temperatureWeather",
+            type: "temperature",
+          },
+        ],
         measures: {
           temperatureExt: null,
           temperatureInt: null,

--- a/tests/scenario/modules/devices/action-scrud.test.ts
+++ b/tests/scenario/modules/devices/action-scrud.test.ts
@@ -57,6 +57,20 @@ describe("Device SCRUD", () => {
       metadata: {
         color: "RED",
       },
+      measureSlots: [
+        {
+          name: "temperature",
+          type: "temperature",
+        },
+        {
+          name: "accelerationSensor",
+          type: "acceleration",
+        },
+        {
+          name: "battery",
+          type: "battery",
+        },
+      ],
       _kuzzle_info: {
         author: "-1",
         updater: "-1",

--- a/tests/scenario/modules/models/asset-model-measure-slots-propagation.test.ts
+++ b/tests/scenario/modules/models/asset-model-measure-slots-propagation.test.ts
@@ -1,0 +1,166 @@
+import {
+  ApiAssetCreateRequest,
+  ApiAssetCreateResult,
+} from "../../../../lib/modules/asset";
+import {
+  ApiModelUpdateAssetRequest,
+  ApiModelUpdateAssetResult,
+  ApiModelWriteAssetRequest,
+  ApiModelWriteAssetResult,
+} from "../../../../lib/modules/model";
+import { setupHooks } from "../../../helpers";
+
+jest.setTimeout(10000);
+
+describe("Asset model measure slots propagation", () => {
+  const sdk = setupHooks();
+
+  it("should update the embedded measure slots of existing assets with writeAsset", async () => {
+    await sdk.query<ApiModelWriteAssetRequest, ApiModelWriteAssetResult>({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroup: "commons",
+        model: "Plane",
+        metadataMappings: { size: { type: "integer" } },
+        measures: [{ name: "temperatureExt", type: "temperature" }],
+      },
+    });
+
+    const { result } = await sdk.query<
+      ApiAssetCreateRequest,
+      ApiAssetCreateResult
+    >({
+      controller: "device-manager/assets",
+      action: "create",
+      engineId: "engine-kuzzle",
+      body: {
+        model: "Plane",
+        reference: "Technoplane",
+        metadata: { size: 8311 },
+      },
+    });
+
+    expect(result).toMatchObject({
+      _source: {
+        measureSlots: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+
+    await sdk.query<ApiModelWriteAssetRequest, ApiModelWriteAssetResult>({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroup: "commons",
+        model: "Plane",
+        metadataMappings: { size: { type: "integer" } },
+        measures: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+          {
+            name: "temperatureInt",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      sdk.document.get("engine-kuzzle", "assets", "Plane-Technoplane"),
+    ).resolves.toMatchObject({
+      _source: {
+        measureSlots: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+          {
+            name: "temperatureInt",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+  });
+
+  it("should update the embedded measure slots of existing assets with updateAsset", async () => {
+    await sdk.query<ApiModelWriteAssetRequest, ApiModelWriteAssetResult>({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroup: "commons",
+        model: "Plane",
+        metadataMappings: { size: { type: "integer" } },
+        measures: [{ name: "temperatureExt", type: "temperature" }],
+      },
+    });
+
+    const { result } = await sdk.query<
+      ApiAssetCreateRequest,
+      ApiAssetCreateResult
+    >({
+      controller: "device-manager/assets",
+      action: "create",
+      engineId: "engine-kuzzle",
+      body: {
+        model: "Plane",
+        reference: "Technoplane",
+        metadata: { size: 8311 },
+      },
+    });
+
+    expect(result).toMatchObject({
+      _source: {
+        measureSlots: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+
+    await sdk.query<ApiModelUpdateAssetRequest, ApiModelUpdateAssetResult>({
+      controller: "device-manager/models",
+      action: "updateAsset",
+      engineGroup: "commons",
+      model: "Plane",
+      body: {
+        measures: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+          {
+            name: "temperatureInt",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      sdk.document.get("engine-kuzzle", "assets", "Plane-Technoplane"),
+    ).resolves.toMatchObject({
+      _source: {
+        measureSlots: [
+          {
+            name: "temperatureExt",
+            type: "temperature",
+          },
+          {
+            name: "temperatureInt",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+  });
+});

--- a/tests/scenario/modules/models/asset-model.test.ts
+++ b/tests/scenario/modules/models/asset-model.test.ts
@@ -385,11 +385,6 @@ describe("ModelsController:assets", () => {
       engineGroup: "commons",
       model: "AdvancedWarehouse",
       body: {
-        metadataMappings: {
-          location: { type: "geo_point" },
-          floor: { type: "integer" },
-        },
-        measures: [{ name: "temperatureInt", type: "temperature" }],
         tooltipModels: updatedTooltipModels,
       },
     });

--- a/tests/scenario/modules/models/device-model-measure-slots-propagation.test.ts
+++ b/tests/scenario/modules/models/device-model-measure-slots-propagation.test.ts
@@ -1,0 +1,88 @@
+import {
+  ApiDeviceCreateRequest,
+  ApiDeviceCreateResult,
+} from "../../../../lib/modules/device";
+import {
+  ApiModelWriteDeviceRequest,
+  ApiModelWriteDeviceResult,
+} from "../../../../lib/modules/model";
+import { setupHooks } from "../../../helpers";
+
+jest.setTimeout(10000);
+
+describe("Device model measure slots propagation", () => {
+  const sdk = setupHooks();
+
+  it("should update the embedded measure slots of existing devices with writeDevice", async () => {
+    await sdk.query<ApiModelWriteDeviceRequest, ApiModelWriteDeviceResult>({
+      controller: "device-manager/models",
+      action: "writeDevice",
+      body: {
+        model: "Zigbee",
+        measures: [{ type: "battery", name: "battery" }],
+        metadataMappings: { network: { type: "keyword" } },
+      },
+    });
+
+    const { result } = await sdk.query<
+      ApiDeviceCreateRequest,
+      ApiDeviceCreateResult
+    >({
+      controller: "device-manager/devices",
+      action: "create",
+      engineId: "engine-kuzzle",
+      body: {
+        model: "Zigbee",
+        reference: "MAYA1",
+        metadata: { network: "yes" },
+      },
+    });
+
+    expect(result).toMatchObject({
+      _source: {
+        measureSlots: [
+          {
+            name: "battery",
+            type: "battery",
+          },
+        ],
+      },
+    });
+
+    await sdk.query<ApiModelWriteDeviceRequest, ApiModelWriteDeviceResult>({
+      controller: "device-manager/models",
+      action: "writeDevice",
+      body: {
+        model: "Zigbee",
+        metadataMappings: { network: { type: "keyword" } },
+        measures: [
+          {
+            name: "battery",
+            type: "battery",
+          },
+          {
+            name: "temperature",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      sdk.document.get("engine-kuzzle", "devices", "Zigbee-MAYA1"),
+    ).resolves.toMatchObject({
+      _source: {
+        measureSlots: [
+          {
+            name: "battery",
+            type: "battery",
+          },
+          {
+            name: "temperature",
+            type: "temperature",
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do ?

This adds a new field to the documents in the `assets` and `devices` collections, `measureSlots`, which is populated with the name and type of the measures from the asset/device model.

This field is automatically updated when the measures of an asset/device model is updated, for each asset/device of that model provisioned in the platform.

> [!IMPORTANT]  
> Existing assets and devices will _not_ automatically be updated with this new field.
> 
> The following script can be used to create this field manually in all existing assets and devices of all engines using [`kourou sdk:execute`](https://github.com/kuzzleio/kourou?tab=readme-ov-file#kourou-sdkexecute-code):
> <details><summary>Migration script</summary>
> 
> ```javascript
> // Change me if necessary
> const adminIndex = 'device-manager';
> 
> console.log('Fetching engine list...');
> const { result: { engines } } = await sdk.query({
>   controller: 'device-manager/engine',
>   action: 'list',
> });
> console.log(`Got ${engines.length} engines`);
> 
> const deviceModels = [];
> console.log('Fetching device models...');
> let result = await sdk.document.search(
>   adminIndex,
>   'models',
>   {
>     query: {
>       term: {
>         type: 'device'
>       }
>     }
>   },
>   { scroll: '10s' }
> );
> 
> while (result) {
>   deviceModels.push(...result.hits.map(v => v._source));
>   result = await result.next();
> }
> 
> console.log(`Got ${deviceModels.length} device models`);
> 
> const assetModels = [];
> console.log('Fetching asset models...');
> result = await sdk.document.search(
>   adminIndex,
>   'models',
>   {
>     query: {
>       term: {
>         type: 'asset'
>       }
>     }
>   },
>   { scroll: '10s' }
> );
> 
> while (result) {
>   assetModels.push(...result.hits.map(v => v._source));
>   result = await result.next();
> }
> 
> const assetModelsPerGroup = assetModels.reduce((acc, v) => {
>   return {
>     ...acc,
>     [v.engineGroup]: [
>       ...(acc[v.engineGroup] ?? []),
>       v,
>     ],
>   };
> }, {});
> 
> console.log(`Got ${assetModels.length} asset models`);
> 
> for (const engine of engines) {
>   const index = engine.index;
>   console.log(`Migrating index "${index}"...`);
> 
>   result = await sdk.document.search(
>     index,
>     'assets',
>     {
>       _source: ['model'],
>       query: {
>         bool: {
>           must_not: {
>             exists: {
>               field: 'measureSlots',
>             },
>           },
>         }
>       }
>     },
>     { scroll: '10s' }
>   );
> 
>   while (result) {
>     const documents = [];
>     for (const hit of result.hits) {
>       let assetModel = assetModelsPerGroup[engine.group].find(v => v.asset.model === hit._source.model);
> 
>       if (assetModel === undefined) {
>         assetModel = assetModels.find(v => v.asset.model === hit._source.model);
> 
>         if (assetModel === undefined) {
>           console.error(`In index "${index}" for asset "${hit._id}": unable to find the model (engine group: "${engine.group}"; model: "${hit._source.model}")`);
>           continue;
>         }
> 
>         console.warn(`In index "${index}" for asset "${hit._id}": using a model not from the same engine group (tenant engine group: "${engine.group}"; model: "${hit._source.model}"; model engine group: "${assetModel.engineGroup}")`);
>       }
> 
>       documents.push({
>         _id: hit._id,
>         body: {
>           measureSlots: assetModel.asset.measures,
>         },
>       });
>     }
> 
>     console.log(`Updating ${documents.length} assets`);
>     await sdk.document.mUpdate(
>       index,
>       'assets',
>       documents,
>       {
>         retryOnConflict: 10,
>         silent: true,
>       },
>     );
> 
>     result = await result.next();
>   }
> 
>   result = await sdk.document.search(
>     index,
>     'devices',
>     {
>       _source: ['model'],
>       query: {
>         bool: {
>           must_not: {
>             exists: {
>               field: 'measureSlots',
>             },
>           },
>         }
>       }
>     },
>     { scroll: '10s' }
>   );
> 
>   while (result) {
>     const documents = [];
>     for (const hit of result.hits) {
>       let deviceModel = deviceModels.find(v => v.device.model === hit._source.model);
> 
>       if (deviceModel === undefined) {
>         console.error(`In index "${index}" for device "${hit._id}": unable to find the model (engine group: "${engine.group}"; model: "${hit._source.model}")`);
>         continue;
>       }
> 
>       documents.push({
>         _id: hit._id,
>         body: {
>           measureSlots: deviceModel.device.measures,
>         },
>       });
>     }
> 
>     console.log(`Updating ${documents.length} devices`);
>     await sdk.document.mUpdate(
>       index,
>       'devices',
>       documents,
>       {
>         retryOnConflict: 10,
>         silent: true,
>       },
>     );
> 
>     result = await result.next();
>   }
> }
> ``` 
> 
> </details> 

### Other changes

A new ask, `ask:device-manager:device:refresh-model`, has been added, that updates the embedded measure slots in each provisioned device with the one found in the requested model (akin to the already-existing `ask:device-manager:asset:refresh-model` ask).

### Boyscout

The `device-manager/models:updateAsset` action has been updated to update all engines and refresh all assets of the updated model if necessary.

The docs were updated to fix the controller names in the `controllers/models/update-asset/` and `controllers/models/write-asset/` pages.

Part of [KZLPRD-438](https://kuzzle.atlassian.net/browse/KZLPRD-438).

[KZLPRD-438]: https://kuzzle.atlassian.net/browse/KZLPRD-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ