### PR TITLE
fix/check-default-values-for-asset-models

### DIFF
--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -256,9 +256,14 @@ export class ModelService extends BaseService {
     const values = Object.keys(flattenObject(defaultMetadata));
 
     for (let i = 0; i < values.length; i++) {
-      if (!metadata.includes(values[i])) {
+      const key = values[i];
+
+      // ? Extract base key for complex types like geo_point
+      const baseKey = key.includes(".") ? key.split(".")[0] : key;
+
+      if (!metadata.includes(baseKey)) {
         throw new BadRequestError(
-          `The default value "${values[i]}" is not in the metadata mappings.`,
+          `The default value "${key}" is not in the metadata mappings.`,
         );
       }
     }

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -710,6 +710,16 @@ export class ModelService extends BaseService {
       { source: true },
     );
 
+    await this.sdk.collection.refresh(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+    );
+    await ask<AskEngineUpdateAll>("ask:device-manager:engine:updateAll");
+
+    await ask<AskAssetRefreshModel>("ask:device-manager:asset:refresh-model", {
+      assetModel: assetModelContent,
+    });
+
     return endDocument;
   }
 }

--- a/tests/hooks/collections.ts
+++ b/tests/hooks/collections.ts
@@ -21,6 +21,8 @@ async function deleteModels(sdk: Kuzzle) {
             "model-measure-presence",
             "model-asset-Plane",
             "model-asset-AdvancedPlane",
+            "model-asset-Vehicle",
+            "model-asset-CompanyAssetInvalid",
             "model-device-Zigbee",
             "model-device-Bluetooth",
             "model-device-Enginko",


### PR DESCRIPTION
## What does this PR do ?

Updated `checkDefaultValues` function to correctly handle validation of `geo_point` and `geo_shape` types in metadataMappings. Ensures nested properties for non-nested types like `keyword` are not allowed, enhancing the robustness of metadata default values validation.

