### PR TITLE
fix(device-metadata): fetch device's metadata from assigned tenant when available

### DIFF
--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -175,7 +175,7 @@ export class PayloadService extends BaseService {
       );
 
     // Due to the existence of a "devices" collection in the tenant index and a platform index,
-    // it is need to fetch the device content associated to the tenant if it exists.
+    // we need to fetch the device content from the associated tenant if it exists.
     const updatedDevices = await Promise.all(
       devices.map((device) =>
         device._source.engineId && device._source.engineId.trim() !== ""


### PR DESCRIPTION
<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

When a payload is sent to register a new measure for a device, the metadata of the device are replaced by those from the index platform (```PayloadService.ts```). So the fix is to retrieve from the associated tenant if it exists. 


KZLPRD-556

<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### How should this be manually tested?

<!--
  Please describe your test configuration, the tests ran to verify your changes
  And give us instructions on how to reproduce them.
-->
  - Step 1 : check the metadata value registered in the device
  - Step 2 : send a payload, for example :
  ```
  {
    "deviceEUI" : "ABE1",
    "lat" : 48.8566,
    "lon" : 2.2523,
    "battery" : 40,
    "externalTemperature" : 1,
    "internalTemperature" : 1
    // "timestamp" : 1711753200000
}
``` 
to this endpoint ```http://localhost:7512/_/device-manager/payload/abeeway``` 

  - Step 3 : check again if the value didn't change

### Other changes

<!--
  Please outline any changes not directly linked to the main issue, but made because of it.
  For instance: on-the-fly fixes, dependencies updates and so on.
-->

### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->
