### PR TITLE
fix: trigger events on metadataReplace call

### DIFF
--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -161,6 +161,7 @@ export class AssetService extends DigitalTwinService {
       InternalCollection.ASSETS,
       assetId,
       updatedPayload.asset._source,
+      { triggerEvents: true },
     );
 
     await this.assetHistoryService.add<AssetHistoryEventMetadata>(engineId, [


### PR DESCRIPTION
Adds a triggerEvent to allow piping on `generic:document:afterWrite` as it was possible before KZLPRD-323