### PR TITLE
fix: getAsset should search in commons assets too

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -23,12 +23,7 @@ module.exports = {
     },
     {
       name: "2-dev",
-      prerelease: "dev",
-      range: "2.x",
-    },
-    {
-      name: "next",
-      prerelease: true,
-    },
+      prerelease: "dev"
+    }
   ],
 };

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -23,7 +23,12 @@ module.exports = {
     },
     {
       name: "2-dev",
-      prerelease: "dev"
-    }
+      prerelease: "dev",
+      range: "2.x",
+    },
+    {
+      name: "next",
+      prerelease: true,
+    },
   ],
 };

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -572,8 +572,14 @@ export class ModelService extends BaseService {
   ): Promise<KDocument<AssetModelContent>> {
     const query = {
       and: [
-        { equals: { engineGroup } },
+        {
+          or: [
+            { equals: { engineGroup } },
+            { equals: { engineGroup: "commons" } },
+          ],
+        },
         { equals: { type: "asset" } },
+
         { equals: { "asset.model": model } },
       ],
     };

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -579,7 +579,6 @@ export class ModelService extends BaseService {
           ],
         },
         { equals: { type: "asset" } },
-
         { equals: { "asset.model": model } },
       ],
     };

--- a/tests/scenario/modules/models/asset-model.test.ts
+++ b/tests/scenario/modules/models/asset-model.test.ts
@@ -111,15 +111,6 @@ describe("ModelsController:assets", () => {
       _id: "model-asset-Plane",
       _source: { asset: { model: "Plane" } },
     });
-
-    const getAssetNotExist = sdk.query({
-      controller: "device-manager/models",
-      action: "getAsset",
-      engineGroup: "other_engine",
-      model: "Plane",
-    });
-
-    await expect(getAssetNotExist).rejects.toMatchObject({ status: 404 });
   });
 
   it("List asset models only from the requested engine group and the common ones", async () => {


### PR DESCRIPTION
## What does this PR do ?

The bug appears when someone tries to create an asset with a model which uses an engineGroup sets to commons, resulting in an error in the frontend saying "insufficient permissions".

The problem comes from the assetCreate in KDM which calls the models:asset:get to get the model of the asset we want to create, the thing is that we don't check if in the engineId: commons, so when this is the case it result in an error being thrown saying the asset we are looking for doesn't exist

### How should this be manually tested?

  - Step 1 : cloen and run the iot platform
  - Step 2 : run the fixtures
  - Step 3 : modify the model container to change engineId to "commons"
  - Step 4: try to create an asset of type Container
