### PR TITLE
feat(groupmodels): add possibility to set up group models with metadatas

### DIFF
--- a/doc/2/controllers/models/delete-group/index.md
+++ b/doc/2/controllers/models/delete-group/index.md
@@ -1,0 +1,51 @@
+---
+code: true
+type: page
+title: deleteGroup
+description: Deletes a group model
+---
+
+# deleteGroup
+
+Deletes a group model.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/group/:id
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "deleteGroup",
+  "_id": "<group model _id>"
+}
+```
+
+---
+
+## Arguments
+
+- `_id`: group model id
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "deleteGroup",
+  "requestId": "<unique request identifier>",
+}
+```

--- a/doc/2/controllers/models/delete-group/index.md
+++ b/doc/2/controllers/models/delete-group/index.md
@@ -17,7 +17,7 @@ Deletes a group model.
 
 ```http
 URL: http://kuzzle:7512/_/device-manager/models/group/:id
-Method: GET
+Method: DELETE
 ```
 
 ### Other protocols

--- a/doc/2/controllers/models/get-group/index.md
+++ b/doc/2/controllers/models/get-group/index.md
@@ -1,0 +1,57 @@
+---
+code: true
+type: page
+title: getGroup
+description: Gets a group model
+---
+
+# getGroup
+
+Gets a group model.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/group/:model
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "getGroup",
+  "model": "<group model>"
+}
+```
+
+---
+
+## Arguments
+
+- `model`: group model
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "getGroup",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<modelId>",
+    "_source": {
+      // Group model content
+    },
+  }
+}
+```

--- a/doc/2/controllers/models/list-groups/index.md
+++ b/doc/2/controllers/models/list-groups/index.md
@@ -1,0 +1,62 @@
+---
+code: true
+type: page
+title: listGroups
+description: Lists group models
+---
+
+# listGroups
+
+Lists group models.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/groups
+Method: GET
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "listGroups",
+  "engineGroup": "<engineGroup>"
+}
+```
+
+---
+
+## Arguments
+
+- `engineGroup`: name of the engine group
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "listGroups",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "models": [
+      {
+        "_id": "<modelId>",
+        "_source": {
+          // Group model content
+        },
+      }
+    ],
+    "total": 42
+  }
+}
+```

--- a/doc/2/controllers/models/search-groups/index.md
+++ b/doc/2/controllers/models/search-groups/index.md
@@ -1,0 +1,81 @@
+---
+code: true
+type: page
+title: searchGroups
+description: Searches for group models
+---
+
+# searchGroups
+
+Searches for group models.
+
+---
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/groups/_search
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "searchGroups",
+  "engineGroup": "<engineGroup>",
+  "body": {
+    "query": {
+      // ...
+    },
+    "sort": [
+      // ...
+    ]
+  },
+
+  // optional:
+  "from": "<starting offset>",
+  "size": "<page size>"
+}
+```
+
+---
+
+## Arguments
+
+- `engineGroup`: name of the engine group
+- `from`: paginates search results by defining the offset from the first result you want to fetch. Usually used with the `size` argument
+- `size`: set the maximum number of documents returned per result page
+
+## Body properties
+
+- `query`: the search query itself, using the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html).
+- `sort`: contains a list of fields, used to [sort search results](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/search-request-sort.html), in order of importance.
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "searchGroups",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "hits": [
+      {
+        "_id": "<GroupModelId>",
+        "_source": {
+          // Group model content
+        },
+      },
+    ],
+    "total": 42
+  }
+}
+```

--- a/doc/2/controllers/models/write-group/index.md
+++ b/doc/2/controllers/models/write-group/index.md
@@ -1,0 +1,163 @@
+---
+code: true
+type: page
+title: writeGroup
+description: Write a group model
+---
+
+# writeGroup
+
+Write a group model.
+
+This action acts like a create or replace
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/models/groups
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/models",
+  "action": "writeGroup",
+  "body": {
+    "engineGroup": "<engine group>",
+    "model": "<group model>",
+
+    // Optional
+
+    "metadataMappings": {
+      // Metadata mappings
+    },
+    "defaultValues": {
+      // Default values for metadata
+    },
+    "metadataDetails": {
+      /*
+        Metadata details including tanslations, group and editor hint.
+          [name: string]: {
+            group?: string;
+            locales: {
+              [locale: string]: {
+                friendlyName: string;
+                description: string;
+              };
+            };
+            editorHint?: BaseEditorHint | OptionsSelectorDefinition | DatetimeEditorHint;
+          };
+      */
+    },
+    "metadataGroups": {
+      /*
+        Metadata groups list and details.
+          {
+            [groupName: string]: {
+              locales: {
+                [locale: string]: {
+                  groupFriendlyName: string;
+                  description: string;
+                };
+              };
+            };
+          };
+      */
+    },
+    "tooltipModels": {
+      /*
+        Tooltip models for a group model.
+          [key: string]: {
+            tooltipLabel: string;
+            content: [
+              {
+                category: "metadata";
+                label?: {
+                  locales: {
+                    [locale: string]: {
+                      friendlyName: string;
+                      description: string;
+                    };
+                  };
+                };
+                metadataPath: string;
+                suffix?: string;
+              },
+              {
+                category: "measure";
+                label?: {
+                  locales: {
+                    [locale: string]: {
+                      friendlyName: string;
+                      description: string;
+                    };
+                  };
+                };
+                measureSlot: string;
+                measureValuePath: string;
+                suffix?: string;
+              },
+              {
+                category: "static";
+                label?: {
+                  locales: {
+                    [locale: string]: {
+                      friendlyName: string;
+                      description: string;
+                    };
+                  };
+                };
+                type: "link" | "image" | "text" | "title" | "separator";
+                value: string;
+              }
+            ];
+          };
+      */
+    },
+  }
+}
+```
+
+---
+
+## Body properties
+
+- `engineGroup`: Name of the engine group
+- `model`: Group model name
+- `metadataMappings`: Mappings of the metadata in Elasticsearch format
+- `defaultValues`: Default values for the metadata
+- `metadataDetails`: Translations, metadata group, and editor hint (See [ MetadataDetails ](../../../concepts/metadatadetails/index.md))
+- `metadataGroups`: Groups list with translations for group name
+- `tooltipModels`: Tooltip model list, containing each labels and tooltip content to display
+
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/models",
+  "action": "writeGroup",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<modelId>",
+    "_source": {
+      // Group model content
+    },
+  }
+}
+```
+
+## Errors
+
+| error                                                                          | code    | cause                                               |
+| ------------------------------------------------------------------------------ | ------- | --------------------------------------------------- |
+| [ MappingsConflictsError ](../../../errors/mappings-conflicts/index.md)        | **409** | Writing a group with conflicting metadata mappings |
+

--- a/lib/modules/asset/AssetsGroupsController.ts
+++ b/lib/modules/asset/AssetsGroupsController.ts
@@ -264,12 +264,16 @@ export class AssetsGroupsController {
       for (const [metadataName, metadataValue] of Object.entries(
         groupModel.group.defaultMetadata,
       )) {
-        _.set(groupMetadata, metadataName, metadataValue);
+        if (!metadata[metadataName]) {
+          _.set(groupMetadata, metadataName, metadataValue);
+        }
       }
       for (const metadataName of Object.keys(
         groupModel.group.metadataMappings,
       )) {
-        groupMetadata[metadataName] = metadata[metadataName] ?? null;
+        if (metadata[metadataName]) {
+          groupMetadata[metadataName] = metadata[metadataName];
+        }
       }
     }
     return this.as(request.getUser()).document.create<AssetsGroupsBody>(

--- a/lib/modules/asset/AssetsGroupsController.ts
+++ b/lib/modules/asset/AssetsGroupsController.ts
@@ -27,7 +27,6 @@ import {
   AssetsGroupsBodyRequest,
 } from "./types/AssetGroupsApi";
 import { AskModelGroupGet } from "../model";
-import _ from "lodash";
 
 export class AssetsGroupsController {
   definition: ControllerDefinition;

--- a/lib/modules/asset/collections/assetsGroupsMapping.ts
+++ b/lib/modules/asset/collections/assetsGroupsMapping.ts
@@ -11,6 +11,11 @@ export const assetGroupsMappings: CollectionMappings = {
       },
       type: "keyword",
     },
+    metadata: {
+      properties: {
+        // populated with group models
+      },
+    },
     name: {
       fields: {
         text: {
@@ -27,7 +32,7 @@ export const assetGroupsMappings: CollectionMappings = {
       },
       type: "keyword",
     },
-    type: {
+    model: {
       fields: {
         text: {
           type: "text",

--- a/lib/modules/asset/types/AssetGroupContent.ts
+++ b/lib/modules/asset/types/AssetGroupContent.ts
@@ -1,11 +1,15 @@
 import { KDocumentContent } from "kuzzle-sdk";
+import { Metadata } from "lib/modules/shared";
 
-export interface AssetsGroupsBody {
+export interface AssetsGroupsBody<TMetadata extends Metadata = Metadata>
+  extends KDocumentContent {
   name: string;
-  type: string | null;
+  model?: string | null;
   children: string[];
   parent: string | null;
   lastUpdate: number;
+  metadata?: TMetadata;
 }
 
-export type AssetsGroupContent = AssetsGroupsBody & KDocumentContent;
+export type AssetsGroupContent<TMetadata extends Metadata = any> =
+  AssetsGroupsBody<TMetadata>;

--- a/lib/modules/model/ModelSerializer.ts
+++ b/lib/modules/model/ModelSerializer.ts
@@ -2,6 +2,7 @@ import { BadRequestError } from "kuzzle";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupModelContent,
   MeasureModelContent,
   ModelContent,
 } from "./types/ModelContent";
@@ -12,6 +13,8 @@ export class ModelSerializer {
       return `model-asset-${ModelSerializer.title(type, model)}`;
     } else if (type === "device") {
       return `model-device-${ModelSerializer.title(type, model)}`;
+    } else if (type === "group") {
+      return `model-group-${ModelSerializer.title(type, model)}`;
     } else if (type === "measure") {
       return `model-measure-${ModelSerializer.title(type, model)}`;
     }
@@ -24,6 +27,8 @@ export class ModelSerializer {
       return (model as AssetModelContent).asset.model;
     } else if (type === "device") {
       return (model as DeviceModelContent).device.model;
+    } else if (type === "group") {
+      return (model as GroupModelContent).group.model;
     } else if (type === "measure") {
       return (model as MeasureModelContent).measure.type;
     }

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -814,6 +814,11 @@ export class ModelService extends BaseService {
     if (result.total === 0) {
       throw new NotFoundError(`Unknown Group model "${model}".`);
     }
+    if (result.total > 1) {
+      app.log.warn(
+        "More than 1 group definition have been found for this model",
+      );
+    }
 
     return result.hits[0];
   }

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -559,8 +559,10 @@ export class ModelService extends BaseService {
     return result.hits;
   }
 
-  async listGroups(): Promise<KDocument<GroupModelContent>[]> {
-    const result = await this.searchGroups({
+  async listGroups(
+    engineGroup: string,
+  ): Promise<KDocument<GroupModelContent>[]> {
+    const result = await this.searchGroups(engineGroup, {
       searchBody: {
         sort: { "group.model": "asc" },
       },
@@ -644,11 +646,23 @@ export class ModelService extends BaseService {
   }
 
   async searchGroups(
+    engineGroup: string,
     searchParams: Partial<SearchParams>,
   ): Promise<SearchResult<KHit<GroupModelContent>>> {
     const query = {
       bool: {
-        must: [searchParams.searchBody.query, { match: { type: "group" } }],
+        must: [
+          searchParams.searchBody.query,
+          { match: { type: "group" } },
+          {
+            bool: {
+              should: [
+                { match: { engineGroup } },
+                { match: { engineGroup: "commons" } },
+              ],
+            },
+          },
+        ],
       },
     };
 

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -24,6 +24,7 @@ import { ModelSerializer } from "./ModelSerializer";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupModelContent,
   MeasureModelContent,
   MetadataDetails,
   MetadataGroups,
@@ -34,6 +35,7 @@ import {
 import {
   AskModelAssetGet,
   AskModelDeviceGet,
+  AskModelGroupGet,
   AskModelMeasureGet,
 } from "./types/ModelEvents";
 import { MappingsConflictsError } from "./MappingsConflictsError";
@@ -67,6 +69,14 @@ export class ModelService extends BaseService {
         const deviceModel = await this.getDevice(model);
 
         return deviceModel._source;
+      },
+    );
+    onAsk<AskModelGroupGet>(
+      "ask:device-manager:model:group:get",
+      async ({ model }) => {
+        const groupModel = await this.getGroup(model);
+
+        return groupModel._source;
       },
     );
     onAsk<AskModelMeasureGet>(
@@ -125,6 +135,10 @@ export class ModelService extends BaseService {
       return elt.type === "device";
     }) as DeviceModelContent[];
 
+    const groups = documents.filter((elt) => {
+      return elt.type === "group";
+    }) as GroupModelContent[];
+
     const measures = documents.filter((elt) => {
       return elt.type === "measure";
     }) as MeasureModelContent[];
@@ -162,6 +176,22 @@ export class ModelService extends BaseService {
       if (conflicts.length > 0) {
         throw new MappingsConflictsError(
           `New devices mappings are causing conflicts`,
+          conflicts,
+        );
+      }
+    }
+
+    if (groups.length > 0) {
+      const conflicts = await ask<AskEngineUpdateConflict>(
+        "ask:device-manager:engine:doesUpdateConflict",
+        {
+          groupModels: groups,
+        },
+      );
+
+      if (conflicts.length > 0) {
+        throw new MappingsConflictsError(
+          `New group mappings are causing conflicts`,
           conflicts,
         );
       }
@@ -342,7 +372,7 @@ export class ModelService extends BaseService {
 
     if (conflicts.length > 0) {
       throw new MappingsConflictsError(
-        `New assets mappings are causing conflicts`,
+        `New devices mappings are causing conflicts`,
         conflicts,
       );
     }
@@ -362,6 +392,59 @@ export class ModelService extends BaseService {
     await ask<AskEngineUpdateAll>("ask:device-manager:engine:updateAll");
 
     return deviceModel;
+  }
+
+  async writeGroup(
+    engineGroup: string,
+    model: string,
+    metadataMappings: MetadataMappings,
+    defaultMetadata: JSONObject,
+    metadataDetails: MetadataDetails,
+    metadataGroups: MetadataGroups,
+  ): Promise<KDocument<GroupModelContent>> {
+    if (Inflector.pascalCase(model) !== model) {
+      throw new BadRequestError(`Group model "${model}" must be PascalCase.`);
+    }
+
+    const modelContent: GroupModelContent = {
+      engineGroup,
+      group: {
+        defaultMetadata,
+        metadataDetails,
+        metadataGroups,
+        metadataMappings,
+        model,
+      },
+      type: "group",
+    };
+
+    const conflicts = await ask<AskEngineUpdateConflict>(
+      "ask:device-manager:engine:doesUpdateConflict",
+      { groupModels: [modelContent] },
+    );
+
+    if (conflicts.length > 0) {
+      throw new MappingsConflictsError(
+        `New group mappings are causing conflicts`,
+        conflicts,
+      );
+    }
+
+    const groupModel =
+      await this.sdk.document.createOrReplace<GroupModelContent>(
+        this.config.adminIndex,
+        InternalCollection.MODELS,
+        ModelSerializer.id<GroupModelContent>("group", modelContent),
+        modelContent,
+      );
+
+    await this.sdk.collection.refresh(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+    );
+    await ask<AskEngineUpdateAll>("ask:device-manager:engine:updateAll");
+
+    return groupModel;
   }
 
   async writeMeasure(
@@ -436,6 +519,14 @@ export class ModelService extends BaseService {
     );
   }
 
+  async deleteGroup(_id: string) {
+    await this.sdk.document.delete(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+      _id,
+    );
+  }
+
   async deleteMeasure(_id: string) {
     await this.sdk.document.delete(
       this.config.adminIndex,
@@ -461,6 +552,17 @@ export class ModelService extends BaseService {
     const result = await this.searchDevices({
       searchBody: {
         sort: { "device.model": "asc" },
+      },
+      size: 5000,
+    });
+
+    return result.hits;
+  }
+
+  async listGroups(): Promise<KDocument<GroupModelContent>[]> {
+    const result = await this.searchGroups({
+      searchBody: {
+        sort: { "group.model": "asc" },
       },
       size: 5000,
     });
@@ -526,6 +628,31 @@ export class ModelService extends BaseService {
     };
 
     return this.sdk.document.search<DeviceModelContent>(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+      {
+        ...searchParams.searchBody,
+        query,
+      },
+      {
+        from: searchParams.from,
+        lang: "elasticsearch",
+        scroll: searchParams.scrollTTL,
+        size: searchParams.size,
+      },
+    );
+  }
+
+  async searchGroups(
+    searchParams: Partial<SearchParams>,
+  ): Promise<SearchResult<KHit<GroupModelContent>>> {
+    const query = {
+      bool: {
+        must: [searchParams.searchBody.query, { match: { type: "group" } }],
+      },
+    };
+
+    return this.sdk.document.search<GroupModelContent>(
       this.config.adminIndex,
       InternalCollection.MODELS,
       {
@@ -650,6 +777,28 @@ export class ModelService extends BaseService {
 
     if (result.total === 0) {
       throw new NotFoundError(`Unknown Device model "${model}".`);
+    }
+
+    return result.hits[0];
+  }
+
+  async getGroup(model: string): Promise<KDocument<GroupModelContent>> {
+    const query = {
+      and: [
+        { equals: { type: "group" } },
+        { equals: { "group.model": model } },
+      ],
+    };
+
+    const result = await this.sdk.document.search<GroupModelContent>(
+      this.config.adminIndex,
+      InternalCollection.MODELS,
+      { query },
+      { lang: "koncorde", size: 1 },
+    );
+
+    if (result.total === 0) {
+      throw new NotFoundError(`Unknown Group model "${model}".`);
     }
 
     return result.hits[0];

--- a/lib/modules/model/ModelsConflicts.ts
+++ b/lib/modules/model/ModelsConflicts.ts
@@ -1,6 +1,10 @@
 import _ from "lodash";
 import { TwinModelContent, TwinType } from "../plugin";
-import { MeasureModelContent, ModelContent } from "./exports";
+import {
+  GroupModelContent,
+  MeasureModelContent,
+  ModelContent,
+} from "./exports";
 
 export type ConflictChunk = {
   sourceModel: string;
@@ -80,6 +84,29 @@ export function getTwinConflicts<TDigitalTwin extends TwinModelContent>(
     models,
     additional,
     metadataPath,
+    modelIdPath,
+  );
+}
+/**
+ * Return every conflicts between the mappings of group models and a new group model
+ *
+ * @param groups The already present group models
+ * @param additional The new group model
+ * @returns An array of ConflictChunk between current groups and the new group
+ */
+export function getGroupConflicts(
+  measures: GroupModelContent[],
+  additional: GroupModelContent,
+): ConflictChunk[] {
+  const modelType = "group";
+  const mappingsPath = "group.metadataMappings";
+  const modelIdPath = "group.model";
+
+  return getModelConflicts(
+    modelType,
+    measures,
+    additional,
+    mappingsPath,
     modelIdPath,
   );
 }

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -303,8 +303,9 @@ export class ModelsController {
     };
   }
 
-  async listGroups(): Promise<ApiModelListGroupsResult> {
-    const models = await this.modelService.listGroups();
+  async listGroups(request: KuzzleRequest): Promise<ApiModelListGroupsResult> {
+    const engineGroup = request.getString("engineGroup");
+    const models = await this.modelService.listGroups(engineGroup);
 
     return {
       models,
@@ -339,7 +340,10 @@ export class ModelsController {
   async searchGroups(
     request: KuzzleRequest,
   ): Promise<ApiModelSearchGroupsResult> {
-    return this.modelService.searchGroups(request.getSearchParams());
+    return this.modelService.searchGroups(
+      request.getString("engineGroup"),
+      request.getSearchParams(),
+    );
   }
 
   async searchMeasures(

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -18,6 +18,11 @@ import {
   ApiModelSearchAssetsResult,
   ApiModelSearchDevicesResult,
   ApiModelSearchMeasuresResult,
+  ApiModelDeleteGroupResult,
+  ApiModelGetGroupResult,
+  ApiModelListGroupsResult,
+  ApiModelSearchGroupsResult,
+  ApiModelWriteGroupResult,
 } from "./types/ModelApi";
 
 export class ModelsController {
@@ -38,6 +43,10 @@ export class ModelsController {
           handler: this.deleteDevice.bind(this),
           http: [{ path: "device-manager/models/device/:_id", verb: "delete" }],
         },
+        deleteGroup: {
+          handler: this.deleteGroup.bind(this),
+          http: [{ path: "device-manager/models/group/:_id", verb: "delete" }],
+        },
         deleteMeasure: {
           handler: this.deleteMeasure.bind(this),
           http: [
@@ -52,6 +61,10 @@ export class ModelsController {
           handler: this.getDevice.bind(this),
           http: [{ path: "device-manager/models/device/:model", verb: "get" }],
         },
+        getGroup: {
+          handler: this.getGroup.bind(this),
+          http: [{ path: "device-manager/models/group/:model", verb: "get" }],
+        },
         getMeasure: {
           handler: this.getMeasure.bind(this),
           http: [{ path: "device-manager/models/measure/:type", verb: "get" }],
@@ -63,6 +76,10 @@ export class ModelsController {
         listDevices: {
           handler: this.listDevices.bind(this),
           http: [{ path: "device-manager/models/devices", verb: "get" }],
+        },
+        listGroups: {
+          handler: this.listGroups.bind(this),
+          http: [{ path: "device-manager/models/groups", verb: "get" }],
         },
         listMeasures: {
           handler: this.listMeasures.bind(this),
@@ -78,6 +95,12 @@ export class ModelsController {
           handler: this.searchDevices.bind(this),
           http: [
             { path: "device-manager/models/devices/_search", verb: "post" },
+          ],
+        },
+        searchGroups: {
+          handler: this.searchGroups.bind(this),
+          http: [
+            { path: "device-manager/models/groups/_search", verb: "post" },
           ],
         },
         searchMeasures: {
@@ -99,6 +122,10 @@ export class ModelsController {
         writeDevice: {
           handler: this.writeDevice.bind(this),
           http: [{ path: "device-manager/models/devices", verb: "post" }],
+        },
+        writeGroup: {
+          handler: this.writeGroup.bind(this),
+          http: [{ path: "device-manager/models/groups", verb: "post" }],
         },
         writeMeasure: {
           handler: this.writeMeasure.bind(this),
@@ -125,6 +152,13 @@ export class ModelsController {
     return deviceModel;
   }
 
+  async getGroup(request: KuzzleRequest): Promise<ApiModelGetGroupResult> {
+    const model = request.getString("model");
+
+    const groupModel = await this.modelService.getGroup(model);
+
+    return groupModel;
+  }
   async getMeasure(request: KuzzleRequest): Promise<ApiModelGetMeasureResult> {
     const type = request.getString("type");
 
@@ -179,6 +213,26 @@ export class ModelsController {
     return deviceModel;
   }
 
+  async writeGroup(request: KuzzleRequest): Promise<ApiModelWriteGroupResult> {
+    const engineGroup = request.getBodyString("engineGroup");
+    const model = request.getBodyString("model");
+    const metadataMappings = request.getBodyObject("metadataMappings", {});
+    const defaultValues = request.getBodyObject("defaultValues", {});
+    const metadataDetails = request.getBodyObject("metadataDetails", {});
+    const metadataGroups = request.getBodyObject("metadataGroups", {});
+
+    const groupModel = await this.modelService.writeGroup(
+      engineGroup,
+      model,
+      metadataMappings,
+      defaultValues,
+      metadataDetails,
+      metadataGroups,
+    );
+
+    return groupModel;
+  }
+
   async writeMeasure(
     request: KuzzleRequest,
   ): Promise<ApiModelWriteMeasureResult> {
@@ -213,6 +267,14 @@ export class ModelsController {
     await this.modelService.deleteDevice(_id);
   }
 
+  async deleteGroup(
+    request: KuzzleRequest,
+  ): Promise<ApiModelDeleteGroupResult> {
+    const _id = request.getId();
+
+    await this.modelService.deleteGroup(_id);
+  }
+
   async deleteMeasure(
     request: KuzzleRequest,
   ): Promise<ApiModelDeleteMeasureResult> {
@@ -234,6 +296,15 @@ export class ModelsController {
 
   async listDevices(): Promise<ApiModelListDevicesResult> {
     const models = await this.modelService.listDevices();
+
+    return {
+      models,
+      total: models.length,
+    };
+  }
+
+  async listGroups(): Promise<ApiModelListGroupsResult> {
+    const models = await this.modelService.listGroups();
 
     return {
       models,
@@ -263,6 +334,12 @@ export class ModelsController {
     request: KuzzleRequest,
   ): Promise<ApiModelSearchDevicesResult> {
     return this.modelService.searchDevices(request.getSearchParams());
+  }
+
+  async searchGroups(
+    request: KuzzleRequest,
+  ): Promise<ApiModelSearchGroupsResult> {
+    return this.modelService.searchGroups(request.getSearchParams());
   }
 
   async searchMeasures(

--- a/lib/modules/model/ModelsRegister.ts
+++ b/lib/modules/model/ModelsRegister.ts
@@ -11,6 +11,7 @@ import { MeasureDefinition } from "../measure";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupModelContent,
   MeasureModelContent,
   MetadataDetails,
   MetadataGroups,
@@ -30,6 +31,7 @@ export class ModelsRegister {
   private context: PluginContext;
   private assetModels: AssetModelContent[] = [];
   private deviceModels: DeviceModelContent[] = [];
+  private groupModels: GroupModelContent[] = [];
   private measureModels: MeasureModelContent[] = [];
 
   private get sdk() {
@@ -45,6 +47,7 @@ export class ModelsRegister {
     await Promise.all([
       this.load("asset", this.assetModels),
       this.load("device", this.deviceModels),
+      this.load("group", this.groupModels),
       this.load("measure", this.measureModels),
     ]);
 
@@ -153,6 +156,46 @@ export class ModelsRegister {
         model,
       },
       type: "device",
+    });
+  }
+
+  /**
+   * Registers a group model.
+   *
+   *
+   * @param engineGroup - The engine group name.
+   * @param model - The name of the group model, which must be in PascalCase.
+   * @param metadataMappings - The metadata mappings for the model, defaults to an empty object.
+   * @param defaultMetadata - The default metadata values for the model, defaults to an empty object.
+   * @param metadataDetails - Optional detailed metadata descriptions, localizations and definition.
+   * @param metadataGroups - Optional groups for organizing metadata, with localizations.
+   * @throws PluginImplementationError if the model name is not in PascalCase.
+   */
+  registerGroup(
+    engineGroup: string,
+    model: string,
+    metadataMappings: MetadataMappings = {},
+    defaultMetadata: JSONObject = {},
+    metadataDetails: MetadataDetails = {},
+    metadataGroups: MetadataGroups = {},
+  ) {
+    if (Inflector.pascalCase(model) !== model) {
+      throw new PluginImplementationError(
+        `Group model "${model}" must be PascalCase`,
+      );
+    }
+
+    // Construct and push the new group model to the groupModels array
+    this.groupModels.push({
+      engineGroup,
+      group: {
+        defaultMetadata,
+        metadataDetails,
+        metadataGroups,
+        metadataMappings,
+        model,
+      },
+      type: "group",
     });
   }
 

--- a/lib/modules/model/collections/modelsMappings.ts
+++ b/lib/modules/model/collections/modelsMappings.ts
@@ -97,5 +97,34 @@ export const modelsMappings: CollectionMappings = {
         },
       },
     },
+
+    /**
+     * Group model
+     */
+    group: {
+      properties: {
+        model: { type: "keyword" },
+        metadataMappings: {
+          dynamic: "false",
+          properties: {},
+        },
+        defaultMetadata: {
+          dynamic: "false",
+          properties: {},
+        },
+        metadataDetails: {
+          dynamic: "false",
+          properties: {},
+        },
+        metadataGroups: {
+          dynamic: "false",
+          properties: {},
+        },
+        tooltipModels: {
+          dynamic: "false",
+          properties: {},
+        },
+      },
+    },
   },
 };

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -204,6 +204,7 @@ export type ApiModelSearchDevicesResult = SearchResult<
 export interface ApiModelSearchGroupsRequest extends ModelsControllerRequest {
   action: "searchGroups";
 
+  engineGroup: string;
   from?: number;
   size?: number;
   scrollTTL?: string;

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -163,6 +163,7 @@ export type ApiModelListDevicesResult = {
 
 export interface ApiModelListGroupsRequest extends ModelsControllerRequest {
   action: "listGroups";
+  engineGroup: string;
 }
 export type ApiModelListGroupsResult = {
   models: KDocument<GroupModelContent>[];

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -3,6 +3,7 @@ import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupModelContent,
   MeasureModelContent,
   MetadataDetails,
   MetadataGroups,
@@ -28,6 +29,12 @@ export interface ApiModelGetDeviceRequest extends ModelsControllerRequest {
   model: string;
 }
 export type ApiModelGetDeviceResult = KDocument<DeviceModelContent>;
+
+export interface ApiModelGetGroupRequest extends ModelsControllerRequest {
+  action: "getGroup";
+  model: string;
+}
+export type ApiModelGetGroupResult = KDocument<GroupModelContent>;
 
 export interface ApiModelGetMeasureRequest extends ModelsControllerRequest {
   action: "getMeasure";
@@ -64,6 +71,20 @@ export interface ApiModelWriteDeviceRequest extends ModelsControllerRequest {
   };
 }
 export type ApiModelWriteDeviceResult = KDocument<DeviceModelContent>;
+
+export interface ApiModelWriteGroupRequest extends ModelsControllerRequest {
+  action: "writeGroup";
+
+  body: {
+    engineGroup: string;
+    model: string;
+    metadataDetails?: MetadataDetails;
+    metadataGroups?: MetadataGroups;
+    metadataMappings?: MetadataMappings;
+    defaultValues?: JSONObject;
+  };
+}
+export type ApiModelWriteGroupResult = KDocument<GroupModelContent>;
 
 export interface ApiModelWriteMeasureRequest extends ModelsControllerRequest {
   action: "writeMeasure";
@@ -108,6 +129,13 @@ export interface ApiModelDeleteDeviceRequest extends ModelsControllerRequest {
 }
 export type ApiModelDeleteDeviceResult = void;
 
+export interface ApiModelDeleteGroupRequest extends ModelsControllerRequest {
+  action: "deleteGroup";
+
+  _id: string;
+}
+export type ApiModelDeleteGroupResult = void;
+
 export interface ApiModelDeleteMeasureRequest extends ModelsControllerRequest {
   action: "deleteMeasure";
 
@@ -130,6 +158,14 @@ export interface ApiModelListDevicesRequest extends ModelsControllerRequest {
 }
 export type ApiModelListDevicesResult = {
   models: KDocument<DeviceModelContent>[];
+  total: number;
+};
+
+export interface ApiModelListGroupsRequest extends ModelsControllerRequest {
+  action: "listGroups";
+}
+export type ApiModelListGroupsResult = {
+  models: KDocument<GroupModelContent>[];
   total: number;
 };
 
@@ -163,6 +199,16 @@ export interface ApiModelSearchDevicesRequest extends ModelsControllerRequest {
 export type ApiModelSearchDevicesResult = SearchResult<
   KHit<DeviceModelContent>
 >;
+
+export interface ApiModelSearchGroupsRequest extends ModelsControllerRequest {
+  action: "searchGroups";
+
+  from?: number;
+  size?: number;
+  scrollTTL?: string;
+  body?: JSONObject;
+}
+export type ApiModelSearchGroupsResult = SearchResult<KHit<GroupModelContent>>;
 
 export interface ApiModelSearchMeasuresRequest extends ModelsControllerRequest {
   action: "searchMeasures";

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -391,7 +391,136 @@ export interface DeviceModelContent extends KDocumentContent {
   };
 }
 
+export interface GroupModelContent extends KDocumentContent {
+  type: "group";
+
+  engineGroup: string;
+
+  group: {
+    /**
+     * Name of the model
+     */
+    model: string;
+
+    /**
+     * Metadata mappings.
+     *
+     * @example
+     * {
+     *   "company": {
+     *     "properties": {
+     *        "name": { "type": "keyword" },
+     *      }
+     *   }
+     * }
+     */
+    metadataMappings: MetadataMappings;
+
+    /**
+     * Default values for metadata.
+     *
+     * @example
+     * {
+     *    "company.name": "Firebird"
+     * }
+     */
+    defaultMetadata: JSONObject;
+    /**
+     * Metadata details
+     * @example
+     * {
+     *   "extTemp": {
+     *     "group": "buildingEnv",
+     *     "locales": {
+     *       "en": {
+     *          "friendlyName": "External temperature",
+     *          "description": "Building external temperature"
+     *       },
+     *       "fr": {
+     *         "friendlyName": "Température extérieure",
+     *         "description": "Température à l'exterieur du bâtiment"
+     *       },
+     *     },
+     *     "editorHint": {
+     *       "readOnly": true,
+     *       "type": EditorHintEnum.OPTION_SELECTOR,
+     *       "values": ["red", "blue"],
+     *       "customValueAllowed": true,
+     *     },
+     *   },
+     * }
+     */
+    metadataDetails?: MetadataDetails;
+    /**
+     * Metadata groups list
+     * @example
+     * {
+     *   "buildingEnv": {
+     *     "locales": {
+     *       "en": {
+     *         "groupFriendlyName": "Building environment",
+     *         "description": "The building environment"
+     *       },
+     *       "fr": {
+     *         "groupFriendlyName": "Environnement du bâtiment",
+     *         "description": "L'environnement du bâtiment"
+     *       }
+     *     }
+     *   }
+     * }
+     */
+    metadataGroups?: MetadataGroups;
+    /**
+     * List of tooltip models for this asset model
+     *
+     * @example
+     * [
+     *   "defaultTooltipKey": {
+     *     "tooltipLabel": "Default tooltip model",
+     *     "content": [
+     *       {
+     *         "metadataPath": "geolocation",
+     *         "label": {
+     *           "locales": {
+     *             "en": {
+     *               "description": "",
+     *               "friendlyName": "Container position"
+     *             },
+     *             "fr": {
+     *               "description": "",
+     *               "friendlyName": "Position du conteneur"
+     *             }
+     *           }
+     *         },
+     *         "category": "metadata"
+     *       },
+     *       {
+     *         "measureValuePath": "externalTemperature",
+     *         "measureSlot": "externalTemperature",
+     *         "label": {
+     *           "locales": {
+     *             "en": {
+     *               "description": "",
+     *               "friendlyName": "External temperature"
+     *             },
+     *             "fr": {
+     *               "description": "",
+     *               "friendlyName": "Température extérieure"
+     *             }
+     *           }
+     *         },
+     *         "category": "measure",
+     *         "suffix": "°C"
+     *       }
+     *     ]
+     *   }
+     * ]
+     */
+    tooltipModels?: TooltipModels;
+  };
+}
 export type ModelContent =
   | MeasureModelContent
   | AssetModelContent
-  | DeviceModelContent;
+  | DeviceModelContent
+  | GroupModelContent;

--- a/lib/modules/model/types/ModelDefinition.ts
+++ b/lib/modules/model/types/ModelDefinition.ts
@@ -212,3 +212,99 @@ export type DeviceModelDefinition = {
    */
   metadataGroups?: MetadataGroups;
 };
+
+/**
+ * Define a group model
+ *
+ * @example
+ *   {
+ *     metadataMappings: {
+ *       position: { type: "geo_point" },
+ *     },
+ *     defaultMetadata: {
+ *       position: {
+ *          lat: 41.12,
+ *          lon: -71.34
+ *       }
+ *     },
+ *     metadataDetails: {
+ *       "position": {
+ *         "group": "geolocation",
+ *         "locales": {
+ *           "en": {
+ *             "friendlyName": "Parking position",
+ *             "description": "The coordinates of the parking"
+ *           },
+ *           "fr": {
+ *             "friendlyName": "Position du parking",
+ *             "description": "Les coordonnées GPS du parking"
+ *           }
+ *         },
+ *       },
+ *     },
+ *     metadataGroups: {
+ *       geolocation: {
+ *         locales: {
+ *           en: {
+ *             groupFriendlyName: "Parking geolocation",
+ *             description: "The parking geolocation"
+ *           },
+ *           fr: {
+ *             groupFriendlyName: "Localisation du parking",
+ *             description: "La localisation du parking"
+ *           }
+ *         }
+ *       }
+ *     },
+ *     tooltipModels: {
+ *       "defaultTooltipKey": {
+ *         "tooltipLabel": "Default Tooltip Model",
+ *         "content": [
+ *           {
+ *             "category": "metadata",
+ *             "label": {
+ *               "locales": {
+ *                 "en": {
+ *                   "friendlyName": "Parking position",
+ *                   "description": ""
+ *                 },
+ *                 "fr": {
+ *                   "friendlyName": "Position du parking",
+ *                   "description": ""
+ *                 }
+ *               }
+ *             },
+ *             "metadataPath": "position"
+ *           },
+ *         ]
+ *       }
+ *     }
+ *   }
+ *
+ */
+export type GroupModelDefinition = {
+  /**
+   * Metadata mappings definition
+   */
+  metadataMappings?: MetadataMappings;
+
+  /**
+   * Default metadata values
+   */
+  defaultMetadata?: JSONObject;
+
+  /**
+   * Metadata details including tanslations and group.
+   */
+  metadataDetails?: MetadataDetails;
+
+  /**
+   * Metadata groups
+   */
+  metadataGroups?: MetadataGroups;
+
+  /**
+   * Tooltip models
+   */
+  tooltipModels?: TooltipModels;
+};

--- a/lib/modules/model/types/ModelEvents.ts
+++ b/lib/modules/model/types/ModelEvents.ts
@@ -1,6 +1,7 @@
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupModelContent,
   MeasureModelContent,
 } from "./ModelContent";
 
@@ -26,4 +27,12 @@ export type AskModelMeasureGet = {
   payload: { type: string };
 
   result: MeasureModelContent;
+};
+
+export type AskModelGroupGet = {
+  name: "ask:device-manager:model:group:get";
+
+  payload: { model: string };
+
+  result: GroupModelContent;
 };

--- a/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/lib/modules/plugin/DeviceManagerEngine.ts
@@ -15,12 +15,13 @@ import {
 import { JSONObject } from "kuzzle-sdk";
 import _ from "lodash";
 
-import { assetGroupsMappings, assetsHistoryMappings } from "../asset";
+import { assetsHistoryMappings } from "../asset";
 import { NamedMeasures } from "../decoder";
 import { getEmbeddedMeasureMappings, measuresMappings } from "../measure";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupModelContent,
   MeasureModelContent,
 } from "../model";
 
@@ -29,6 +30,7 @@ import { DeviceManagerConfiguration } from "./types/DeviceManagerConfiguration";
 import { InternalCollection } from "./types/InternalCollection";
 import {
   ConflictChunk,
+  getGroupConflicts,
   getMeasureConflicts,
   getTwinConflicts,
 } from "../model/ModelsConflicts";
@@ -74,6 +76,7 @@ export type AskEngineUpdateConflict = {
       models: TwinModelContent[];
     };
     measuresModels?: MeasureModelContent[];
+    groupModels?: GroupModelContent[];
   };
 
   result: ConflictChunk[];
@@ -123,7 +126,8 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
         if (
           payload.twin === undefined &&
-          payload.measuresModels === undefined
+          payload.measuresModels === undefined &&
+          payload.groupModels === undefined
         ) {
           return [];
         }
@@ -162,6 +166,16 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
           return this.doesMeasuresUpdateConflicts(
             measureModels,
             payload.measuresModels,
+          );
+        }
+        if (payload.groupModels) {
+          const groupModels = await this.getModels<GroupModelContent>(
+            this.config.adminIndex,
+            "group",
+          );
+          return this.doesGroupsUpdateConflicts(
+            groupModels,
+            payload.groupModels,
           );
         }
 
@@ -206,6 +220,26 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
       }
 
       conflicts.push(...getTwinConflicts(twinType, twinModels, additional));
+    }
+
+    return conflicts;
+  }
+
+  /**
+   * Return conflicts between the new and already present group models
+   *
+   * @param groupModels The already present group models
+   * @param additionalGroups The new or updated group models
+   * @returns An array of ConflictChunk
+   */
+  private async doesGroupsUpdateConflicts(
+    groupModels: GroupModelContent[],
+    additionalGroups: GroupModelContent[],
+  ): Promise<ConflictChunk[]> {
+    const conflicts: ConflictChunk[] = [];
+
+    for (const model of additionalGroups) {
+      conflicts.push(...getGroupConflicts(groupModels, model));
     }
 
     return conflicts;
@@ -407,9 +441,9 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
    */
   async createAssetsGroupsCollection(engineId: string) {
     const settings = this.config.engineCollections.assetGroups.settings;
-
+    const mappings = await this.getAssetGroupsMappingFromDB();
     await this.tryCreateCollection(engineId, InternalCollection.ASSETS_GROUPS, {
-      mappings: assetGroupsMappings,
+      mappings,
       settings,
     });
 
@@ -616,6 +650,24 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
     mappings.properties.origin.properties.deviceMetadata.properties =
       deviceMappings.properties.metadata.properties;
 
+    return mappings;
+  }
+
+  async getAssetGroupsMappingFromDB() {
+    const models = await this.getModels<GroupModelContent>(
+      this.config.adminIndex,
+      "group",
+    );
+    const mappings = JSON.parse(
+      JSON.stringify(this.config.engineCollections.assetGroups.mappings),
+    );
+
+    for (const model of models) {
+      _.merge(
+        mappings.properties.metadata.properties,
+        model.group.metadataMappings,
+      );
+    }
     return mappings;
   }
 

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -18,7 +18,7 @@ import {
   temperatureMeasureDefinition,
 } from "../measure";
 
-import { AssetModule, assetsMappings } from "../asset";
+import { assetGroupsMappings, AssetModule, assetsMappings } from "../asset";
 import {
   DecoderModule,
   DecodersRegister,
@@ -30,6 +30,7 @@ import { MeasureModule } from "../measure";
 import {
   AssetModelDefinition,
   DeviceModelDefinition,
+  GroupModelDefinition,
   ModelModule,
   modelsMappings,
   ModelsRegister,
@@ -252,6 +253,73 @@ export class DeviceManagerPlugin extends Plugin {
       },
 
       /**
+       * Register a group.
+       *
+       * @param model Name of the group model
+       * @param definition Object containing the group model definition, including:
+       *                   - metadataMappings: Metadata mappings definition
+       *                   - defaultMetadata: Default metadata values
+       *                   - metadataDetails: Localizations, detailed metadata descriptions and definition
+       *                   - metadataGroups: Groups for organizing metadata, with localizations
+       *
+       * @example
+       * ```
+       * deviceManager.models.registerGroup(
+       *   "Parking",
+       *   {
+       *     metadataMappings: {
+       *       geolocation: { type: "geo_point" },
+       *     },
+       *     defaultMetadata: {
+       *
+       *     },
+       *     metadataDetails: {
+       *       geolocation: {
+       *         group: "access",
+       *         locales: {
+       *           en: {
+       *             friendlyName: "Parking location",
+       *             description: "GPS position of the parking"
+       *           },
+       *           fr: {
+       *             friendlyName: "Emplacement du parking",
+       *             description: "Position GPS du parking"
+       *           }
+       *         }
+       *       }
+       *     },
+       *     metadataGroups: {
+       *       access: {
+       *         locales: {
+       *           en: {
+       *             groupFriendlyName: "Parking access info"
+       *           },
+       *           fr: {
+       *             groupFriendlyName: "Information d'accès au parking"
+       *           }
+       *         }
+       *       }
+       *     }
+       *   }
+       * );
+       * ```
+       */
+      registerGroup: (
+        engineGroup: string,
+        model: string,
+        definition: GroupModelDefinition,
+      ) => {
+        this.modelsRegister.registerGroup(
+          engineGroup,
+          model,
+          definition.metadataMappings,
+          definition.defaultMetadata,
+          definition.metadataDetails,
+          definition.metadataGroups,
+        );
+      },
+
+      /**
        * Register a new measure
        *
        * @param name Name of the measure
@@ -329,6 +397,7 @@ export class DeviceManagerPlugin extends Plugin {
         },
         assetGroups: {
           name: InternalCollection.ASSETS_GROUPS,
+          mappings: assetGroupsMappings,
         },
         assetHistory: {
           name: InternalCollection.ASSETS_HISTORY,

--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -60,6 +60,7 @@ export type DeviceManagerConfiguration = {
     };
     assetGroups: {
       name: string;
+      mappings: JSONObject;
       settings?: JSONObject;
     };
     assetHistory: {

--- a/lib/modules/shared/types/Models.ts
+++ b/lib/modules/shared/types/Models.ts
@@ -1,5 +1,9 @@
 import { MeasureDefinition } from "../../measure";
-import { AssetModelDefinition, DeviceModelDefinition } from "../../model";
+import {
+  AssetModelDefinition,
+  DeviceModelDefinition,
+  GroupModelDefinition,
+} from "../../model";
 
 interface ModelDefinition<Definition> {
   /**
@@ -15,3 +19,4 @@ interface ModelDefinition<Definition> {
 export type AssetModel = ModelDefinition<AssetModelDefinition>;
 export type DeviceModel = ModelDefinition<DeviceModelDefinition>;
 export type MeasureModel = ModelDefinition<MeasureDefinition>;
+export type GroupModel = ModelDefinition<GroupModelDefinition>;

--- a/tests/application/app.ts
+++ b/tests/application/app.ts
@@ -20,6 +20,12 @@ deviceManager.config.engineCollections.device.mappings.properties["custom"] = {
   type: "keyword",
   fields: { text: { type: "text" } },
 };
+deviceManager.config.engineCollections.assetGroups.mappings.properties[
+  "custom"
+] = {
+  type: "keyword",
+  fields: { text: { type: "text" } },
+};
 
 registerModels(deviceManager);
 registerTestPipes(app);

--- a/tests/application/groups/Parking.ts
+++ b/tests/application/groups/Parking.ts
@@ -1,0 +1,61 @@
+import { AssetsGroupContent } from "lib/modules/asset/exports";
+import { GroupModel, Metadata } from "lib/modules/shared";
+
+const modelName = "Parking";
+
+export interface ParkingMetadata extends Metadata {
+  geolocation: {
+    lat: number;
+    lon: number;
+  };
+}
+
+export interface ParkingGroupContent
+  extends AssetsGroupContent<ParkingMetadata> {
+  model: typeof modelName;
+}
+
+export const Parking: GroupModel = {
+  modelName,
+  definition: {
+    metadataMappings: {
+      geolocation: { type: "geo_point" },
+    },
+    metadataDetails: {
+      geolocation: {
+        group: "environment",
+        locales: {
+          en: {
+            friendlyName: "Geolocation",
+            description: "Parking geolocation",
+          },
+          fr: {
+            friendlyName: "Géolocalisation",
+            description: "Géolocalisation du parking",
+          },
+        },
+      },
+    },
+    defaultMetadata: {
+      geolocation: {
+        lon: 3.8761,
+        lat: 43.6109,
+      },
+    },
+    metadataGroups: {
+      environment: {
+        locales: {
+          en: {
+            groupFriendlyName: "Environmental information",
+            description: "All environmental relative information",
+          },
+          fr: {
+            groupFriendlyName: "Informations environnementales",
+            description:
+              "Toutes les informations liées a l'environement du parking",
+          },
+        },
+      },
+    },
+  },
+};

--- a/tests/application/groups/index.ts
+++ b/tests/application/groups/index.ts
@@ -1,0 +1,1 @@
+export * from "./Parking";

--- a/tests/application/models.ts
+++ b/tests/application/models.ts
@@ -1,6 +1,7 @@
 import { DeviceManagerPlugin } from "../../index";
 import { Container, Warehouse, MagicHouse, Room, StreetLamp } from "./assets";
 import { DummyTemp, DummyTempPosition } from "./devices";
+import { Parking } from "./groups/Parking";
 import {
   Acceleration,
   Brightness,
@@ -29,6 +30,9 @@ const assetsModels = {
   air_quality: [Room],
   public_lighting: [StreetLamp],
 };
+const groupModels = {
+  air_quality: [Parking],
+};
 
 export function registerModels(deviceManager: DeviceManagerPlugin) {
   for (const model of measuresModels) {
@@ -42,6 +46,15 @@ export function registerModels(deviceManager: DeviceManagerPlugin) {
   for (const [engine, models] of Object.entries(assetsModels)) {
     for (const model of models) {
       deviceManager.models.registerAsset(
+        engine,
+        model.modelName,
+        model.definition,
+      );
+    }
+  }
+  for (const [engine, models] of Object.entries(groupModels)) {
+    for (const model of models) {
+      deviceManager.models.registerGroup(
         engine,
         model.modelName,
         model.definition,

--- a/tests/fixtures/assetsGroups.ts
+++ b/tests/fixtures/assetsGroups.ts
@@ -16,7 +16,14 @@ export const assetGroupTestBody: AssetsGroupsBody = {
   model: null,
   metadata: {},
 };
-
+export const assetGroupParking: AssetsGroupsBody = {
+  name: "Test group with parking model",
+  children: [],
+  lastUpdate: Date.now(),
+  parent: null,
+  model: "Parking",
+  metadata: {},
+};
 export const assetGroupTestParentBody1: AssetsGroupsBody = {
   name: "Test parent 1",
   children: [assetGroupTestChildrenId1],

--- a/tests/fixtures/assetsGroups.ts
+++ b/tests/fixtures/assetsGroups.ts
@@ -13,7 +13,8 @@ export const assetGroupTestBody: AssetsGroupsBody = {
   children: [],
   lastUpdate: Date.now(),
   parent: null,
-  type: null,
+  model: null,
+  metadata: {},
 };
 
 export const assetGroupTestParentBody1: AssetsGroupsBody = {
@@ -21,7 +22,8 @@ export const assetGroupTestParentBody1: AssetsGroupsBody = {
   children: [assetGroupTestChildrenId1],
   lastUpdate: Date.now(),
   parent: null,
-  type: "Type 1",
+  model: "Type 1",
+  metadata: {},
 };
 
 export const assetGroupTestParentBody2: AssetsGroupsBody = {
@@ -29,7 +31,8 @@ export const assetGroupTestParentBody2: AssetsGroupsBody = {
   children: [assetGroupTestChildrenId2],
   lastUpdate: Date.now(),
   parent: null,
-  type: null,
+  model: null,
+  metadata: {},
 };
 
 export const assetGroupTestChildrenBody1: AssetsGroupsBody = {
@@ -37,7 +40,8 @@ export const assetGroupTestChildrenBody1: AssetsGroupsBody = {
   children: [],
   lastUpdate: Date.now(),
   parent: assetGroupTestParentId1,
-  type: null,
+  model: null,
+  metadata: {},
 };
 
 export const assetGroupTestChildrenBody2: AssetsGroupsBody = {
@@ -45,7 +49,8 @@ export const assetGroupTestChildrenBody2: AssetsGroupsBody = {
   children: [],
   lastUpdate: Date.now(),
   parent: assetGroupTestParentId2,
-  type: "Type 2",
+  model: "Type 2",
+  metadata: {},
 };
 
 export const assetGroupParentWithAssetBody: AssetsGroupsBody = {
@@ -53,7 +58,8 @@ export const assetGroupParentWithAssetBody: AssetsGroupsBody = {
   children: [assetGroupChildrenWithAssetId],
   lastUpdate: Date.now(),
   parent: null,
-  type: null,
+  model: null,
+  metadata: {},
 };
 
 export const assetGroupChildrenWithAssetBody: AssetsGroupsBody = {
@@ -61,7 +67,8 @@ export const assetGroupChildrenWithAssetBody: AssetsGroupsBody = {
   children: [],
   lastUpdate: Date.now(),
   parent: assetGroupParentWithAssetId,
-  type: null,
+  model: null,
+  metadata: {},
 };
 
 export const assetGroupFixtures = {

--- a/tests/hooks/models.ts
+++ b/tests/hooks/models.ts
@@ -2,6 +2,7 @@ import { Kuzzle } from "kuzzle-sdk";
 import * as assets from "../application/assets";
 import * as devices from "../application/devices";
 import * as measures from "../application/measures";
+import * as groups from "../application/groups";
 
 // ? List of embedded measures register directly by plugin
 const embeddedMeasures = [
@@ -22,7 +23,9 @@ const devicesModels = Object.values(devices).map(
 const measuresModels = Object.values(measures).map(
   (model) => `model-measure-${model.modelName}`,
 );
-
+const groupModels = Object.values(groups).map(
+  (model) => `model-group-${model.modelName}`,
+);
 export async function deleteModels(sdk: Kuzzle) {
   // ? Exclude ids of models defined in code to remove all others, instead of use a hard coded list
   // * This avoids forgetting when adding measurements in the tests
@@ -31,6 +34,7 @@ export async function deleteModels(sdk: Kuzzle) {
     ...assetsModels,
     ...devicesModels,
     ...measuresModels,
+    ...groupModels,
   ];
 
   await sdk.collection.refresh("device-manager", "models");

--- a/tests/scenario/modules/assets/asset-group-permissions.test.ts
+++ b/tests/scenario/modules/assets/asset-group-permissions.test.ts
@@ -60,6 +60,7 @@ describe("AssetsGroupsController", () => {
       _id: "root-group",
       body: {
         name: "root group",
+        model: null,
       },
     });
 

--- a/tests/scenario/modules/assets/asset-group.test.ts
+++ b/tests/scenario/modules/assets/asset-group.test.ts
@@ -10,6 +10,7 @@ import {
   assetGroupTestParentId2,
   assetGroupChildrenWithAssetId,
   assetGroupParentWithAssetId,
+  assetGroupParking,
 } from "../../../fixtures/assetsGroups";
 
 // Lib
@@ -25,6 +26,7 @@ import {
   ApiGroupAddAssetsResult,
   ApiGroupRemoveAssetsRequest,
   ApiGroupRemoveAssetsResult,
+  ApiGroupUpdateResult,
 } from "../../../../lib/modules/asset/types/AssetGroupsApi";
 import {
   AssetContent,
@@ -57,7 +59,7 @@ describe("AssetsGroupsController", () => {
       body: {},
     };
     await expect(sdk.query(missingNameQuery)).rejects.toThrow(
-      /^A group must have a name$/,
+      'Missing argument "body.name".',
     );
 
     const badParentIdQuery: ApiGroupCreateRequest = {
@@ -318,7 +320,111 @@ describe("AssetsGroupsController", () => {
     });
     expect(resultChildren._source.lastUpdate).toBeGreaterThanOrEqual(now);
   });
+  it("can create a group with default metadata", async () => {
+    const { result: parkingGroup } = await sdk.query<
+      ApiGroupCreateRequest,
+      ApiGroupCreateResult
+    >({
+      controller: "device-manager/assetsGroup",
+      action: "create",
+      engineId: "engine-ayse",
+      body: assetGroupParking,
+    });
 
+    expect(parkingGroup._source.metadata).toMatchObject({
+      geolocation: {
+        lon: 3.8761,
+        lat: 43.6109,
+      },
+    });
+  });
+  it("can create a group with custom metadata", async () => {
+    const { result: parkingGroup } = await sdk.query<
+      ApiGroupCreateRequest,
+      ApiGroupCreateResult
+    >({
+      controller: "device-manager/assetsGroup",
+      action: "create",
+      engineId: "engine-ayse",
+      body: {
+        ...assetGroupParking,
+        metadata: { geolocation: { lon: 10, lat: 10 } },
+      },
+    });
+
+    expect(parkingGroup._source.metadata).toMatchObject({
+      geolocation: {
+        lon: 10,
+        lat: 10,
+      },
+    });
+  });
+
+  it("can create a group with defined metadata only", async () => {
+    const { result: parkingGroup } = await sdk.query<
+      ApiGroupCreateRequest,
+      ApiGroupCreateResult
+    >({
+      controller: "device-manager/assetsGroup",
+      action: "create",
+      engineId: "engine-ayse",
+      body: {
+        ...assetGroupParking,
+        metadata: {
+          geolocation: { lon: 10, lat: 10 },
+          randomMetadata: "wrongvalue",
+        },
+      },
+    });
+
+    expect(parkingGroup._source.metadata).not.toMatchObject({
+      geolocation: { lon: 10, lat: 10 },
+      randomMetadata: "wrongvalue",
+    });
+    expect(parkingGroup._source.metadata).toMatchObject({
+      geolocation: { lon: 10, lat: 10 },
+    });
+  });
+  it("can update a group with defined metadata only", async () => {
+    await sdk.query<ApiGroupCreateRequest, ApiGroupCreateResult>({
+      controller: "device-manager/assetsGroup",
+      action: "create",
+      engineId: "engine-ayse",
+      _id: "group-test-parking",
+      body: {
+        ...assetGroupParking,
+
+        metadata: {
+          geolocation: { lon: 10, lat: 10 },
+          randomMetadata: "wrongvalue",
+        },
+      },
+    });
+    const { result: parkingGroup } = await sdk.query<
+      ApiGroupUpdateRequest,
+      ApiGroupUpdateResult
+    >({
+      controller: "device-manager/assetsGroup",
+      action: "update",
+      engineId: "engine-ayse",
+      _id: "group-test-parking",
+
+      body: {
+        ...assetGroupParking,
+        metadata: {
+          geolocation: { lon: 9.47, lat: 43.05 },
+          randomMetadata: "wrongvalue",
+        },
+      },
+    });
+    expect(parkingGroup._source.metadata).not.toMatchObject({
+      geolocation: { lon: 9.47, lat: 43.05 },
+      randomMetadata: "wrongvalue",
+    });
+    expect(parkingGroup._source.metadata).toMatchObject({
+      geolocation: { lon: 9.47, lat: 43.05 },
+    });
+  });
   it("can delete a group", async () => {
     const missingIdQuery: Omit<ApiGroupDeleteRequest, "_id"> = {
       controller: "device-manager/assetsGroup",

--- a/tests/scenario/modules/assets/asset-group.test.ts
+++ b/tests/scenario/modules/assets/asset-group.test.ts
@@ -68,6 +68,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "Parent not exist",
         parent: "not-exist",
+        model: null,
       },
     };
     await expect(sdk.query(badParentIdQuery)).rejects.toThrow(
@@ -80,6 +81,7 @@ describe("AssetsGroupsController", () => {
       action: "create",
       body: {
         name: "test group",
+        model: null,
       },
     };
     await expect(sdk.query(duplicateGroupName)).rejects.toThrow(
@@ -93,6 +95,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "nested group",
         parent: assetGroupTestChildrenId1,
+        model: null,
       },
     };
     await expect(sdk.query(tooMuchNested)).rejects.toThrow(
@@ -109,6 +112,7 @@ describe("AssetsGroupsController", () => {
       _id: "root-group",
       body: {
         name: "root group",
+        model: null,
       },
     });
 
@@ -131,6 +135,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "children group",
         parent: "root-group",
+        model: null,
       },
     });
 
@@ -162,6 +167,7 @@ describe("AssetsGroupsController", () => {
       engineId: "engine-ayse",
       body: {
         name: "group",
+        model: null,
       },
     });
 
@@ -219,6 +225,7 @@ describe("AssetsGroupsController", () => {
         name: "root group",
         children: ["children-group"],
         parent: "not-exist",
+        model: null,
       },
     };
     await expect(sdk.query(badParentIdQuery)).rejects.toThrow(
@@ -233,6 +240,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "root group",
         children: [assetGroupTestChildrenId1, "not-exist"],
+        model: null,
       },
     };
     await expect(sdk.query(badChildrenIdQuery)).rejects.toThrow(
@@ -247,6 +255,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "test group",
         children: [],
+        model: null,
       },
     };
     await expect(sdk.query(duplicateGroupName)).rejects.toThrow(
@@ -262,6 +271,7 @@ describe("AssetsGroupsController", () => {
         name: "Test group",
         parent: assetGroupTestChildrenId1,
         children: [],
+        model: null,
       },
     };
     await expect(sdk.query(tooMuchNested)).rejects.toThrow(
@@ -276,6 +286,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "root group",
         children: [],
+        model: null,
       },
     });
 
@@ -295,6 +306,7 @@ describe("AssetsGroupsController", () => {
       body: {
         name: "root group",
         children: [assetGroupTestChildrenId1],
+        model: null,
       },
     });
 

--- a/tests/scenario/modules/models/group-model.test.ts
+++ b/tests/scenario/modules/models/group-model.test.ts
@@ -230,6 +230,7 @@ describe("ModelsController:groups", () => {
     const listGroups = await sdk.query<ApiModelListGroupsRequest>({
       controller: "device-manager/models",
       action: "listGroups",
+      engineGroup: "air_quality",
     });
     expect(listGroups.result).toMatchObject({
       total: 2,
@@ -340,6 +341,7 @@ describe("ModelsController:groups", () => {
     const searchDevices = await sdk.query<ApiModelSearchGroupsRequest>({
       controller: "device-manager/models",
       action: "searchGroups",
+      engineGroup: "air_quality",
       body: {
         query: {
           match: {

--- a/tests/scenario/modules/models/group-model.test.ts
+++ b/tests/scenario/modules/models/group-model.test.ts
@@ -1,0 +1,374 @@
+import {
+  ApiModelGetGroupRequest,
+  ApiModelListGroupsRequest,
+  ApiModelSearchGroupsRequest,
+  ApiModelWriteGroupRequest,
+} from "../../../../lib/modules/model";
+import { setupHooks } from "../../../helpers";
+
+jest.setTimeout(20000);
+
+describe("ModelsController:groups", () => {
+  const sdk = setupHooks();
+
+  it("Write and List a Group model", async () => {
+    await sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        engineGroup: "air_quality",
+        model: "TruckFleet",
+        metadataMappings: {
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description: "The number of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre de camions dans la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const groupModel1 = await sdk.document.get(
+      "device-manager",
+      "models",
+      "model-group-TruckFleet",
+    );
+    expect(groupModel1._source).toMatchObject({
+      type: "group",
+      engineGroup: "air_quality",
+      group: {
+        model: "TruckFleet",
+        metadataMappings: {
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description: "The number of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre de camions dans la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        engineGroup: "air_quality",
+        model: "TruckFleet",
+        metadataMappings: {
+          sector: { type: "keyword" },
+          zone: { type: "geo_shape" },
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          sector: {
+            group: "delimitation",
+            locales: {
+              en: {
+                friendlyName: "Geographic sector name",
+                description:
+                  "The name of the geographic sector of activity of the fleet",
+              },
+              fr: {
+                friendlyName: "Nom de la zone d'activité",
+                description:
+                  "Le nom de la  zone géographique d'activité de la zone",
+              },
+            },
+          },
+          zone: {
+            group: "delimitation",
+            locales: {
+              en: {
+                friendlyName: "Sector's GPS zone",
+                description: "The GPS delimitations of the sector of activity",
+              },
+              fr: {
+                friendlyName: "Zone géographique d'activité",
+                description: "Limites géographiques de la zone d'activité",
+              },
+            },
+          },
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description: "The number of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre de camions dans la flotte",
+              },
+            },
+          },
+        },
+        metadataGroups: {
+          delimitation: {
+            locales: {
+              en: {
+                groupFriendlyName: "Delimitations",
+                description: "The limits of the fleet's activity zone",
+              },
+              fr: {
+                groupFriendlyName: "Limites géographiques",
+                description: "Les limites de la zone d'activité de la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const groupModel2 = await sdk.document.get(
+      "device-manager",
+      "models",
+      "model-group-TruckFleet",
+    );
+    expect(groupModel2._source).toMatchObject({
+      type: "group",
+      engineGroup: "air_quality",
+      group: {
+        model: "TruckFleet",
+        metadataMappings: {
+          sector: { type: "keyword" },
+          zone: { type: "geo_shape" },
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          sector: {
+            group: "delimitation",
+            locales: {
+              en: {
+                friendlyName: "Geographic sector name",
+                description:
+                  "The name of the geographic sector of activity of the fleet",
+              },
+              fr: {
+                friendlyName: "Nom de la zone d'activité",
+                description:
+                  "Le nom de la  zone géographique d'activité de la zone",
+              },
+            },
+          },
+          zone: {
+            group: "delimitation",
+            locales: {
+              en: {
+                friendlyName: "Sector's GPS zone",
+                description: "The GPS delimitations of the sector of activity",
+              },
+              fr: {
+                friendlyName: "Zone géographique d'activité",
+                description: "Limites géographiques de la zone d'activité",
+              },
+            },
+          },
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description: "The number of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre de camions dans la flotte",
+              },
+            },
+          },
+        },
+        metadataGroups: {
+          delimitation: {
+            locales: {
+              en: {
+                groupFriendlyName: "Delimitations",
+                description: "The limits of the fleet's activity zone",
+              },
+              fr: {
+                groupFriendlyName: "Limites géographiques",
+                description: "Les limites de la zone d'activité de la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const tenantGroupMapping = await sdk.collection.getMapping(
+      "engine-ayse",
+      "assets-groups",
+    );
+    expect(tenantGroupMapping.properties).toMatchObject({
+      metadata: {
+        properties: {
+          sector: { type: "keyword" },
+          zone: { type: "geo_shape" },
+          size: { type: "integer" },
+        },
+      },
+    });
+    const listGroups = await sdk.query<ApiModelListGroupsRequest>({
+      controller: "device-manager/models",
+      action: "listGroups",
+    });
+    expect(listGroups.result).toMatchObject({
+      total: 2,
+      models: [
+        { _id: "model-group-Parking" },
+        { _id: "model-group-TruckFleet" },
+      ],
+    });
+
+    const getGroup = await sdk.query<ApiModelGetGroupRequest>({
+      controller: "device-manager/models",
+      action: "getGroup",
+      model: "TruckFleet",
+    });
+
+    expect(getGroup.result).toMatchObject({
+      _id: "model-group-TruckFleet",
+      _source: { group: { model: "TruckFleet" } },
+    });
+  });
+
+  it("Write and Search a group model", async () => {
+    await sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        engineGroup: "air_quality",
+        model: "TruckFleet",
+        metadataMappings: {
+          sector: { type: "keyword" },
+          zone: { type: "geo_shape" },
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          sector: {
+            group: "delimitation",
+            locales: {
+              en: {
+                friendlyName: "Geographic sector name",
+                description:
+                  "The name of the geographic sector of activity of the fleet",
+              },
+              fr: {
+                friendlyName: "Nom de la zone d'activité",
+                description:
+                  "Le nom de la  zone géographique d'activité de la zone",
+              },
+            },
+          },
+          zone: {
+            group: "delimitation",
+            locales: {
+              en: {
+                friendlyName: "Sector's GPS zone",
+                description: "The GPS delimitations of the sector of activity",
+              },
+              fr: {
+                friendlyName: "Zone géographique d'activité",
+                description: "Limites géographiques de la zone d'activité",
+              },
+            },
+          },
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description: "The number of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre de camions dans la flotte",
+              },
+            },
+          },
+        },
+        metadataGroups: {
+          delimitation: {
+            locales: {
+              en: {
+                groupFriendlyName: "Delimitations",
+                description: "The limits of the fleet's activity zone",
+              },
+              fr: {
+                groupFriendlyName: "Limites géographiques",
+                description: "Les limites de la zone d'activité de la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        engineGroup: "air_quality",
+        model: "Building",
+        metadataMappings: {
+          location: { type: "geo_point" },
+          floors: { type: "integer" },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const searchDevices = await sdk.query<ApiModelSearchGroupsRequest>({
+      controller: "device-manager/models",
+      action: "searchGroups",
+      body: {
+        query: {
+          match: {
+            "group.model": "TruckFleet",
+          },
+        },
+      },
+    });
+
+    expect(searchDevices.result).toMatchObject({
+      total: 1,
+      hits: [{ _id: "model-group-TruckFleet" }],
+    });
+  });
+
+  it("Error if the model name is not PascalCase", async () => {
+    const badModelName = sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        engineGroup: "commons",
+        model: "flatgroupnape",
+        metadataMappings: { size: { type: "integer" } },
+        defaultValues: { size: 12 },
+      },
+    });
+
+    await expect(badModelName).rejects.toMatchObject({
+      message: 'Group model "flatgroupnape" must be PascalCase.',
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do ?
This PR adds the possibility to create group models fro asset groups and define metadatas, metadataDetails, defaultValues and tooltipModels.

### How should this be manually tested?

  - Step 1 : Create a group model with metadatas and default values using the api/action 
`{
  "controller": "device-manager/models",
  "action": "writeGroup",
}`
  - Step 2 : Create an assetGroup specifying the model you previously created
  - Step 3 : Verify that the default values for metadatas have been created
  - Step 4 : Update the assetGroup and try changing the value of the metadataFields

[KZLPRD-751]


[KZLPRD-751]: https://kuzzle.atlassian.net/browse/KZLPRD-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ