### PR TITLE
fix(assetsGroups roles): add missing actions from group models

### DIFF
--- a/lib/modules/asset/roles/RoleAssetsGroupsAdmin.ts
+++ b/lib/modules/asset/roles/RoleAssetsGroupsAdmin.ts
@@ -31,6 +31,12 @@ export const RoleAssetsGroupsAdmin: KuzzleRole = {
           "*": true,
         },
       },
+      "device-manager/models": {
+        actions: {
+          listGroups: true,
+          getGroup: true,
+        },
+      },
     },
   },
 };

--- a/lib/modules/asset/roles/RoleAssetsGroupsReader.ts
+++ b/lib/modules/asset/roles/RoleAssetsGroupsReader.ts
@@ -32,6 +32,12 @@ export const RoleAssetsGroupsReader: KuzzleRole = {
           search: true,
         },
       },
+      "device-manager/models": {
+        actions: {
+          listGroups: true,
+          getGroup: true,
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
This PR adds following actions to `RoleAssetsGroupsAdmin` and `RoleAssetsGroupsReader`
``` ts
      "device-manager/models": {
        actions: {
          listGroups: true,
          getGroup: true,
        },
      },
```