### PR TITLE
feat(assetsGroups): add service to handle group logic

### DIFF
--- a/lib/modules/asset/AssetModule.ts
+++ b/lib/modules/asset/AssetModule.ts
@@ -9,18 +9,24 @@ import { RoleAssetsReader } from "./roles/RoleAssetsReader";
 import { RoleAssetsGroupsAdmin } from "./roles/RoleAssetsGroupsAdmin";
 import { RoleAssetsGroupsReader } from "./roles/RoleAssetsGroupsReader";
 import * as specificRoles from "./roles/specificRoles";
+import { AssetsGroupsService } from "./AssetsGroupsService";
 
 export class AssetModule extends Module {
   private assetService: AssetService;
   private assetHistoryService: AssetHistoryService;
   private assetController: AssetsController;
   private assetGroupsController: AssetsGroupsController;
+  private assetsGroupsService: AssetsGroupsService;
 
   public async init(): Promise<void> {
     this.assetHistoryService = new AssetHistoryService(this.plugin);
     this.assetService = new AssetService(this.plugin, this.assetHistoryService);
     this.assetController = new AssetsController(this.plugin, this.assetService);
-    this.assetGroupsController = new AssetsGroupsController(this.plugin);
+    this.assetsGroupsService = new AssetsGroupsService(this.plugin);
+    this.assetGroupsController = new AssetsGroupsController(
+      this.plugin,
+      this.assetsGroupsService,
+    );
 
     this.plugin.api["device-manager/assetsGroup"] =
       this.assetGroupsController.definition;

--- a/lib/modules/asset/AssetsGroupsController.ts
+++ b/lib/modules/asset/AssetsGroupsController.ts
@@ -9,11 +9,7 @@ import {
 import { ask } from "kuzzle-plugin-commons";
 
 import { DeviceManagerPlugin, InternalCollection } from "../plugin";
-import { AssetContent } from "./exports";
-import {
-  AssetsGroupContent,
-  AssetsGroupsBody,
-} from "./types/AssetGroupContent";
+import { AssetsGroupContent } from "./types/AssetGroupContent";
 import {
   ApiGroupAddAssetsRequest,
   ApiGroupAddAssetsResult,
@@ -27,11 +23,15 @@ import {
   AssetsGroupsBodyRequest,
 } from "./types/AssetGroupsApi";
 import { AskModelGroupGet } from "../model";
+import { AssetsGroupsService } from "./AssetsGroupsService";
 
 export class AssetsGroupsController {
   definition: ControllerDefinition;
 
-  constructor(private plugin: DeviceManagerPlugin) {
+  constructor(
+    private plugin: DeviceManagerPlugin,
+    private assetsGroupsService: AssetsGroupsService,
+  ) {
     /* eslint-disable sort-keys */
     this.definition = {
       actions: {
@@ -229,61 +229,17 @@ export class AssetsGroupsController {
     });
 
     await this.checkGroupName(engineId, name);
-
     if (parent !== null) {
       await this.checkParent(engineId, parent);
-      const parentGroup = await this.sdk.document.get<AssetsGroupsBody>(
-        engineId,
-        InternalCollection.ASSETS_GROUPS,
-        parent,
-      );
-
-      const children = parentGroup._source.children ?? [];
-      children.push(_id);
-
-      await this.sdk.document.update<AssetsGroupsBody>(
-        engineId,
-        InternalCollection.ASSETS_GROUPS,
-        parent,
-        {
-          children,
-          lastUpdate: Date.now(),
-        },
-      );
     }
-
-    const groupMetadata = {};
-
-    if (model !== null) {
-      const groupModel = await ask<AskModelGroupGet>(
-        "ask:device-manager:model:group:get",
-        { model },
-      );
-      for (const metadataName of Object.keys(
-        groupModel.group.metadataMappings,
-      )) {
-        if (metadata[metadataName]) {
-          groupMetadata[metadataName] = metadata[metadataName];
-        } else if (groupModel.group.defaultMetadata[metadataName]) {
-          groupMetadata[metadataName] =
-            groupModel.group.defaultMetadata[metadataName];
-        } else {
-          groupMetadata[metadataName] = null;
-        }
-      }
-    }
-    return this.as(request.getUser()).document.create<AssetsGroupsBody>(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      {
-        children: [],
-        lastUpdate: Date.now(),
-        metadata: { ...groupMetadata },
-        model,
-        name,
-        parent,
-      },
+    return this.assetsGroupsService.create(
       _id,
+      engineId,
+      metadata,
+      model,
+      name,
+      parent,
+      request,
     );
   }
 
@@ -291,11 +247,7 @@ export class AssetsGroupsController {
     const engineId = request.getString("engineId");
     const _id = request.getId();
 
-    return this.as(request.getUser()).document.get<AssetsGroupsBody>(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      _id,
-    );
+    return this.assetsGroupsService.get(engineId, _id, request);
   }
 
   async update(request: KuzzleRequest): Promise<ApiGroupUpdateResult> {
@@ -340,174 +292,33 @@ export class AssetsGroupsController {
       }
     }
     updateRequestBody = { ...updateRequestBody, lastUpdate: Date.now() };
-    return this.as(request.getUser()).document.update<AssetsGroupsBody>(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
+    return this.assetsGroupsService.update(
+      request,
       _id,
+      engineId,
       updateRequestBody,
-      { source: true },
     );
   }
 
   async delete(request: KuzzleRequest): Promise<ApiGroupDeleteResult> {
     const engineId = request.getString("engineId");
     const _id = request.getId();
-
-    const { _source: assetGroup } =
-      await this.sdk.document.get<AssetsGroupsBody>(
-        engineId,
-        InternalCollection.ASSETS_GROUPS,
-        _id,
-      );
-
-    if (assetGroup.parent !== null) {
-      const { _source: parentGroup } =
-        await this.sdk.document.get<AssetsGroupsBody>(
-          engineId,
-          InternalCollection.ASSETS_GROUPS,
-          assetGroup.parent,
-        );
-      await this.sdk.document.update(
-        engineId,
-        InternalCollection.ASSETS_GROUPS,
-        assetGroup.parent,
-        {
-          children: parentGroup.children.filter((children) => children !== _id),
-          lastUpdate: Date.now(),
-        },
-      );
-    }
-
-    await this.sdk.document.mUpdate(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      assetGroup.children.map((childrenId) => ({
-        _id: childrenId,
-        body: {
-          lastUpdate: Date.now(),
-          parent: null,
-        },
-      })),
-      { strict: true },
-    );
-
-    const { hits: assets } = await this.sdk.document.search<AssetContent>(
-      engineId,
-      InternalCollection.ASSETS,
-      { query: { equals: { "groups.id": _id } } },
-      { lang: "koncorde" },
-    );
-
-    await this.sdk.document.mUpdate(
-      engineId,
-      InternalCollection.ASSETS,
-      assets.map((asset) => ({
-        _id: asset._id,
-        body: {
-          groups: asset._source.groups.filter(
-            ({ id: groupId }) => groupId !== _id,
-          ),
-        },
-      })),
-      { strict: true },
-    );
-
-    await this.as(request.getUser()).document.delete(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      _id,
-    );
+    await this.assetsGroupsService.delete(_id, engineId, request);
   }
 
   async search(request: KuzzleRequest): Promise<ApiGroupSearchResult> {
     const engineId = request.getString("engineId");
-    const {
-      searchBody,
-      from,
-      size,
-      scrollTTL: scroll,
-    } = request.getSearchParams();
-    const lang = request.getLangParam();
+    const searchParams = request.getSearchParams();
 
-    return this.as(request.getUser()).document.search<AssetsGroupContent>(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      searchBody,
-      {
-        from,
-        lang,
-        scroll,
-        size,
-      },
-    );
+    return this.assetsGroupsService.search(engineId, searchParams, request);
   }
 
   async addAsset(request: KuzzleRequest): Promise<ApiGroupAddAssetsResult> {
     const engineId = request.getString("engineId");
     const _id = request.getId();
     const body = request.getBody() as ApiGroupAddAssetsRequest["body"];
-
-    // ? Get document to check if really exists, even if not indexed
-    const assetGroup = await this.sdk.document.get<AssetsGroupContent>(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      _id,
-    );
-
-    const assets = [];
-    for (const assetId of body.assetIds) {
-      const assetContent = (
-        await this.sdk.document.get(
-          engineId,
-          InternalCollection.ASSETS,
-          assetId,
-        )
-      )._source;
-
-      if (!Array.isArray(assetContent.groups)) {
-        assetContent.groups = [];
-      }
-
-      if (assetGroup._source.parent !== null) {
-        assetContent.groups.push({
-          date: Date.now(),
-          id: assetGroup._source.parent,
-        });
-      }
-
-      assetContent.groups.push({
-        date: Date.now(),
-        id: _id,
-      });
-
-      assets.push({
-        _id: assetId,
-        body: assetContent,
-      });
-    }
-
-    const assetsGroupsUpdate = await this.as(
-      request.getUser(),
-    ).document.update<AssetsGroupsBody>(
-      engineId,
-      InternalCollection.ASSETS_GROUPS,
-      _id,
-      {
-        lastUpdate: Date.now(),
-      },
-      { source: true },
-    );
-
-    const update = await this.sdk.document.mReplace(
-      engineId,
-      InternalCollection.ASSETS,
-      assets,
-    );
-
-    return {
-      ...update,
-      assetsGroups: assetsGroupsUpdate,
-    };
+    const assetIds = body.assetIds;
+    return this.assetsGroupsService.addAsset(engineId, _id, assetIds, request);
   }
 
   async removeAsset(
@@ -517,62 +328,11 @@ export class AssetsGroupsController {
     const _id = request.getId();
     const body = request.getBody() as ApiGroupRemoveAssetsRequest["body"];
 
-    // ? Get document to check if really exists, even if not indexed
-    const { _source: AssetGroupContent } =
-      await this.sdk.document.get<AssetsGroupContent>(
-        engineId,
-        InternalCollection.ASSETS_GROUPS,
-        _id,
-      );
-
-    const removedGroups = AssetGroupContent.children;
-    removedGroups.push(_id);
-
-    const assets = [];
-    for (const assetId of body.assetIds) {
-      const assetContent = (
-        await this.sdk.document.get<AssetContent>(
-          engineId,
-          InternalCollection.ASSETS,
-          assetId,
-        )
-      )._source;
-
-      if (!Array.isArray(assetContent.groups)) {
-        continue;
-      }
-
-      assetContent.groups = assetContent.groups.filter(
-        ({ id: groupId }) => !removedGroups.includes(groupId),
-      );
-
-      assets.push({
-        _id: assetId,
-        body: assetContent,
-      });
-    }
-
-    const assetsGroupsUpdate = await this.as(
-      request.getUser(),
-    ).document.update<AssetsGroupsBody>(
+    return this.assetsGroupsService.removeAsset(
       engineId,
-      InternalCollection.ASSETS_GROUPS,
       _id,
-      {
-        lastUpdate: Date.now(),
-      },
-      { source: true },
+      body.assetIds,
+      request,
     );
-
-    const update = await this.sdk.document.mReplace(
-      engineId,
-      InternalCollection.ASSETS,
-      assets,
-    );
-
-    return {
-      ...update,
-      assetsGroups: assetsGroupsUpdate,
-    };
   }
 }

--- a/lib/modules/asset/AssetsGroupsService.ts
+++ b/lib/modules/asset/AssetsGroupsService.ts
@@ -1,0 +1,283 @@
+import { JSONObject, KDocument } from "kuzzle-sdk";
+import { DeviceManagerPlugin, InternalCollection } from "../plugin";
+import { BaseService, SearchParams } from "../shared";
+import { KuzzleRequest } from "kuzzle";
+import {
+  AssetsGroupContent,
+  AssetsGroupsBody,
+} from "./types/AssetGroupContent";
+import { AskModelGroupGet } from "../model";
+import { ask } from "kuzzle-plugin-commons";
+import { AssetContent } from "./types/AssetContent";
+
+export class AssetsGroupsService extends BaseService {
+  constructor(plugin: DeviceManagerPlugin) {
+    super(plugin);
+  }
+
+  async create(
+    _id: string,
+    engineId: string,
+    metadata: JSONObject,
+    model: string,
+    name: string,
+    parent: string | null,
+    request: KuzzleRequest,
+  ): Promise<KDocument<AssetsGroupContent>> {
+    if (parent !== null) {
+      const parentGroup = await this.sdk.document.get<AssetsGroupsBody>(
+        engineId,
+        InternalCollection.ASSETS_GROUPS,
+        parent,
+      );
+
+      const children = parentGroup._source.children ?? [];
+      children.push(_id);
+
+      await this.sdk.document.update<AssetsGroupsBody>(
+        engineId,
+        InternalCollection.ASSETS_GROUPS,
+        parent,
+        {
+          children,
+          lastUpdate: Date.now(),
+        },
+      );
+    }
+
+    const groupMetadata = {};
+
+    if (model !== null) {
+      const groupModel = await ask<AskModelGroupGet>(
+        "ask:device-manager:model:group:get",
+        { model },
+      );
+      for (const metadataName of Object.keys(
+        groupModel.group.metadataMappings,
+      )) {
+        if (metadata[metadataName]) {
+          groupMetadata[metadataName] = metadata[metadataName];
+        } else if (groupModel.group.defaultMetadata[metadataName]) {
+          groupMetadata[metadataName] =
+            groupModel.group.defaultMetadata[metadataName];
+        } else {
+          groupMetadata[metadataName] = null;
+        }
+      }
+    }
+    const group: KDocument<AssetsGroupContent> = {
+      _id,
+      _source: {
+        children: [],
+        lastUpdate: Date.now(),
+        metadata: { ...groupMetadata },
+        model,
+        name,
+        parent,
+      },
+    };
+    return this.createDocument<AssetsGroupContent>(request, group, {
+      collection: InternalCollection.ASSETS_GROUPS,
+      engineId,
+    });
+  }
+
+  async get(engineId: string, _id: string, request: KuzzleRequest) {
+    return this.getDocument<AssetsGroupContent>(request, _id, {
+      collection: InternalCollection.ASSETS_GROUPS,
+      engineId,
+    });
+  }
+
+  async update(
+    request: KuzzleRequest,
+    _id: string,
+    engineId: string,
+    updateContent: JSONObject,
+  ) {
+    const updatedGroup = await this.updateDocument<AssetsGroupContent>(
+      request,
+      {
+        _id,
+        _source: updateContent,
+      },
+      { collection: InternalCollection.ASSETS_GROUPS, engineId },
+      { source: true, triggerEvents: true },
+    );
+
+    return updatedGroup;
+  }
+  async delete(_id: string, engineId: string, request: KuzzleRequest) {
+    const { _source: assetGroup } = await this.get(engineId, _id, request);
+
+    if (assetGroup.parent !== null) {
+      const { _source: parentGroup } = await this.get(
+        engineId,
+        assetGroup.parent,
+        request,
+      );
+      await this.update(request, assetGroup.parent, engineId, {
+        children: parentGroup.children.filter((children) => children !== _id),
+        lastUpdate: Date.now(),
+      });
+    }
+
+    await this.sdk.document.mUpdate(
+      engineId,
+      InternalCollection.ASSETS_GROUPS,
+      assetGroup.children.map((childrenId) => ({
+        _id: childrenId,
+        body: {
+          lastUpdate: Date.now(),
+          parent: null,
+        },
+      })),
+      { strict: true },
+    );
+
+    const { hits: assets } = await this.sdk.document.search<AssetContent>(
+      engineId,
+      InternalCollection.ASSETS,
+      { query: { equals: { "groups.id": _id } } },
+      { lang: "koncorde" },
+    );
+
+    await this.sdk.document.mUpdate(
+      engineId,
+      InternalCollection.ASSETS,
+      assets.map((asset) => ({
+        _id: asset._id,
+        body: {
+          groups: asset._source.groups.filter(
+            ({ id: groupId }) => groupId !== _id,
+          ),
+        },
+      })),
+      { strict: true },
+    );
+
+    return this.deleteDocument(request, _id, {
+      collection: InternalCollection.ASSETS_GROUPS,
+      engineId,
+    });
+  }
+  async search(
+    engineId: string,
+    searchParams: SearchParams,
+    request: KuzzleRequest,
+  ) {
+    return this.searchDocument<AssetsGroupContent>(request, searchParams, {
+      collection: InternalCollection.ASSETS_GROUPS,
+      engineId,
+    });
+  }
+  async addAsset(
+    engineId: string,
+    _id: string,
+    assetIds: string[],
+    request: KuzzleRequest,
+  ) {
+    const assetGroup = await this.get(engineId, _id, request);
+
+    const assets = [];
+    for (const assetId of assetIds) {
+      const assetContent = (
+        await this.getDocument<AssetContent>(request, assetId, {
+          collection: InternalCollection.ASSETS,
+          engineId,
+        })
+      )._source;
+
+      if (!Array.isArray(assetContent.groups)) {
+        assetContent.groups = [];
+      }
+
+      if (assetGroup._source.parent !== null) {
+        assetContent.groups.push({
+          date: Date.now(),
+          id: assetGroup._source.parent,
+        });
+      }
+
+      assetContent.groups.push({
+        date: Date.now(),
+        id: _id,
+      });
+
+      assets.push({
+        _id: assetId,
+        body: assetContent,
+      });
+    }
+
+    const assetsGroupsUpdate = await this.update(request, _id, engineId, {
+      lastUpdate: Date.now(),
+    });
+
+    const update = await this.sdk.document.mReplace(
+      engineId,
+      InternalCollection.ASSETS,
+      assets,
+      { triggerEvents: true },
+    );
+
+    return {
+      ...update,
+      assetsGroups: assetsGroupsUpdate,
+    };
+  }
+  async removeAsset(
+    engineId: string,
+    _id: string,
+    assetIds: string[],
+    request: KuzzleRequest,
+  ) {
+    const { _source: AssetGroupContent } = await this.get(
+      engineId,
+      _id,
+      request,
+    );
+
+    const removedGroups = AssetGroupContent.children;
+    removedGroups.push(_id);
+
+    const assets = [];
+    for (const assetId of assetIds) {
+      const assetContent = (
+        await this.getDocument<AssetContent>(request, assetId, {
+          collection: InternalCollection.ASSETS,
+          engineId,
+        })
+      )._source;
+
+      if (!Array.isArray(assetContent.groups)) {
+        continue;
+      }
+
+      assetContent.groups = assetContent.groups.filter(
+        ({ id: groupId }) => !removedGroups.includes(groupId),
+      );
+
+      assets.push({
+        _id: assetId,
+        body: assetContent,
+      });
+    }
+
+    const assetsGroupsUpdate = await this.update(request, _id, engineId, {
+      lastUpdate: Date.now(),
+    });
+
+    const update = await this.sdk.document.mReplace(
+      engineId,
+      InternalCollection.ASSETS,
+      assets,
+      { triggerEvents: true },
+    );
+
+    return {
+      ...update,
+      assetsGroups: assetsGroupsUpdate,
+    };
+  }
+}


### PR DESCRIPTION
## What does this PR do ?
This Pr adds an `assetsGroupsService` to handle group logic.
This allows more consistency with device and assets services and permit the use of base service methods allowing for pipes to b