### PR TITLE
fix: assets and devices engine collections names

### DIFF
--- a/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -52,8 +52,7 @@ export type DeviceManagerConfiguration = {
       mappings: JSONObject;
       settings?: JSONObject;
     };
-    // ! TODO next major release: pluralize the collection name
-    asset: {
+    assets: {
       name: string;
       mappings: CollectionMappings;
       settings?: JSONObject;
@@ -66,8 +65,7 @@ export type DeviceManagerConfiguration = {
       name: string;
       settings?: JSONObject;
     };
-    // ! TODO next major release: pluralize the collection name
-    device: {
+    devices: {
       name: string;
       mappings: CollectionMappings;
       settings?: JSONObject;


### PR DESCRIPTION
TODO KZLPRD-822 migration guide for this change