### PR TITLE
fix(assetModels): error on create asset model with commons engine

### DIFF
--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -1,5 +1,5 @@
 import { BadRequestError, KuzzleRequest, PartialError, User } from "kuzzle";
-import { ask, EngineContent, onAsk } from "kuzzle-plugin-commons";
+import { ask, onAsk } from "kuzzle-plugin-commons";
 import {
   BaseRequest,
   DocumentSearchResult,

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -722,17 +722,12 @@ export class AssetService extends DigitalTwinService {
   }: {
     assetModel: AssetModelContent;
   }): Promise<void> {
-    let engines: EngineContent[];
     // For engine group 'commons', fetch all engines
-    if (assetModel.engineGroup === "commons") {
-      engines = await ask<AskEngineList>("ask:device-manager:engine:list", {
-        group: null,
-      });
-    } else {
-      engines = await ask<AskEngineList>("ask:device-manager:engine:list", {
-        group: assetModel.engineGroup,
-      });
-    }
+    const engines = await ask<AskEngineList>("ask:device-manager:engine:list", {
+      group:
+        assetModel.engineGroup === "commons" ? null : assetModel.engineGroup,
+    });
+
     const targets = engines.map((engine) => ({
       collections: [InternalCollection.ASSETS],
       index: engine.index,


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the issue on the creation of asset models with the engine group 'commons'.
The model was created but the client receives a 400 error.

The issue was that after creating/updating an asset model we then fetch the assets from this model in the different engine to update them.

In case of commons engine group we must do this for every engine. If no engine is present we don't need to throw an error.

### How should this be manually tested?

Create an asset model with common engine, check that there are no errors
Create an asset of this model in 2 different engines
Recreate the model with an additional metadata field
Check that your assets have been updated accordingly

