### PR TITLE
fix(plugin exports): export pipe event for DocumentBefore/Aftersearch

### DIFF
--- a/lib/modules/plugin/types/exports.ts
+++ b/lib/modules/plugin/types/exports.ts
@@ -1,1 +1,2 @@
 export * from "./DeviceManagerConfiguration";
+export * from "./Pipes";


### PR DESCRIPTION
## What does this PR do ?
This PR adds the pipe events `DocumentBeforeSearch` and `DocumentAfterSearch` to the exports.
