### PR TITLE
feat(decoder): warn no measures instead of throwing error

### DIFF
--- a/lib/modules/decoder/DecodersRegister.ts
+++ b/lib/modules/decoder/DecodersRegister.ts
@@ -66,8 +66,8 @@ export class DecodersRegister {
     decoder.action = decoder.action || Inflector.kebabCase(decoder.deviceModel);
 
     if (decoder.measures.length === 0) {
-      throw new PluginImplementationError(
-        `Decoder "${decoder.deviceModel}" did not declare any measures in the "decoder.measures" property.`,
+      this.context.log.warn(
+        `Decoder "${decoder.deviceModel}" did not declare any measures in the "decoder.measures" property, no payload will be ingested`,
       );
     }
 

--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -82,7 +82,11 @@ export class PayloadService extends BaseService {
     decodedPayload = await decoder.decode(decodedPayload, payload, request);
 
     if (decodedPayload.references.length === 0) {
-      throw new BadRequestError("No measurement has been decoded");
+      this.app.log.warn(
+        `No measurement has been decoded for device model "${decoder.deviceModel}", skipping ingestion`,
+      );
+
+      return { valid };
     }
 
     const devices = await this.retrieveDevices(


### PR DESCRIPTION
## What does this PR do ?
This PR removes a behavior from the decoder module, without measures, it was throwing and stopping Kuzzle from starting. This behavior is also seen in the `decodedPayload`, an ingestion can not happen without an `addMeasurement`