### PR TITLE
feat(group):Allow devices group and add groupModel affinity

### DIFF
--- a/lib/modules/asset/types/AssetContent.ts
+++ b/lib/modules/asset/types/AssetContent.ts
@@ -32,7 +32,7 @@ export interface AssetContent<
     measureNames: Array<{ asset: string; device: string; type: string }>;
   }>;
   /**
-   * Id's of asset groups
+   * Path's of asset groups
    */
   groups: Array<{
     path: string;

--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -321,6 +321,7 @@ export class PayloadService extends BaseService {
       const body: DeviceContent = {
         assetId: null,
         engineId: null,
+        groups: [],
         lastMeasuredAt: 0,
         measureSlots: deviceModelContent.device.measures,
         measures: {},

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -110,6 +110,7 @@ export class DeviceService extends DigitalTwinService {
       _source: {
         assetId: null,
         engineId: null,
+        groups: [],
         lastMeasuredAt: 0,
         measureSlots: [],
         measures: {},

--- a/lib/modules/device/collections/deviceMappings.ts
+++ b/lib/modules/device/collections/deviceMappings.ts
@@ -12,6 +12,15 @@ export const devicesMappings: CollectionMappings = {
       type: "keyword",
       fields: { text: { type: "text" } },
     },
+    groups: {
+      properties: {
+        path: {
+          type: "keyword",
+          fields: { text: { type: "text" } },
+        },
+        date: { type: "date" },
+      },
+    },
     reference: {
       type: "keyword",
       fields: { text: { type: "text" } },

--- a/lib/modules/device/types/DeviceContent.ts
+++ b/lib/modules/device/types/DeviceContent.ts
@@ -17,4 +17,11 @@ export interface DeviceContent<
   /**
    */
   engineId: string;
+  /**
+   * Path's of device's groups
+   */
+  groups: Array<{
+    path: string;
+    date: number;
+  }>;
 }

--- a/lib/modules/group/GroupsService.ts
+++ b/lib/modules/group/GroupsService.ts
@@ -181,13 +181,6 @@ export class GroupsService extends BaseService {
     if (!group) {
       throw new BadRequestError(`The group with _id "${_id}" does not exist`);
     }
-    /*     let model: GroupModelContent;
-    if (group._source.model) {
-      model = await ask<AskModelGroupGet>(
-        "ask:device-manager:model:group:get",
-        { model: group._source.model },
-      );
-    } */
     const body = includeChildren
       ? {
           query: {
@@ -205,21 +198,23 @@ export class GroupsService extends BaseService {
             },
           },
         };
-    const { hits: assetHits } = await this.sdk.document.search<AssetContent>(
-      engineId,
-      InternalCollection.ASSETS,
-      body,
-      options,
-    );
-    const { hits: deviceHits } = await this.sdk.document.search<DeviceContent>(
-      engineId,
-      InternalCollection.DEVICES,
-      body,
-      options,
-    );
+    const { hits: assetHits, total: assetTotal } =
+      await this.sdk.document.search<AssetContent>(
+        engineId,
+        InternalCollection.ASSETS,
+        body,
+        options,
+      );
+    const { hits: deviceHits, total: deviceTotal } =
+      await this.sdk.document.search<DeviceContent>(
+        engineId,
+        InternalCollection.DEVICES,
+        body,
+        options,
+      );
     return {
-      assets: assetHits,
-      devices: deviceHits,
+      assets: { hits: assetHits, total: assetTotal },
+      devices: { hits: deviceHits, total: deviceTotal },
     };
   }
 

--- a/lib/modules/group/types/GroupsApi.ts
+++ b/lib/modules/group/types/GroupsApi.ts
@@ -67,10 +67,11 @@ export interface ApiGroupListItemsRequest extends GroupControllerRequest {
   from?: number;
   size?: number;
   body: { includeChildren?: boolean };
+  _id: string;
 }
 export type ApiGroupListItemsResult = {
-  assets: Array<KHit<AssetContent>>;
-  devices: Array<KHit<DeviceContent>>;
+  assets: { hits: Array<KHit<AssetContent>>; total: number };
+  devices: { hits: Array<KHit<DeviceContent>>; total: number };
 };
 
 export interface ApiGroupAddAssetsRequest extends GroupControllerRequest {

--- a/lib/modules/group/types/GroupsApi.ts
+++ b/lib/modules/group/types/GroupsApi.ts
@@ -6,6 +6,8 @@ import {
   mUpdateResponse,
 } from "kuzzle-sdk";
 import { GroupsBody, GroupContent } from "./GroupContent";
+import { DeviceContent } from "lib/modules/device";
+import { AssetContent } from "lib/modules/asset";
 
 // Remove "lastUpdate" property for request
 type GroupsRequest = Omit<GroupsBody, "lastUpdate">;
@@ -59,6 +61,17 @@ export interface ApiGroupSearchRequest extends GroupControllerRequest {
   body: JSONObject;
 }
 export type ApiGroupSearchResult = SearchResult<KHit<GroupContent>>;
+
+export interface ApiGroupListItemsRequest extends GroupControllerRequest {
+  action: "listItems";
+  from?: number;
+  size?: number;
+  body: { includeChildren?: boolean };
+}
+export type ApiGroupListItemsResult = {
+  assets: Array<KHit<AssetContent>>;
+  devices: Array<KHit<DeviceContent>>;
+};
 
 export interface ApiGroupAddAssetsRequest extends GroupControllerRequest {
   action: "addAsset";

--- a/lib/modules/group/types/GroupsApi.ts
+++ b/lib/modules/group/types/GroupsApi.ts
@@ -11,7 +11,7 @@ import { GroupsBody, GroupContent } from "./GroupContent";
 type GroupsRequest = Omit<GroupsBody, "lastUpdate">;
 export type GroupsBodyRequest = Partial<GroupsRequest>;
 
-export type UpdateAssetLinkResponse = mUpdateResponse & {
+export type UpdateLinkResponse = mUpdateResponse & {
   group: KDocument<GroupContent>;
 };
 
@@ -67,7 +67,7 @@ export interface ApiGroupAddAssetsRequest extends GroupControllerRequest {
     assetIds: string[];
   };
 }
-export type ApiGroupAddAssetsResult = UpdateAssetLinkResponse;
+export type ApiGroupAddAssetsResult = UpdateLinkResponse;
 
 export interface ApiGroupRemoveAssetsRequest extends GroupControllerRequest {
   action: "removeAsset";
@@ -76,4 +76,21 @@ export interface ApiGroupRemoveAssetsRequest extends GroupControllerRequest {
     assetIds: string[];
   };
 }
-export type ApiGroupRemoveAssetsResult = UpdateAssetLinkResponse;
+export type ApiGroupRemoveAssetsResult = UpdateLinkResponse;
+export interface ApiGroupAddDeviceRequest extends GroupControllerRequest {
+  action: "addDevice";
+  body: {
+    path: string;
+    deviceIds: string[];
+  };
+}
+export type ApiGroupAddDevicesResult = UpdateLinkResponse;
+
+export interface ApiGroupRemoveDeviceRequest extends GroupControllerRequest {
+  action: "removeDevice";
+  body: {
+    path: string;
+    deviceIds: string[];
+  };
+}
+export type ApiGroupRemoveDeviceResult = UpdateLinkResponse;

--- a/lib/modules/model/ModelsController.ts
+++ b/lib/modules/model/ModelsController.ts
@@ -218,6 +218,11 @@ export class ModelsController {
   async writeGroup(request: KuzzleRequest): Promise<ApiModelWriteGroupResult> {
     const engineGroup = request.getBodyString("engineGroup");
     const model = request.getBodyString("model");
+    const affinity = request.getBodyObject("affinity", {
+      models: { assets: [], devices: [] },
+      strict: false,
+      type: ["assets", "devices"],
+    });
     const metadataMappings = request.getBodyObject("metadataMappings", {});
     const defaultValues = request.getBodyObject("defaultValues", {});
     const metadataDetails = request.getBodyObject("metadataDetails", {});
@@ -226,6 +231,7 @@ export class ModelsController {
     const groupModel = await this.modelService.writeGroup(
       engineGroup,
       model,
+      affinity,
       metadataMappings,
       defaultValues,
       metadataDetails,

--- a/lib/modules/model/ModelsRegister.ts
+++ b/lib/modules/model/ModelsRegister.ts
@@ -11,6 +11,7 @@ import { MeasureDefinition } from "../measure";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupAffinity,
   GroupModelContent,
   LocaleDetails,
   MeasureModelContent,
@@ -168,6 +169,7 @@ export class ModelsRegister {
    *
    * @param engineGroup - The engine group name.
    * @param model - The name of the group model, which must be in PascalCase.
+   * @param affinity - The type of object accepted and their model affinity.
    * @param metadataMappings - The metadata mappings for the model, defaults to an empty object.
    * @param defaultMetadata - The default metadata values for the model, defaults to an empty object.
    * @param metadataDetails - Optional detailed metadata descriptions, localizations and definition.
@@ -177,6 +179,7 @@ export class ModelsRegister {
   registerGroup(
     engineGroup: string,
     model: string,
+    affinity: GroupAffinity,
     metadataMappings: MetadataMappings = {},
     defaultMetadata: JSONObject = {},
     metadataDetails: MetadataDetails = {},
@@ -192,6 +195,7 @@ export class ModelsRegister {
     this.groupModels.push({
       engineGroup,
       group: {
+        affinity,
         defaultMetadata,
         metadataDetails,
         metadataGroups,

--- a/lib/modules/model/collections/modelsMappings.ts
+++ b/lib/modules/model/collections/modelsMappings.ts
@@ -112,6 +112,24 @@ export const modelsMappings: CollectionMappings = {
     group: {
       properties: {
         model: { type: "keyword" },
+        affinity: {
+          properties: {
+            type: {
+              type: "keyword",
+            },
+            models: {
+              properties: {
+                assets: {
+                  type: "keyword",
+                },
+                devices: {
+                  type: "keyword",
+                },
+              },
+            },
+            strict: { type: "boolean" },
+          },
+        },
         metadataMappings: {
           dynamic: "false",
           properties: {},

--- a/lib/modules/model/types/ModelApi.ts
+++ b/lib/modules/model/types/ModelApi.ts
@@ -3,6 +3,7 @@ import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 import {
   AssetModelContent,
   DeviceModelContent,
+  GroupAffinity,
   GroupModelContent,
   LocaleDetails,
   MeasureModelContent,
@@ -78,6 +79,7 @@ export interface ApiModelWriteGroupRequest extends ModelsControllerRequest {
   action: "writeGroup";
 
   body: {
+    affinity: GroupAffinity;
     engineGroup: string;
     model: string;
     metadataDetails?: MetadataDetails;

--- a/lib/modules/model/types/ModelContent.ts
+++ b/lib/modules/model/types/ModelContent.ts
@@ -29,6 +29,23 @@ export interface MetadataMappings {
   [key: string]: MetadataProperty | MetadataObject;
 }
 
+export interface GroupAffinity {
+  /**
+   * Type of elements accepted in the group
+   */
+  type: Array<"assets" | "devices">;
+  /**
+   * Models accepted in the group
+   */
+  models: {
+    assets?: string[];
+    devices?: string[];
+  };
+  /**
+   * Weather the affinities are a strict restriction or not
+   */
+  strict: boolean;
+}
 export interface LocaleDetails {
   friendlyName: string;
   description: string;
@@ -405,6 +422,10 @@ export interface GroupModelContent extends KDocumentContent {
      */
     model: string;
 
+    /**
+     * Group types and model affinities
+     */
+    affinity: GroupAffinity;
     /**
      * Metadata mappings.
      *

--- a/lib/modules/model/types/ModelDefinition.ts
+++ b/lib/modules/model/types/ModelDefinition.ts
@@ -1,6 +1,7 @@
 import { JSONObject } from "kuzzle-sdk";
 import { Decoder, NamedMeasures } from "../../../modules/decoder";
 import {
+  GroupAffinity,
   LocaleDetails,
   MetadataDetails,
   MetadataGroups,
@@ -296,6 +297,11 @@ export type DeviceModelDefinition = {
  *
  */
 export type GroupModelDefinition = {
+  /**
+   * Metadata mappings definition
+   */
+  affinity: GroupAffinity;
+
   /**
    * Metadata mappings definition
    */

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -308,6 +308,7 @@ export class DeviceManagerPlugin extends Plugin {
         this.modelsRegister.registerGroup(
           engineGroup,
           model,
+          definition.affinity,
           definition.metadataMappings,
           definition.defaultMetadata,
           definition.metadataDetails,

--- a/tests/application/groups/AssetRestricted.ts
+++ b/tests/application/groups/AssetRestricted.ts
@@ -1,0 +1,19 @@
+import { GroupContent } from "lib/modules/group/exports";
+import { GroupModel } from "lib/modules/shared";
+
+const modelName = "AssetRestricted";
+
+export interface AssetRestrictedContent extends GroupContent {
+  model: typeof modelName;
+}
+
+export const AssetRestricted: GroupModel = {
+  modelName,
+  definition: {
+    affinity: {
+      type: ["assets"],
+      models: { assets: ["Container"] },
+      strict: true,
+    },
+  },
+};

--- a/tests/application/groups/DeviceRestricted.ts
+++ b/tests/application/groups/DeviceRestricted.ts
@@ -1,0 +1,19 @@
+import { GroupContent } from "lib/modules/group/exports";
+import { GroupModel } from "lib/modules/shared";
+
+const modelName = "DeviceRestricted";
+
+export interface DeviceRestrictedContent extends GroupContent {
+  model: typeof modelName;
+}
+
+export const DeviceRestricted: GroupModel = {
+  modelName,
+  definition: {
+    affinity: {
+      type: ["devices"],
+      models: { devices: ["DummyTemp"] },
+      strict: true,
+    },
+  },
+};

--- a/tests/application/groups/Parking.ts
+++ b/tests/application/groups/Parking.ts
@@ -17,6 +17,11 @@ export interface ParkingGroupContent extends GroupContent<ParkingMetadata> {
 export const Parking: GroupModel = {
   modelName,
   definition: {
+    affinity: {
+      type: ["assets"],
+      models: { assets: [] },
+      strict: false,
+    },
     metadataMappings: {
       geolocation: { type: "geo_point" },
     },

--- a/tests/application/groups/index.ts
+++ b/tests/application/groups/index.ts
@@ -1,1 +1,3 @@
 export * from "./Parking";
+export * from "./AssetRestricted";
+export * from "./DeviceRestricted";

--- a/tests/application/models.ts
+++ b/tests/application/models.ts
@@ -1,13 +1,7 @@
 import { DeviceManagerPlugin } from "../../index";
 import { Container, Warehouse, MagicHouse, Room, StreetLamp } from "./assets";
-<<<<<<< Updated upstream
 import { Parking } from "./groups/Parking";
 import { DummyTemp, DummyTempPosition, EmptyTemp } from "./devices";
-=======
-import { DummyTemp, DummyTempPosition } from "./devices";
-import { AssetRestricted, DeviceRestricted, Parking } from "./groups";
-
->>>>>>> Stashed changes
 import {
   Acceleration,
   Brightness,
@@ -21,6 +15,7 @@ import {
   movementMeasureModel,
   humidityMeasureModel,
 } from "./measures";
+import { AssetRestricted, DeviceRestricted } from "./groups";
 
 const measuresModels = [
   Acceleration,

--- a/tests/application/models.ts
+++ b/tests/application/models.ts
@@ -1,7 +1,13 @@
 import { DeviceManagerPlugin } from "../../index";
 import { Container, Warehouse, MagicHouse, Room, StreetLamp } from "./assets";
+<<<<<<< Updated upstream
 import { Parking } from "./groups/Parking";
 import { DummyTemp, DummyTempPosition, EmptyTemp } from "./devices";
+=======
+import { DummyTemp, DummyTempPosition } from "./devices";
+import { AssetRestricted, DeviceRestricted, Parking } from "./groups";
+
+>>>>>>> Stashed changes
 import {
   Acceleration,
   Brightness,
@@ -41,7 +47,7 @@ const assetsModels = {
   public_lighting: [StreetLamp],
 };
 const groupModels = {
-  air_quality: [Parking],
+  air_quality: [Parking, AssetRestricted, DeviceRestricted],
 };
 
 export function registerModels(deviceManager: DeviceManagerPlugin) {

--- a/tests/fixtures/devices.ts
+++ b/tests/fixtures/devices.ts
@@ -9,6 +9,7 @@ export const deviceDetached1: DeviceContent = {
   engineId: null,
   assetId: null,
   lastMeasuredAt: null,
+  groups: [],
 };
 export const deviceDetached1Id = `${deviceDetached1.model}-${deviceDetached1.reference}`;
 
@@ -21,6 +22,7 @@ export const deviceAyseLinked1 = {
   engineId: "engine-ayse",
   assetId: "Container-linked1",
   lastMeasuredAt: null,
+  groups: [],
 };
 export const deviceAyseLinked1Id = `${deviceAyseLinked1.model}-${deviceAyseLinked1.reference}`;
 
@@ -33,6 +35,12 @@ export const deviceAyseLinked2: DeviceContent = {
   engineId: "engine-ayse",
   assetId: "Container-linked2",
   lastMeasuredAt: null,
+  groups: [
+    {
+      path: "test-parent-asset",
+      date: Date.now(),
+    },
+  ],
 };
 export const deviceAyseLinked2Id = `${deviceAyseLinked2.model}-${deviceAyseLinked2.reference}`;
 
@@ -45,6 +53,7 @@ export const deviceAyseUnlinked1: DeviceContent = {
   engineId: "engine-ayse",
   assetId: null,
   lastMeasuredAt: null,
+  groups: [],
 };
 export const deviceAyseUnlinked1Id = `${deviceAyseUnlinked1.model}-${deviceAyseUnlinked1.reference}`;
 
@@ -57,6 +66,7 @@ export const deviceAyseUnlinked2: DeviceContent = {
   engineId: "engine-ayse",
   assetId: null,
   lastMeasuredAt: null,
+  groups: [],
 };
 export const deviceAyseUnlinked2Id = `${deviceAyseUnlinked2.model}-${deviceAyseUnlinked2.reference}`;
 
@@ -69,6 +79,7 @@ export const deviceAyseUnlinked3: DeviceContent = {
   engineId: "engine-ayse",
   assetId: null,
   lastMeasuredAt: null,
+  groups: [],
 };
 export const deviceAyseUnlinked3Id = `${deviceAyseUnlinked3.model}-${deviceAyseUnlinked3.reference}`;
 
@@ -81,6 +92,12 @@ export const deviceAyseWarehouse: DeviceContent = {
   engineId: "engine-ayse",
   assetId: "Warehouse-linked",
   lastMeasuredAt: null,
+  groups: [
+    {
+      path: "test-parent-asset.test-children-asset",
+      date: Date.now(),
+    },
+  ],
 };
 export const deviceAyseWarehouseId = `${deviceAyseWarehouse.model}-${deviceAyseWarehouse.reference}`;
 

--- a/tests/fixtures/devices.ts
+++ b/tests/fixtures/devices.ts
@@ -112,6 +112,7 @@ export const deviceEmptyTemp: DeviceContent = {
   engineId: "engine-ayse",
   assetId: null,
   lastMeasuredAt: null,
+  groups: [],
 };
 export const deviceEmptyTempId = `${deviceEmptyTemp.model}-${deviceEmptyTemp.reference}`;
 

--- a/tests/fixtures/groups.ts
+++ b/tests/fixtures/groups.ts
@@ -11,7 +11,7 @@ export const groupChildrenWithAssetId = "test-children-asset";
 export const groupTestBody: GroupsBody = {
   name: "Test group",
   lastUpdate: Date.now(),
-  model: null,
+  model: "AssetRestricted",
   path: `${groupTestId}`,
 };
 
@@ -19,14 +19,13 @@ export const groupTestParentBody1: GroupsBody = {
   name: "Test parent 1",
   path: `${groupTestParentId1}`,
   lastUpdate: Date.now(),
-  model: "Type 1",
 };
 
 export const groupTestParentBody2: GroupsBody = {
   name: "Test parent 2",
   path: `${groupTestParentId2}`,
   lastUpdate: Date.now(),
-  model: null,
+  model: "DeviceRestricted",
 };
 
 export const groupTestChildrenBody1: GroupsBody = {

--- a/tests/scenario/modules/groups/group.test.ts
+++ b/tests/scenario/modules/groups/group.test.ts
@@ -8,6 +8,7 @@ import {
   groupTestChildrenBody1,
   groupChildrenWithAssetId,
   groupParentWithAssetId,
+  groupTestParentId2,
 } from "../../../fixtures/groups";
 
 // Lib
@@ -23,11 +24,21 @@ import {
   ApiGroupAddAssetsResult,
   ApiGroupRemoveAssetsRequest,
   ApiGroupRemoveAssetsResult,
+  ApiGroupAddDeviceRequest,
+  ApiGroupAddDevicesResult,
+  ApiGroupRemoveDeviceRequest,
+  ApiGroupRemoveDeviceResult,
 } from "../../../../lib/modules/group/types/GroupsApi";
 import { AssetContent } from "../../../../lib/modules/asset/exports";
 import { InternalCollection } from "../../../../lib/modules/plugin";
 import { setupHooks } from "../../../helpers";
 import { GroupContent } from "lib/modules/group/types/GroupContent";
+import {
+  assetAyseDebug1Id,
+  deviceAyseLinked2Id,
+  deviceAyseWarehouseId,
+} from "../../../fixtures";
+import { DeviceContent } from "lib/modules/device";
 
 jest.setTimeout(10000);
 
@@ -347,7 +358,7 @@ describe("GroupsController", () => {
       },
     };
     await expect(sdk.query(badIdQuery)).rejects.toThrow(
-      'The group with path "bad-id" does not exist',
+      'Document "bad-id" not found in "engine-ayse":"groups".',
     );
 
     const { result } = await sdk.query<
@@ -484,9 +495,34 @@ describe("GroupsController", () => {
     expect(assets3[0]._source.groups[0].date).toBeGreaterThan(now);
 
     expect(result3.group._source.lastUpdate).toBeGreaterThan(now);
-  });
 
-  it("can remove asset to group", async () => {
+    const restrictedGroup: ApiGroupAddAssetsRequest = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addAsset",
+      body: {
+        path: groupTestParentId2,
+        assetIds: ["Container-linked1"],
+      },
+    };
+    await expect(sdk.query(restrictedGroup)).rejects.toThrow(
+      `The group ${groupTestParentId2} of model DeviceRestricted can not contain assets`,
+    );
+
+    const wrongAssetModel: ApiGroupAddAssetsRequest = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addAsset",
+      body: {
+        path: groupTestId,
+        assetIds: [assetAyseDebug1Id],
+      },
+    };
+    await expect(sdk.query(wrongAssetModel)).rejects.toThrow(
+      `Groups of model AssetRestricted can not contain assets of model MagicHouse`,
+    );
+  });
+  it("can remove asset from group", async () => {
     const missingPathQuery: Omit<ApiGroupRemoveAssetsRequest, "body"> & {
       body: {
         assetIds: string[];
@@ -566,6 +602,282 @@ describe("GroupsController", () => {
 
     expect(result2.successes[0]).toMatchObject({
       _id: "Container-grouped2",
+      _source: {
+        groups: [],
+      },
+    });
+
+    expect(result2.group._source.lastUpdate).toBeGreaterThan(now);
+  });
+
+  it("can add device to a group", async () => {
+    const missingBodyQuery: Omit<ApiGroupAddDeviceRequest, "body"> = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+    };
+    await expect(sdk.query(missingBodyQuery)).rejects.toThrow(
+      /^The request must specify a body.$/,
+    );
+
+    const badIdQuery: ApiGroupAddDeviceRequest = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+      body: {
+        path: "bad-id",
+        deviceIds: ["DummyTemp-linked1"],
+      },
+    };
+    await expect(sdk.query(badIdQuery)).rejects.toThrow(
+      'Document "bad-id" not found in "engine-ayse":"groups".',
+    );
+
+    const { result } = await sdk.query<
+      ApiGroupAddDeviceRequest,
+      ApiGroupAddDevicesResult
+    >({
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+      body: {
+        path: groupParentWithAssetId,
+        deviceIds: ["DummyTemp-unlinked1", "DummyTemp-unlinked2"],
+      },
+    });
+
+    expect(result.errors).toHaveLength(0);
+
+    expect(result.successes).toMatchObject([
+      {
+        _id: "DummyTemp-unlinked1",
+        _source: {
+          groups: [
+            {
+              path: groupParentWithAssetId,
+            },
+          ],
+        },
+      },
+      {
+        _id: "DummyTemp-unlinked2",
+        _source: {
+          groups: [
+            {
+              path: groupParentWithAssetId,
+            },
+          ],
+        },
+      },
+    ]);
+
+    // ? Dates should be separately because is not really predictable
+    const devices = result.successes as KDocument<DeviceContent>[];
+    expect(devices[0]._source.groups[0].date).toBeGreaterThan(now);
+    expect(devices[1]._source.groups[0].date).toBeGreaterThan(now);
+
+    expect(result.group._source.lastUpdate).toBeGreaterThan(now);
+
+    // Add devices in an second group
+    const { result: result2 } = await sdk.query<
+      ApiGroupAddDeviceRequest,
+      ApiGroupAddDevicesResult
+    >({
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+      body: {
+        path: groupTestParentId1,
+        deviceIds: ["DummyTemp-unlinked1", "DummyTemp-unlinked2"],
+      },
+    });
+
+    expect(result2.errors).toHaveLength(0);
+
+    expect(result2.successes).toMatchObject([
+      {
+        _id: "DummyTemp-unlinked1",
+        _source: {
+          groups: [
+            {
+              path: groupParentWithAssetId,
+            },
+            {
+              path: groupTestParentId1,
+            },
+          ],
+        },
+      },
+      {
+        _id: "DummyTemp-unlinked2",
+        _source: {
+          groups: [
+            {
+              path: groupParentWithAssetId,
+            },
+            {
+              path: groupTestParentId1,
+            },
+          ],
+        },
+      },
+    ]);
+
+    // ? Dates should be separately because is not really predictable
+    const devices2 = result2.successes as KDocument<DeviceContent>[];
+    expect(devices2[0]._source.groups[0].date).toBeLessThan(Date.now());
+    expect(devices2[0]._source.groups[1].date).toBeGreaterThan(now);
+
+    expect(devices2[1]._source.groups[0].date).toBeLessThan(Date.now());
+    expect(devices2[1]._source.groups[1].date).toBeGreaterThan(now);
+
+    expect(result2.group._source.lastUpdate).toBeGreaterThan(now);
+
+    // Add an device to a subgroup also add the reference of the parent group
+    const { result: result3 } = await sdk.query<
+      ApiGroupAddDeviceRequest,
+      ApiGroupAddDevicesResult
+    >({
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+      body: {
+        path: groupTestParentId1 + "." + groupTestChildrenId1,
+        deviceIds: ["DummyTempPosition-linked2"],
+      },
+    });
+
+    expect(result3.errors).toHaveLength(0);
+
+    expect(result3.successes).toMatchObject([
+      {
+        _id: "DummyTempPosition-linked2",
+        _source: {
+          groups: [
+            {
+              path: groupParentWithAssetId,
+            },
+            {
+              path: groupTestParentId1 + "." + groupTestChildrenId1,
+            },
+          ],
+        },
+      },
+    ]);
+
+    // ? Dates should be separately because is not really predictable
+    const devices3 = result3.successes as KDocument<DeviceContent>[];
+    expect(devices3[0]._source.groups[1].date).toBeGreaterThan(now);
+
+    expect(result3.group._source.lastUpdate).toBeGreaterThan(now);
+
+    const restrictedGroup: ApiGroupAddDeviceRequest = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+      body: {
+        path: groupTestId,
+        deviceIds: ["DummyTempPosition-unlinked3"],
+      },
+    };
+    await expect(sdk.query(restrictedGroup)).rejects.toThrow(
+      `The group ${groupTestId} of model AssetRestricted can not contain devices`,
+    );
+
+    const wrongDeviceModel: ApiGroupAddDeviceRequest = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "addDevice",
+      body: {
+        path: groupTestParentId2,
+        deviceIds: ["DummyTempPosition-unlinked3"],
+      },
+    };
+    await expect(sdk.query(wrongDeviceModel)).rejects.toThrow(
+      `Groups of model DeviceRestricted can not contain devices of model DummyTempPosition`,
+    );
+  });
+
+  it("can remove device from group", async () => {
+    const missingPathQuery: Omit<ApiGroupRemoveDeviceRequest, "body"> & {
+      body: {
+        deviceIds: string[];
+      };
+    } = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "removeDevice",
+      body: {
+        deviceIds: [deviceAyseWarehouseId],
+      },
+    };
+    await expect(sdk.query(missingPathQuery)).rejects.toThrow(
+      /^Missing argument "body.path".$/,
+    );
+
+    const missingBodyQuery: Omit<ApiGroupRemoveDeviceRequest, "body"> = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "removeDevice",
+    };
+    await expect(sdk.query(missingBodyQuery)).rejects.toThrow(
+      /^The request must specify a body.$/,
+    );
+
+    const badIdQuery: ApiGroupRemoveDeviceRequest = {
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "removeDevice",
+      body: {
+        path: "bad-path",
+        deviceIds: [],
+      },
+    };
+    await expect(sdk.query(badIdQuery)).rejects.toThrow(
+      'The group with path "bad-path" does not exist',
+    );
+
+    const { result } = await sdk.query<
+      ApiGroupRemoveDeviceRequest,
+      ApiGroupRemoveDeviceResult
+    >({
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "removeDevice",
+      body: {
+        path: groupParentWithAssetId + "." + groupChildrenWithAssetId,
+        deviceIds: [deviceAyseWarehouseId],
+      },
+    });
+
+    expect(result.errors).toHaveLength(0);
+
+    expect(result.successes[0]).toMatchObject({
+      _id: deviceAyseWarehouseId,
+      _source: {
+        groups: [],
+      },
+    });
+
+    expect(result.group._source.lastUpdate).toBeGreaterThan(now);
+
+    const { result: result2 } = await sdk.query<
+      ApiGroupRemoveDeviceRequest,
+      ApiGroupRemoveDeviceResult
+    >({
+      controller: "device-manager/groups",
+      engineId: "engine-ayse",
+      action: "removeDevice",
+      body: {
+        path: groupParentWithAssetId,
+        deviceIds: [deviceAyseLinked2Id],
+      },
+    });
+
+    expect(result2.errors).toHaveLength(0);
+
+    expect(result2.successes[0]).toMatchObject({
+      _id: deviceAyseLinked2Id,
       _source: {
         groups: [],
       },

--- a/tests/scenario/modules/models/group-model.test.ts
+++ b/tests/scenario/modules/models/group-model.test.ts
@@ -16,6 +16,11 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets"],
+          models: { assets: [] },
+          strict: false,
+        },
         engineGroup: "air_quality",
         model: "TruckFleet",
         metadataMappings: {
@@ -72,6 +77,14 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets", "devices"],
+          models: {
+            assets: ["truck"],
+            devices: [],
+          },
+          strict: true,
+        },
         engineGroup: "air_quality",
         model: "TruckFleet",
         metadataMappings: {
@@ -233,8 +246,10 @@ describe("ModelsController:groups", () => {
       engineGroup: "air_quality",
     });
     expect(listGroups.result).toMatchObject({
-      total: 2,
+      total: 4,
       models: [
+        { _id: "model-group-AssetRestricted" },
+        { _id: "model-group-DeviceRestricted" },
         { _id: "model-group-Parking" },
         { _id: "model-group-TruckFleet" },
       ],
@@ -257,6 +272,14 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets", "devices"],
+          models: {
+            assets: ["truck"],
+            devices: [],
+          },
+          strict: true,
+        },
         engineGroup: "air_quality",
         model: "TruckFleet",
         metadataMappings: {
@@ -327,6 +350,14 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets", "devices"],
+          models: {
+            assets: [],
+            devices: [],
+          },
+          strict: false,
+        },
         engineGroup: "air_quality",
         model: "Building",
         metadataMappings: {
@@ -362,6 +393,14 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets", "devices"],
+          models: {
+            assets: [],
+            devices: [],
+          },
+          strict: false,
+        },
         engineGroup: "commons",
         model: "flatgroupnape",
         metadataMappings: { size: { type: "integer" } },
@@ -379,6 +418,14 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets", "devices"],
+          models: {
+            assets: ["truck"],
+            devices: [],
+          },
+          strict: true,
+        },
         engineGroup: "air_quality",
         model: "TruckFleet",
         metadataMappings: {
@@ -404,6 +451,14 @@ describe("ModelsController:groups", () => {
       controller: "device-manager/models",
       action: "writeGroup",
       body: {
+        affinity: {
+          type: ["assets", "devices"],
+          models: {
+            assets: ["truck"],
+            devices: [],
+          },
+          strict: true,
+        },
         engineGroup: "air_quality",
         model: "BadModel",
         metadataMappings: {
@@ -428,6 +483,82 @@ describe("ModelsController:groups", () => {
     });
     await expect(badMappingRequest).rejects.toThrow(
       "New group mappings are causing conflicts",
+    );
+  });
+  it("Should throw if affinity isn't valid", async () => {
+    const noTypeRequest = sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        affinity: {
+          type: [],
+          models: {
+            assets: ["truck"],
+            devices: [],
+          },
+          strict: true,
+        },
+        engineGroup: "air_quality",
+        model: "BadType",
+        metadataMappings: {
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description:
+                  "The word representing the size of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre en lettre de camions dans la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+    await expect(noTypeRequest).rejects.toThrow(
+      'The group type must be an array containing "assets" and/or "devices"',
+    );
+
+    const noModels = sdk.query<ApiModelWriteGroupRequest>({
+      controller: "device-manager/models",
+      action: "writeGroup",
+      body: {
+        affinity: {
+          type: ["assets"],
+          models: {
+            devices: [],
+          },
+          strict: true,
+        },
+        engineGroup: "air_quality",
+        model: "BadModels",
+        metadataMappings: {
+          size: { type: "integer" },
+        },
+        metadataDetails: {
+          size: {
+            locales: {
+              en: {
+                friendlyName: "Truck fleet size",
+                description:
+                  "The word representing the size of trucks in the fleet",
+              },
+              fr: {
+                friendlyName: "Taille de la flotte",
+                description: "Le nombre en lettre de camions dans la flotte",
+              },
+            },
+          },
+        },
+      },
+    });
+    await expect(noModels).rejects.toThrow(
+      "The group affinity must contain an array for every present type",
     );
   });
 });


### PR DESCRIPTION
## What this PR does ? 
Allows group to contain devices on top of assets

Adds an affinity object in the group model

```ts
{
  /**
   * Type of elements accepted in the group
   */
  type: Array<"assets" | "devices">;
  /**
   * Models accepted in the group
   */
  models: {
    assets?: string[];
    devices?: string[];
  };
  /**
   * Weather the affinities are a strict restriction or not
   */
  strict: boolean;
}
```
This affinity define if a group can contain assets and/or devices
It also defines an array of preferred models for each of those types. If the strict field is set to true, the group can only contain assets/devices of those models.  

### Other changes
Adds a listItems endpoint to the group controller to fetch the devices and assets