### PR TITLE
fix(implicitMeasureLinking): no error if link already exists

### DIFF
--- a/lib/modules/shared/services/DigitalTwinService.ts
+++ b/lib/modules/shared/services/DigitalTwinService.ts
@@ -230,7 +230,7 @@ export class DigitalTwinService extends BaseService {
           )
         ) {
           throw new BadRequestError(
-            `No measure can be linked from"${deviceId}" to asset "${assetId}".`,
+            `No free compatible measure slot available to linked device "${deviceId}" to asset "${assetId}".`,
           );
         }
       }

--- a/lib/modules/shared/services/DigitalTwinService.ts
+++ b/lib/modules/shared/services/DigitalTwinService.ts
@@ -230,7 +230,7 @@ export class DigitalTwinService extends BaseService {
           )
         ) {
           throw new BadRequestError(
-            `No free compatible measure slot available to linked device "${deviceId}" to asset "${assetId}".`,
+            `No free compatible measure slot available to link device "${deviceId}" to asset "${assetId}".`,
           );
         }
       }

--- a/tests/scenario/modules/assets/action-link-devices.test.ts
+++ b/tests/scenario/modules/assets/action-link-devices.test.ts
@@ -444,7 +444,7 @@ describe("AssetController: linkDevices", () => {
       }),
     ).rejects.toMatchObject({
       message:
-        'No measure can be linked from"DummyTemp-linked1" to asset "Container-unlinked1".',
+        'No free compatible measure slot available to link device "DummyTemp-linked1" to asset "Container-unlinked1".',
     });
   });
 });

--- a/tests/scenario/modules/devices/action-link-asset.test.ts
+++ b/tests/scenario/modules/devices/action-link-asset.test.ts
@@ -451,7 +451,7 @@ describe("DeviceController: receiveMeasure", () => {
       }),
     ).rejects.toMatchObject({
       message:
-        'No measure can be linked from"DummyTemp-linked1" to asset "Container-unlinked1".',
+        'No free compatible measure slot available to link device "DummyTemp-linked1" to asset "Container-unlinked1".',
     });
   });
 });


### PR DESCRIPTION
## What does this PR do ?
issue [KZLPRD-1003](https://kuzzle.atlassian.net/browse/KZLPRD-1003)
If no measure available to link between an asset and a device, add a check that it's not because the link already exists before throwing an error.

Fix implicitMeasureLinking, wrong asset measure name passed, + check which measure is available in assets if has several measures of same type


[KZLPRD-1003]: https://kuzzle.atlassian.net/browse/KZLPRD-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ