### PR TITLE
fix(measures): add device origin groups field to measure documents

### DIFF
--- a/lib/modules/decoder/PayloadService.ts
+++ b/lib/modules/decoder/PayloadService.ts
@@ -115,7 +115,14 @@ export class PayloadService extends BaseService {
     for (const device of devices) {
       const {
         _id,
-        _source: { reference, model, metadata, linkedMeasures, engineId },
+        _source: {
+          reference,
+          model,
+          metadata,
+          linkedMeasures,
+          engineId,
+          groups,
+        },
       } = device;
       // ? Done here to avoid invoque Measure service only for device metadata change (if no engineId)
       const deviceMetadataChanges = decodedPayload.getMetadata(reference);
@@ -147,6 +154,7 @@ export class PayloadService extends BaseService {
               payloadUuids: [uuid],
               source: {
                 deviceMetadata: metadata,
+                groups,
                 id: _id,
                 metadata: deviceMetadataChanges,
                 model: model,
@@ -177,6 +185,7 @@ export class PayloadService extends BaseService {
               payloadUuids: [uuid],
               source: {
                 deviceMetadata: metadata,
+                groups,
                 id: _id,
                 metadata: deviceMetadataChanges,
                 model: model,
@@ -208,6 +217,7 @@ export class PayloadService extends BaseService {
               payloadUuids: [uuid],
               source: {
                 deviceMetadata: metadata,
+                groups,
                 id: _id,
                 metadata: deviceMetadataChanges,
                 model: model,
@@ -236,7 +246,7 @@ export class PayloadService extends BaseService {
     const apiAction = "device-manager/devices:receiveMeasure";
     const {
       _id,
-      _source: { reference, model, metadata, linkedMeasures, engineId },
+      _source: { reference, model, metadata, linkedMeasures, engineId, groups },
     } = device;
 
     // TODO: do we want update a metadata from formatted payload to ?
@@ -262,6 +272,7 @@ export class PayloadService extends BaseService {
             payloadUuids,
             source: {
               deviceMetadata: metadata,
+              groups,
               id: _id,
               model: model,
               reference: reference,
@@ -292,6 +303,7 @@ export class PayloadService extends BaseService {
             payloadUuids,
             source: {
               deviceMetadata: metadata,
+              groups,
               id: _id,
               model: model,
               reference: reference,

--- a/lib/modules/measure/MeasureService.ts
+++ b/lib/modules/measure/MeasureService.ts
@@ -70,8 +70,7 @@ export class MeasureService extends BaseService {
   ) {
     const { id: dataSourceId } = source;
     const { indexId, assetId } = target;
-
-    if (!measurements) {
+    if (!measurements || measurements.length === 0) {
       this.app.log.warn(
         `No measurements provided for "${dataSourceId}" measures ingest`,
       );

--- a/lib/modules/measure/MeasureSourcesBuilder.ts
+++ b/lib/modules/measure/MeasureSourcesBuilder.ts
@@ -25,11 +25,12 @@ export function deviceSourceToOriginDevice(
   payloadUuids: string[],
   deviceMetadata: Metadata,
 ): MeasureOriginDevice {
-  const { id: dataSourceId, model, reference } = source;
+  const { id: dataSourceId, model, reference, groups } = source;
   return {
     _id: dataSourceId,
     deviceMetadata,
     deviceModel: model,
+    groups,
     measureName,
     payloadUuids,
     reference: reference,

--- a/lib/modules/measure/collections/measuresMappings.ts
+++ b/lib/modules/measure/collections/measuresMappings.ts
@@ -34,10 +34,7 @@ export const measuresMappings: CollectionMappings = {
         },
         groups: {
           properties: {
-            path: {
-              type: "keyword",
-              fields: { text: { type: "text" } },
-            },
+            path: { type: "keyword", fields: { text: { type: "text" } } },
             date: { type: "date" },
           },
         },
@@ -58,11 +55,13 @@ export const measuresMappings: CollectionMappings = {
             // populated with device models metadata mappings
           },
         },
-
-        apiMetadata: {
-          dynamic: "false",
-          properties: {},
+        groups: {
+          properties: {
+            path: { type: "keyword", fields: { text: { type: "text" } } },
+            date: { type: "date" },
+          },
         },
+        apiMetadata: { dynamic: "false", properties: {} },
 
         payloadUuids: { type: "keyword" },
 

--- a/lib/modules/measure/types/MeasureContent.ts
+++ b/lib/modules/measure/types/MeasureContent.ts
@@ -46,6 +46,11 @@ export interface MeasureOriginDevice extends AbstractMeasureOrigin {
   deviceMetadata?: Metadata;
 
   /**
+   * Origin device groups
+   */
+  groups: Array<{ path: string; date: number }>;
+
+  /**
    * Device ID
    */
   _id: string;

--- a/lib/modules/measure/types/MeasureSources.ts
+++ b/lib/modules/measure/types/MeasureSources.ts
@@ -12,6 +12,10 @@ export interface DeviceMeasureSource extends AbstractMeasureSource {
   deviceMetadata: Metadata;
   model: string;
   lastMeasuredAt?: number;
+  groups: Array<{
+    path: string;
+    date: number;
+  }>;
 }
 
 export interface ApiMeasureSource extends AbstractMeasureSource {

--- a/tests/scenario/migrated/measure-ingestion-pipeline.test.ts
+++ b/tests/scenario/migrated/measure-ingestion-pipeline.test.ts
@@ -126,9 +126,7 @@ describe('features/Measure/IngestionPipeline', () => {
   });
 
   it('Should enrich measure with the origin device metadata', async () => {
-    const metadata = {
-      color: 'blue',
-    };
+    const metadata = { color: 'blue' };
 
     await sdk.query({
       controller: 'device-manager/devices',
@@ -184,6 +182,26 @@ describe('features/Measure/IngestionPipeline', () => {
           },
         },
       ],
+    });
+  });
+
+  it('Should enrich measure with the origin device groups', async () => {
+    await sendPayloads(sdk, 'dummy-temp-position', [
+      { deviceEUI: 'linked2', temperature: 35, location: { lon: 12, lat: 12 } },
+    ]);
+
+    await sdk.collection.refresh('engine-ayse', 'measures');
+
+    const response = await sdk.query({
+      controller: 'document',
+      action: 'search',
+      index: 'engine-ayse',
+      collection: 'measures',
+      body: { query: { term: { 'origin.reference': 'linked2' } } },
+    });
+
+    expect(response.result.hits[0]._source.origin.groups[0]).toMatchObject({
+      path: 'test-parent-asset',
     });
   });
 });


### PR DESCRIPTION
## What does this PR do ?
This PR adds missing origin device groups in measure documents during ingestion.

### Other changes
Linked to issue [KZLPRD-1039](https://kuzzle.atlassian.net/browse/KZLPRD-1040) prevent the ingestion with no measures


[KZLPRD-1039]: https://kuzzle.atlassian.net/browse/KZLPRD-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ