### PR TITLE
fix(deviceService): accept nullish device metadata

### DIFF
--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -834,7 +834,7 @@ export class AssetsController {
           engineId,
           deviceId,
           assetId,
-          measureSlots || [],
+          measureSlots ?? [],
           implicitMeasuresLinking,
           request,
         );

--- a/lib/modules/device/DeviceService.ts
+++ b/lib/modules/device/DeviceService.ts
@@ -465,8 +465,8 @@ export class DeviceService extends DigitalTwinService {
       deviceModel.device.metadataMappings,
     )) {
       engineDevice._source.metadata[metadataName] =
-        metadata?.[metadataName] ||
-        deviceModel.device.defaultMetadata[metadataName] ||
+        metadata?.[metadataName] ??
+        deviceModel.device.defaultMetadata[metadataName] ??
         null;
     }
 

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -375,7 +375,7 @@ export class DevicesController {
           engineId,
           deviceId,
           assetId,
-          measureSlots || [],
+          measureSlots ?? [],
           implicitMeasuresLinking,
           request,
         );


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the init of metadata of a device to accept a nullish value (ie: 0)
Issue [KZLPRD-1105](https://kuzzle.atlassian.net/browse/KZLPRD-1105)

[KZLPRD-1105]: https://kuzzle.atlassian.net/browse/KZLPRD-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ