### PR TITLE
fix(unlinkAsset): throw if no measure to unlink is provided

### DIFF
--- a/doc/3/controllers/assets/unlink-devices/index.md
+++ b/doc/3/controllers/assets/unlink-devices/index.md
@@ -7,7 +7,13 @@ description: Unlinks measures from an asset
 
 # unlinkDevices
 
-Unlinks measures from an asset.
+Unlinks measures from an asset. This action takes 3 optional parameters. One of them must be present. 
+There are 3 ways to unlink measures:
+        - One can unlink all of the asset measure slots with the flag "allMeasures".
+        - One can unlink all of the slots for specific devices with the array of devices' ids. 
+        - One can specify the asset measure slots to unlink.
+
+It is possible to combine those parameters. 
 
 ## Query Syntax
 
@@ -27,18 +33,9 @@ Method: DELETE
   "engineId": "<engineId>",
   "_id": "<assetId>"
   "body": {
-    "linkedMeasures": [
-      { "deviceId":"<id of the device>"
-        "allMeasures": "<boolean>"                            // optional
-        "measureSlots":[                                      // optional
-            {
-              "asset": "<name of the measure in the asset>",
-              "device": "<name of the measure in the device>"
-            }
-        ]
-    },
-    {...}
-    ]
+    "allMeasures": "<boolean>"                            // optional Indicates if all the measures from the asset must be unlinked
+    "devices":  "<string[]>"                              // optional List of devices' ids to completely unlink from the asset
+    "measureSlots":  "<string[]>"                         // optional List of asset's measures slots to unlink
   },
 }
 ```

--- a/doc/3/controllers/devices/unlink-assets/index.md
+++ b/doc/3/controllers/devices/unlink-assets/index.md
@@ -7,7 +7,13 @@ description: Unlinks measures from a device
 
 # unlinkAssets
 
-Unlinks measures from a devices.
+Unlinks measures from a devices. This action takes 3 optional parameters. One of them must be present. 
+There are 3 ways to unlink measures:
+        - One can unlink all of the device measure slots with the flag "allMeasures".
+        - One can unlink all of the slots for specific assets with the array of assets' ids. 
+        - One can specify the device measure slots to unlink.
+        
+It is possible to combine those parameters. 
 
 ## Query Syntax
 
@@ -27,18 +33,9 @@ Method: DELETE
   "engineId": "<engineId>",
   "_id": "<deviceId>"
   "body": {
-    "linkedMeasures": [
-      { "assetId":"<id of the asset>"
-        "allMeasures": "<boolean>"                            // optional
-        "measureSlots":[                                      // optional
-            {
-              "asset": "<name of the measure in the asset>",
-              "device": "<name of the measure in the device>"
-            }
-        ]
-    },
-    {...}
-    ]
+    "allMeasures": "<boolean>"                            // optional Indicates if all the measures from the device must be unlinked
+    "assets":  "<string[]>"                              // optional List of assets' ids to completely unlink from the device
+    "measureSlots":  "<string[]>"                         // optional List of device's measures slots to unlink
   },
 }
 ```

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -858,8 +858,15 @@ export class AssetsController {
       "linkedMeasures",
     ) as ApiAssetUnlinkDevicesRequest["body"]["linkedMeasures"];
 
+    if (measureToUnlink.length === 0) {
+      throw new BadRequestError(
+        `The list of measures to unlink from asset ${assetId} is empty`,
+      );
+    }
+
     const devices: KDocument<DeviceContent>[] = [];
     let asset: KDocument<AssetContent>;
+
     for (const measure of measureToUnlink) {
       const { deviceId, allMeasures, measureSlots } = measure;
       if (!measureSlots?.length && !allMeasures) {

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -321,26 +321,30 @@ export interface ApiAssetUnlinkDevicesRequest extends AssetsControllerRequest {
   refresh?: string;
 
   body: {
-    linkedMeasures: Array<{
-      deviceId: string;
-      /**
-       * This option allows to not specify the names of all the measures that should
-       * be unlinked from the asset.
-       */
-      allMeasures?: boolean;
-      /**
-       * Names of the linked measures.
-       *
-       * Array<{ asset: string, device: string }>
-       *
-       * @example
-       *
-       * [
-       *   { asset: "externalTemperature", device: "temperature" }
-       * ]
-       */
-      measureSlots?: Array<{ asset: string; device: string }>;
-    }>;
+    /**
+     * This options allows to unlink all the measures of the asset
+     */
+    allMeasures?: boolean;
+    /**
+     * Names of the measure slots of the asset to unlink.
+     *
+     * string[]
+     *
+     * @example
+     *
+     * ['externalTemperature','position']
+     */
+    measureSlots?: string[];
+    /**
+     * Ids of the devices to unlink.
+     *
+     * string[]
+     *
+     * @example
+     *
+     * ['First-asset','Second-asset']
+     */
+    devices?: string[];
   };
 }
 

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -399,6 +399,12 @@ export class DevicesController {
       "linkedMeasures",
     ) as ApiDeviceUnlinkAssetsRequest["body"]["linkedMeasures"];
 
+    if (measureToUnlink.length === 0) {
+      throw new BadRequestError(
+        `The list of measures to unlink from device ${deviceId} is empty`,
+      );
+    }
+
     const assets: KDocument<AssetContent>[] = [];
     let device: KDocument<DeviceContent>;
     for (const measure of measureToUnlink) {

--- a/lib/modules/device/DevicesController.ts
+++ b/lib/modules/device/DevicesController.ts
@@ -33,7 +33,6 @@ import {
   ApiDeviceGetLastMeasuredAtResult,
   ApiDeviceMGetLastMeasuredAtResult,
   ApiDeviceMetadataReplaceResult,
-  ApiDeviceUnlinkAssetsRequest,
 } from "./types/DeviceApi";
 import { AssetContent } from "../asset";
 import { DeviceContent } from "./exports";
@@ -395,41 +394,21 @@ export class DevicesController {
     request: KuzzleRequest,
   ): Promise<ApiDeviceUnlinkAssetsResult> {
     const deviceId = request.getId();
-    const measureToUnlink = request.getBodyArray(
-      "linkedMeasures",
-    ) as ApiDeviceUnlinkAssetsRequest["body"]["linkedMeasures"];
-
-    if (measureToUnlink.length === 0) {
+    const allMeasures = request.getBodyBoolean("allMeasures");
+    const assetIds = request.getBodyArray("assets", []);
+    const measureSlots = request.getBodyArray("measureSlots", []);
+    if (!allMeasures && assetIds.length === 0 && measureSlots.length === 0) {
       throw new BadRequestError(
         `The list of measures to unlink from device ${deviceId} is empty`,
       );
     }
-
-    const assets: KDocument<AssetContent>[] = [];
-    let device: KDocument<DeviceContent>;
-    for (const measure of measureToUnlink) {
-      const { assetId, allMeasures, measureSlots } = measure;
-      if (!measureSlots?.length && !allMeasures) {
-        throw new BadRequestError(
-          `You must provide at least one measure name or set "allMeasures" to true.`,
-        );
-      }
-      const { asset, device: updatedDevice } =
-        await this.deviceService.unlinkAssetDevice(
-          deviceId,
-          assetId,
-          measureSlots,
-          allMeasures,
-          request,
-        );
-      assets.push(AssetSerializer.serialize(asset));
-      device = updatedDevice;
-    }
-
-    return {
-      assets,
-      device: DeviceSerializer.serialize(device),
-    };
+    return this.deviceService.unlinkAssets(
+      deviceId,
+      allMeasures,
+      assetIds,
+      measureSlots,
+      request,
+    );
   }
 
   async getMeasures(

--- a/lib/modules/device/types/DeviceApi.ts
+++ b/lib/modules/device/types/DeviceApi.ts
@@ -113,26 +113,30 @@ export interface ApiDeviceUnlinkAssetsRequest extends DevicesControllerRequest {
   refresh?: string;
 
   body: {
-    linkedMeasures: Array<{
-      assetId: string;
-      /**
-       * This option allows to not specify the names of all the measures that should
-       * be unlinked from the asset.
-       */
-      allMeasures?: boolean;
-      /**
-       * Names of the linked measures.
-       *
-       * Array<{ asset: string, device: string }>
-       *
-       * @example
-       *
-       * [
-       *   { asset: "externalTemperature", device: "temperature" }
-       * ]
-       */
-      measureSlots?: Array<{ asset: string; device: string }>;
-    }>;
+    /**
+     * This options allows to unlink all the measures of the device
+     */
+    allMeasures?: boolean;
+    /**
+     * Names of the measure slots of the device to unlink.
+     *
+     * string[]
+     *
+     * @example
+     *
+     * ['externalTemperature','position']
+     */
+    measureSlots?: string[];
+    /**
+     * Ids of the assets to unlink.
+     *
+     * string[]
+     *
+     * @example
+     *
+     * ['First-asset','Second-asset']
+     */
+    assets?: string[];
   };
 }
 

--- a/tests/scenario/migrated/asset-history.test.ts
+++ b/tests/scenario/migrated/asset-history.test.ts
@@ -3,10 +3,9 @@ import {
   ApiAssetUnlinkDevicesRequest,
   ApiDeviceLinkAssetsRequest,
   ApiDeviceUnlinkAssetsRequest,
-  AssetHistoryContent,
 } from '../../../index';
 
-import { useSdk, sendPayloads } from '../../helpers';
+import { useSdk } from '../../helpers';
 import { beforeEachTruncateCollections } from '../../hooks/collections';
 import { beforeAllCreateEngines } from '../../hooks/engines';
 import { beforeEachLoadFixtures } from '../../hooks/fixtures';
@@ -104,12 +103,7 @@ describe('features/Asset/History', () => {
       engineId: 'engine-ayse',
       _id: 'DummyTemp-unlinked1',
       body: {
-        linkedMeasures: [
-          {
-            assetId: 'Container-unlinked1',
-            allMeasures: true,
-          },
-        ],
+        assets: ['Container-unlinked1'],
       },
     });
     response = await sdk.query<ApiAssetlinkDevicesRequest>({
@@ -140,12 +134,7 @@ describe('features/Asset/History', () => {
       engineId: 'engine-ayse',
       _id: 'Container-unlinked1',
       body: {
-        linkedMeasures: [
-          {
-            deviceId: 'DummyTemp-unlinked1',
-            allMeasures: true,
-          },
-        ],
+        devices: ['DummyTemp-unlinked1'],
       },
     });
     await sdk.collection.refresh('engine-ayse', 'assets-history');

--- a/tests/scenario/migrated/device-controller-unlink-asset.test.ts
+++ b/tests/scenario/migrated/device-controller-unlink-asset.test.ts
@@ -56,6 +56,27 @@ describe('features/Device/Controller/UnlinkAssets', () => {
     });
   });
 
+   it('Throw an error if no measure is provided', async () => {
+    let response;
+    let promise;
+
+    response = await sdk.query<ApiDeviceUnlinkAssetsRequest>({
+      controller: 'device-manager/devices',
+      action: 'unlinkAssets',
+      engineId: 'engine-ayse',
+      _id: 'DummyTemp-linked1',
+      body: {
+        linkedMeasures: [
+         
+        ],
+      },
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      message: 'The list of measures to unlink from device DummyTemp-linked1 is empty',
+    });
+  });
+
   it('Error when the device was not linked', async () => {
     let response;
     let promise;

--- a/tests/scenario/migrated/device-controller-unlink-asset.test.ts
+++ b/tests/scenario/migrated/device-controller-unlink-asset.test.ts
@@ -57,10 +57,8 @@ describe('features/Device/Controller/UnlinkAssets', () => {
   });
 
    it('Throw an error if no measure is provided', async () => {
-    let response;
-    let promise;
 
-    response = await sdk.query<ApiDeviceUnlinkAssetsRequest>({
+    const promise = sdk.query<ApiDeviceUnlinkAssetsRequest>({
       controller: 'device-manager/devices',
       action: 'unlinkAssets',
       engineId: 'engine-ayse',
@@ -72,9 +70,9 @@ describe('features/Device/Controller/UnlinkAssets', () => {
       },
     });
 
-    await expect(promise).rejects.toMatchObject({
-      message: 'The list of measures to unlink from device DummyTemp-linked1 is empty',
-    });
+     await expect(promise).rejects.toThrow(
+      "The list of measures to unlink from device DummyTemp-linked1 is empty",
+    );
   });
 
   it('Error when the device was not linked', async () => {

--- a/tests/scenario/modules/assets/action-unlink-devices.test.ts
+++ b/tests/scenario/modules/assets/action-unlink-devices.test.ts
@@ -32,12 +32,7 @@ describe("features/Device/Controller/UnlinkAssets", () => {
       engineId: "engine-ayse",
       _id: "Container-linked1",
       body: {
-        linkedMeasures: [
-          {
-            deviceId: "DummyTemp-linked1",
-            allMeasures: true,
-          },
-        ],
+        devices: ["DummyTemp-linked1"],
       },
     });
 
@@ -53,14 +48,80 @@ describe("features/Device/Controller/UnlinkAssets", () => {
       _source: { linkedMeasures: [] },
     });
   });
+
+  it("Unlink one slot from the asset", async () => {
+    await sdk.query<ApiAssetUnlinkDevicesRequest>({
+      controller: "device-manager/assets",
+      action: "unlinkDevices",
+      engineId: "engine-ayse",
+      _id: "Container-linked2",
+      body: {
+        measureSlots: ["temperatureExt"],
+      },
+    });
+
+    await expect(
+      sdk.document.get("engine-ayse", "devices", "DummyTempPosition-linked2"),
+    ).resolves.toMatchObject({
+      _source: {
+        linkedMeasures: expect.arrayContaining([
+          {
+            assetId: "Container-linked2",
+            measureSlots: [
+              {
+                asset: "position",
+                device: "position",
+              },
+            ],
+          },
+        ]),
+      },
+    });
+
+    await expect(
+      sdk.document.get("engine-ayse", "assets", "Container-linked2"),
+    ).resolves.toMatchObject({
+      _source: {
+        linkedMeasures: expect.arrayContaining([
+          {
+            deviceId: "DummyTempPosition-linked2",
+            measureSlots: [
+              {
+                asset: "position",
+                device: "position",
+              },
+            ],
+          },
+        ]),
+      },
+    });
+  });
+
+  it("Unlink all measures from the asset", async () => {
+    await sdk.query<ApiAssetUnlinkDevicesRequest>({
+      controller: "device-manager/assets",
+      action: "unlinkDevices",
+      engineId: "engine-ayse",
+      _id: "Container-linked2",
+      body: {
+        allMeasures: true,
+      },
+    });
+
+    await expect(
+      sdk.document.get("engine-ayse", "assets", "Container-linked2"),
+    ).resolves.toMatchObject({
+      _source: {
+        linkedMeasures: [],
+      },
+    });
+  });
   it("Throw an error if no measure is provided", async () => {
     const promise = sdk.query<ApiAssetUnlinkDevicesRequest>({
       controller: "device-manager/assets",
       action: "unlinkDevices",
       _id: "Container-unlinked1",
-      body: {
-        linkedMeasures: [],
-      },
+      body: {},
       engineId: "engine-ayse",
     });
 
@@ -74,12 +135,7 @@ describe("features/Device/Controller/UnlinkAssets", () => {
       action: "unlinkDevices",
       _id: "Container-unlinked1",
       body: {
-        linkedMeasures: [
-          {
-            deviceId: "DummyTemp-unlinked1",
-            allMeasures: true,
-          },
-        ],
+        devices: ["DummyTemp-unlinked1"],
       },
       engineId: "engine-ayse",
     });

--- a/tests/scenario/modules/assets/action-unlink-devices.test.ts
+++ b/tests/scenario/modules/assets/action-unlink-devices.test.ts
@@ -53,7 +53,22 @@ describe("features/Device/Controller/UnlinkAssets", () => {
       _source: { linkedMeasures: [] },
     });
   });
+  it("Throw an error if no measure is provided", async () => {
+    const promise = sdk.query<ApiAssetUnlinkDevicesRequest>({
+      controller: "device-manager/assets",
+      action: "unlinkDevices",
+      _id: "Container-unlinked1",
+      body: {
+        linkedMeasures: [],
+      },
+      engineId: "engine-ayse",
+    });
 
+    await expect(promise).rejects.toMatchObject({
+      message:
+        "The list of measures to unlink from device Container-unlinked1 is empty",
+    });
+  });
   it("Error when the asset was not linked", async () => {
     const promise = sdk.query<ApiAssetUnlinkDevicesRequest>({
       controller: "device-manager/assets",

--- a/tests/scenario/modules/assets/action-unlink-devices.test.ts
+++ b/tests/scenario/modules/assets/action-unlink-devices.test.ts
@@ -64,10 +64,9 @@ describe("features/Device/Controller/UnlinkAssets", () => {
       engineId: "engine-ayse",
     });
 
-    await expect(promise).rejects.toMatchObject({
-      message:
-        "The list of measures to unlink from device Container-unlinked1 is empty",
-    });
+    await expect(promise).rejects.toThrow(
+      "The list of measures to unlink from asset Container-unlinked1 is empty",
+    );
   });
   it("Error when the asset was not linked", async () => {
     const promise = sdk.query<ApiAssetUnlinkDevicesRequest>({


### PR DESCRIPTION
## What does this PR do ?
This PR adds a guard in `AssetsController` `unlinkDevices` and `DevicesController` `unlinkAssets` that throws if threre are no measures provided to be unlinked

### How should this be manually tested?
Try unlinking measures from a device or an assets with an empty array of measures

KZLPRD-1125