### PR TITLE
fix(measureIngest): infer engineGroup from engine

### DIFF
--- a/doc/3/controllers/assets/ingest-measure/index.md
+++ b/doc/3/controllers/assets/ingest-measure/index.md
@@ -26,7 +26,7 @@ Method: POST
 ```js
 {
   "controller": "device-manager/assets",
-  "action": "measureIngest",
+  "action": "ingestMeasure",
   "assetId": "<assetId>",
   "engineId": "<engineId>",
   "slotName": "<slotName>"
@@ -44,9 +44,6 @@ Method: POST
       // ...
     }
   },
-
-  // optional:
-  "engineGroup": "<engine group>"
 }
 ```
 
@@ -57,7 +54,6 @@ Method: POST
 - `engineId`: target engine id
 - `assetId`: target asset id
 - `slotName`: target measure slot name
-- `engineGroup` (optional): target engine group
 
 ## Body properties
 - `dataSource`: the measure source
@@ -78,7 +74,7 @@ Method: POST
   "status": 200,
   "error": null,
   "controller": "device-manager/assets",
-  "action": "measureIngest",
+  "action": "ingestMeasure",
   "requestId": "<unique request identifier>",
   "result": null,
 }

--- a/doc/3/controllers/assets/ingest-measures/index.md
+++ b/doc/3/controllers/assets/ingest-measures/index.md
@@ -17,7 +17,7 @@ Ingest measures from a data source into an asset.
 ### HTTP
 
 ```http
-URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:assetId/_mMeasureIngest
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:assetId/_mIngestMeasure
 Method: POST
 ```
 
@@ -26,7 +26,7 @@ Method: POST
 ```js
 {
   "controller": "device-manager/assets",
-  "action": "_mMeasureIngest",
+  "action": "mIngestMeasure",
   "assetId": "<assetId>",
   "engineId": "<engineId>",
   "body": {
@@ -49,9 +49,6 @@ Method: POST
       // ...
     ]
   },
-
-  // optional:
-  "engineGroup": "<engine group>"
 }
 ```
 
@@ -61,7 +58,6 @@ Method: POST
 
 - `engineId`: target engine id
 - `assetId`: target asset id
-- `engineGroup`: (optional): target engine group
 
 ## Body properties
 
@@ -88,7 +84,7 @@ Method: POST
   "status": 200,
   "error": null,
   "controller": "device-manager/assets",
-  "action": "mMeasureIngest",
+  "action": "mIngestMeasure",
   "requestId": "<unique request identifier>",
   "result": null,
 }

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -151,14 +151,10 @@ export type ApiAssetGetMeasuresResult = {
 type TypelessApiMeasureSource = Omit<ApiMeasureSource, "type">;
 
 export interface ApiAssetMeasureIngestRequest extends AssetsControllerRequest {
-  action: "measureIngest";
-
+  action: "ingestMeasure";
   assetId: string;
-
   engineId: string;
-  engineGroup?: string;
   slotName: string;
-
   body: {
     dataSource: TypelessApiMeasureSource;
     measuredAt: number;
@@ -170,13 +166,9 @@ export type ApiAssetMeasureIngestResult = void;
 type APIDecodedMeasurement = Omit<Measurement, "type"> & { slotName: string };
 
 export interface ApiAssetmMeasureIngestRequest extends AssetsControllerRequest {
-  action: "mMeasureIngest";
-
+  action: "mIngestMeasure";
   assetId: string;
-
   engineId: string;
-  engineGroup?: string;
-
   body: {
     dataSource: TypelessApiMeasureSource;
     measurements: APIDecodedMeasurement[];

--- a/lib/modules/model/ModelService.ts
+++ b/lib/modules/model/ModelService.ts
@@ -823,7 +823,9 @@ export class ModelService extends BaseService {
     );
 
     if (result.total === 0) {
-      throw new NotFoundError(`Unknown Asset model "${model}".`);
+      throw new NotFoundError(
+        `Unknown Asset model "${model}" for engineGroup ${engineGroup}.`,
+      );
     }
 
     return result.hits[0];

--- a/lib/modules/shared/services/DigitalTwinService.ts
+++ b/lib/modules/shared/services/DigitalTwinService.ts
@@ -817,7 +817,7 @@ export class DigitalTwinService extends BaseService {
       model,
     });
   }
-  protected async getEngine(engineId: string): Promise<JSONObject> {
+  public async getEngine(engineId: string): Promise<JSONObject> {
     const engine = await this.sdk.document.get(
       this.config.platformIndex,
       InternalCollection.CONFIG,

--- a/tests/scenario/modules/assets/action-measure-ingest.test.ts
+++ b/tests/scenario/modules/assets/action-measure-ingest.test.ts
@@ -21,7 +21,7 @@ describe("AssetsController:measureIngest", () => {
         ApiAssetMeasureIngestResult
       >({
         controller: "device-manager/assets",
-        action: "measureIngest",
+        action: "ingestMeasure",
         assetId,
         engineId: indexId,
         slotName: "magiculeExt",
@@ -82,7 +82,7 @@ describe("AssetsController:measureIngest", () => {
         ApiAssetMeasureIngestResult
       >({
         controller: "device-manager/assets",
-        action: "measureIngest",
+        action: "ingestMeasure",
         assetId,
         engineId: "engine-ayse",
         slotName: "magiculeExt",
@@ -126,7 +126,7 @@ describe("AssetsController:measureIngest", () => {
         ApiAssetMeasureIngestResult
       >({
         controller: "device-manager/assets",
-        action: "measureIngest",
+        action: "ingestMeasure",
         assetId,
         engineId: "engine-ayse",
         slotName: "magiculeExt",

--- a/tests/scenario/modules/assets/action-mmeasure-ingest.test.ts
+++ b/tests/scenario/modules/assets/action-mmeasure-ingest.test.ts
@@ -199,7 +199,7 @@ describe("AssetsController:mMeasureIngest", () => {
       const indexId = "engine-ayse";
 
       const query = await axios.post(
-        `http://localhost:7512/_/device-manager/${indexId}/assets/${assetId}/_mMeasureIngest`,
+        `http://localhost:7512/_/device-manager/${indexId}/assets/${assetId}/_mIngestMeasure`,
         {
           dataSource: {
             type: "api",
@@ -277,7 +277,7 @@ describe("AssetsController:mMeasureIngest", () => {
 
       const query = await axios
         .post(
-          `http://localhost:7512/_/device-manager/${indexId}/assets/${assetId}/_mMeasureIngest`,
+          `http://localhost:7512/_/device-manager/${indexId}/assets/${assetId}/_mIngestMeasure`,
           {
             dataSource: {
               type: "api",
@@ -323,7 +323,7 @@ describe("AssetsController:mMeasureIngest", () => {
 
       const query = await axios
         .post(
-          `http://localhost:7512/_/device-manager/${indexId}/assets/${assetId}/_mMeasureIngest`,
+          `http://localhost:7512/_/device-manager/${indexId}/assets/${assetId}/_mIngestMeasure`,
           {
             dataSource: {
               type: "api",

--- a/tests/scenario/modules/assets/action-mmeasure-ingest.test.ts
+++ b/tests/scenario/modules/assets/action-mmeasure-ingest.test.ts
@@ -21,7 +21,7 @@ describe("AssetsController:mMeasureIngest", () => {
         ApiAssetmMeasureIngestResult
       >({
         controller: "device-manager/assets",
-        action: "mMeasureIngest",
+        action: "mIngestMeasure",
         assetId,
         engineId: indexId,
         body: {
@@ -103,7 +103,7 @@ describe("AssetsController:mMeasureIngest", () => {
         ApiAssetmMeasureIngestResult
       >({
         controller: "device-manager/assets",
-        action: "mMeasureIngest",
+        action: "mIngestMeasure",
         assetId,
         engineId: "engine-ayse",
         body: {
@@ -151,7 +151,7 @@ describe("AssetsController:mMeasureIngest", () => {
         ApiAssetmMeasureIngestResult
       >({
         controller: "device-manager/assets",
-        action: "mMeasureIngest",
+        action: "mIngestMeasure",
         assetId,
         engineId: "engine-ayse",
         body: {

--- a/tests/scenario/modules/assets/asset-SCRUD.test.ts
+++ b/tests/scenario/modules/assets/asset-SCRUD.test.ts
@@ -74,7 +74,7 @@ describe("AssetsController:SCRUD", () => {
       },
     };
     await expect(sdk.query(unknownModel)).rejects.toThrow(
-      /^Unknown Asset model "truck".$/,
+      'Unknown Asset model "truck" for engineGroup commons.',
     );
 
     const withoutMetadata = await sdk.query<


### PR DESCRIPTION
## What does this PR do ?
This PR infer engineGroup from engine for measureIngest cf [PR](https://github.com/kuzzleio/kuzzle-device-manager/pull/454)

It also changes the endpoints for more consistancy in the api (related to [ticket](https://kuzzle.atlassian.net/browse/KZLPRD-1127))