### PR TITLE
feat(assets): allow to add or remove measure slots to an asset

### DIFF
--- a/doc/3/controllers/assets/add-measure-slot/index.md
+++ b/doc/3/controllers/assets/add-measure-slot/index.md
@@ -1,0 +1,70 @@
+---
+code: true
+type: page
+title: create
+description: Add measure slot
+---
+
+# addMeasureSlot
+
+Adds a measure slot to an asset.
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/measure-slot/
+Method: POST
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/assets",
+  "action": "addMeasureSlot",
+  "engineId": "<engineId>",
+  "_id":"<asset _id>"
+  "body": {
+    "measureSlot":{
+      "name":"string"
+      "type":"string"
+    }
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+- `engineId`: Engine ID
+- `_id`: Asset ID
+
+## Body properties
+
+- `measureSlot`: The measure slot to be added 
+          - `name`: Asset name of the measure slot
+          - `type`: The type of measure
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/assets",
+  "action": "addMeasureSlot",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<assetId>",
+    "_source": {
+      // Asset content
+    },
+  }
+}
+```

--- a/doc/3/controllers/assets/remove-measure-slot/index.md
+++ b/doc/3/controllers/assets/remove-measure-slot/index.md
@@ -1,0 +1,66 @@
+---
+code: true
+type: page
+title: create
+description: Remove measure slot
+---
+
+# removeMeasureSlot
+
+Removes a measure slot from an asset.
+It can only remove a measure slot that is not linked to a device and that is not defined in the asset model.
+
+## Query Syntax
+
+### HTTP
+
+```http
+URL: http://kuzzle:7512/_/device-manager/:engineId/assets/:_id/measure-slot/
+Method: delete
+```
+
+### Other protocols
+
+```js
+{
+  "controller": "device-manager/assets",
+  "action": "removeMeasureSlot",
+  "engineId": "<engineId>",
+  "_id":"<asset _id>"
+  "body": {
+    "measureSlot":"string"
+    }
+  }
+}
+```
+
+---
+
+## Arguments
+
+- `engineId`: Engine ID
+- `_id`: Asset ID
+
+## Body properties
+
+- `measureSlot`: The asset name of the measure slot
+
+---
+
+## Response
+
+```js
+{
+  "status": 200,
+  "error": null,
+  "controller": "device-manager/assets",
+  "action": "removeMeasureSlot",
+  "requestId": "<unique request identifier>",
+  "result": {
+    "_id": "<assetId>",
+    "_source": {
+      // Asset content
+    },
+  }
+}
+```

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -22,7 +22,11 @@ import {
   AskDeviceDetachEngine,
   DeviceSerializer,
 } from "../device";
-import { AskModelAssetGet, AssetModelContent } from "../model";
+import {
+  AskModelAssetGet,
+  AskModelMeasureGet,
+  AssetModelContent,
+} from "../model";
 import {
   AskEngineList,
   DeviceManagerPlugin,
@@ -766,6 +770,89 @@ export class AssetService extends DigitalTwinService {
     }
 
     return results;
+  }
+
+  public async addMeasureSlot(
+    assetId: string,
+    measureSlot: AssetContent["measureSlots"][0],
+    engineId: string,
+    request: KuzzleRequest,
+  ): Promise<KDocument<AssetContent>> {
+    const asset = await this.get(engineId, assetId, request);
+    if (
+      asset._source.measureSlots.some((slot) => slot.name === measureSlot.name)
+    ) {
+      throw new BadRequestError(
+        `A measure slot with ${measureSlot.name} as a name already exists for ${assetId}`,
+      );
+    }
+    try {
+      await ask<AskModelMeasureGet>("ask:device-manager:model:measure:get", {
+        type: measureSlot.type,
+      });
+    } catch {
+      throw new BadRequestError(
+        `There is no measure of type ${measureSlot.type} registered.`,
+      );
+    }
+    asset._source.measureSlots.push(measureSlot);
+    const updatedAsset = await this.updateDocument<AssetContent>(
+      request,
+      asset,
+      {
+        collection: InternalCollection.ASSETS,
+        engineId,
+      },
+    );
+    return updatedAsset;
+  }
+  public async removeMeasureSlot(
+    assetId: string,
+    measureSlotName: string,
+    engineId: string,
+    request: KuzzleRequest,
+  ): Promise<KDocument<AssetContent>> {
+    const asset = await this.get(engineId, assetId, request);
+    if (
+      !asset._source.measureSlots.some((slot) => slot.name === measureSlotName)
+    ) {
+      throw new BadRequestError(
+        `Asset ${assetId} does not have a measure slot named ${measureSlotName}`,
+      );
+    }
+    const linkedDevice = asset._source.linkedMeasures.find((link) =>
+      link.measureSlots.some((slot) => slot.asset === measureSlotName),
+    );
+    if (linkedDevice) {
+      throw new BadRequestError(
+        `Measure slot ${measureSlotName} can not be removed as it is currently linked to ${linkedDevice.deviceId}`,
+      );
+    }
+    const engine = await this.getEngine(engineId);
+    const assetModel = await this.getAssetModel(
+      engine.group,
+      asset._source.model,
+    );
+    if (!assetModel) {
+      throw new NotFoundError(`Model ${asset._source.model} not found`);
+    }
+    if (assetModel.asset.measures.some((m) => m.name === measureSlotName)) {
+      throw new BadRequestError(
+        `Measure slot ${measureSlotName} can not be removed as it is set in the ${asset._source.model} model`,
+      );
+    }
+    asset._source.measureSlots = asset._source.measureSlots.filter(
+      (slot) => slot.name !== measureSlotName,
+    );
+    const updatedAsset = await this.updateDocument<AssetContent>(
+      request,
+      asset,
+      {
+        collection: InternalCollection.ASSETS,
+        engineId,
+      },
+    );
+    return updatedAsset;
   }
 
   private async refreshModel({

--- a/lib/modules/asset/AssetService.ts
+++ b/lib/modules/asset/AssetService.ts
@@ -59,7 +59,7 @@ import {
 } from "./types/AssetHistoryContent";
 
 export class AssetService extends DigitalTwinService {
-  private assetHistoryService: AssetHistoryService;
+  readonly assetHistoryService: AssetHistoryService;
 
   constructor(
     plugin: DeviceManagerPlugin,
@@ -539,7 +539,7 @@ export class AssetService extends DigitalTwinService {
       }));
 
       //We want to create the new asset with linked devices and groups empty
-      const assetsContentCopy = _.cloneDeep(assetsContent);
+      const assetsContentCopy = structuredClone(assetsContent);
       for (const asset of assetsContentCopy) {
         asset.body.linkedMeasures = [];
         asset.body.groups = [];

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -36,6 +36,8 @@ import {
   ApiAssetLinkDevicesResult,
   ApiAssetlinkDevicesRequest,
   ApiAssetUnlinkDevicesResult,
+  ApiAssetAddMeasureSlotResult,
+  ApiAssetRemoveMeasureSlotResult,
 } from "./types/AssetApi";
 import { isSourceApi } from "../measure/types/MeasureSources";
 import { getValidator } from "../shared/utils/AJValidator";
@@ -233,6 +235,24 @@ export class AssetsController {
           http: [
             {
               path: "device-manager/:engineId/assets/:_id/_unlink/",
+              verb: "delete",
+            },
+          ],
+        },
+        addMeasureSlot: {
+          handler: this.addMeasureSlot.bind(this),
+          http: [
+            {
+              path: "device-manager/:engineId/assets/:_id/measure-slot/",
+              verb: "post",
+            },
+          ],
+        },
+        removeMeasureSlot: {
+          handler: this.removeMeasureSlot.bind(this),
+          http: [
+            {
+              path: "device-manager/:engineId/assets/:_id/measure-slot/",
               verb: "delete",
             },
           ],
@@ -864,6 +884,51 @@ export class AssetsController {
       allMeasures,
       deviceIds,
       measureSlots,
+      request,
+    );
+  }
+  /**
+   * Remove a measure slot from an asset
+   */
+  async addMeasureSlot(
+    request: KuzzleRequest,
+  ): Promise<ApiAssetAddMeasureSlotResult> {
+    const assetId = request.getId();
+    const engineId = request.getString("engineId");
+    const measureSlot = request.getBodyObject("measureSlot");
+    const { type, name } = measureSlot;
+    if (typeof type !== "string" || typeof name !== "string") {
+      throw new BadRequestError(
+        `Please provide a valid measure slot to be added`,
+      );
+    }
+
+    return this.assetService.addMeasureSlot(
+      assetId,
+      { name, type },
+      engineId,
+      request,
+    );
+  }
+  /**
+   * Remove a measure slot from an asset
+   */
+  async removeMeasureSlot(
+    request: KuzzleRequest,
+  ): Promise<ApiAssetRemoveMeasureSlotResult> {
+    const assetId = request.getId();
+    const engineId = request.getString("engineId");
+    const measureSlotName = request.getBodyString("measureSlot");
+    if (typeof measureSlotName !== "string") {
+      throw new BadRequestError(
+        `Please provide a valid measure slot name to be removed`,
+      );
+    }
+
+    return this.assetService.removeMeasureSlot(
+      assetId,
+      measureSlotName,
+      engineId,
       request,
     );
   }

--- a/lib/modules/asset/AssetsController.ts
+++ b/lib/modules/asset/AssetsController.ts
@@ -54,12 +54,12 @@ import { DeviceContent, DeviceSerializer } from "../device";
 
 export class AssetsController {
   public definition: ControllerDefinition;
-  private exporter: DigitalTwinExporter;
-  private measureExporter: MeasureExporter;
+  readonly exporter: DigitalTwinExporter;
+  readonly measureExporter: MeasureExporter;
 
   constructor(
-    private plugin: DeviceManagerPlugin,
-    private assetService: AssetService,
+    readonly plugin: DeviceManagerPlugin,
+    readonly assetService: AssetService,
   ) {
     /* eslint-disable sort-keys */
     this.definition = {
@@ -494,7 +494,7 @@ export class AssetsController {
         );
 
       asset = assetDocument._source;
-    } catch (error) {
+    } catch {
       throw new BadRequestError(
         `Asset "${assetId}" does not exists on index "${indexId}"`,
       );

--- a/lib/modules/asset/types/AssetApi.ts
+++ b/lib/modules/asset/types/AssetApi.ts
@@ -344,3 +344,45 @@ export type ApiAssetUnlinkDevicesResult = {
   asset: KDocument<AssetContent>;
   devices: KDocument<DeviceContent>[];
 };
+
+export interface ApiAssetAddMeasureSlotRequest extends AssetsControllerRequest {
+  action: "addMeasureSlot";
+
+  _id: string;
+
+  body: {
+    /**
+     * Measure slot containing the name of the slot and it's type of measurement
+     *
+     * { name: string , type: string}
+     *
+     * @example
+     *
+     *   { name: "externalTemperature", type: "temperature" }
+     */
+    measureSlot: { name: string; type: string };
+  };
+}
+
+export type ApiAssetAddMeasureSlotResult = KDocument<AssetContent>;
+
+export interface ApiAssetRemoveMeasureSlotRequest
+  extends AssetsControllerRequest {
+  action: "removeMeasureSlot";
+
+  _id: string;
+
+  body: {
+    /**
+     * Name of the measure slot to be removed
+     *
+     *
+     * @example
+     *
+     *   measureSlot: "externalTemperature",
+     */
+    measureSlot: string;
+  };
+}
+
+export type ApiAssetRemoveMeasureSlotResult = KDocument<AssetContent>;

--- a/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -9,7 +9,7 @@ import { ConfigManager, EngineController } from "kuzzle-plugin-commons";
 import { JSONObject } from "kuzzle-sdk";
 import _ from "lodash";
 
-import { MeasureDefinition, measuresMappings } from "../measure";
+import { MeasureDefinition, measuresMappings, MeasureModule } from "../measure";
 
 import { groupsMappings, AssetModule, assetsMappings } from "../asset";
 import {
@@ -23,7 +23,6 @@ import {
   devicesPlatformMappings,
   devicesMappings,
 } from "../device";
-import { MeasureModule } from "../measure";
 import {
   AssetModelDefinition,
   DeviceModelDefinition,
@@ -54,8 +53,8 @@ export class DeviceManagerPlugin extends Plugin {
   private measureModule: MeasureModule;
   private modelModule: ModelModule;
 
-  private modelsRegister: ModelsRegister;
-  private decodersRegister: DecodersRegister;
+  readonly modelsRegister: ModelsRegister;
+  readonly decodersRegister: DecodersRegister;
 
   private get sdk() {
     return this.context.accessors.sdk;
@@ -596,8 +595,8 @@ export class DeviceManagerPlugin extends Plugin {
    * Those custom mappings allow to search raw payloads more efficiently.
    */
   private getPayloadsMappings(): JSONObject {
-    const { mappings } = JSON.parse(
-      JSON.stringify(this.config.platformCollections.payloads),
+    const { mappings } = structuredClone(
+      this.config.platformCollections.payloads,
     );
 
     for (const decoder of this.decodersRegister.decoders) {

--- a/lib/modules/shared/services/DigitalTwinService.ts
+++ b/lib/modules/shared/services/DigitalTwinService.ts
@@ -72,7 +72,7 @@ export class DigitalTwinService extends BaseService {
 
   constructor(
     plugin: DeviceManagerPlugin,
-    private targetCollection: InternalCollection,
+    readonly targetCollection: InternalCollection,
   ) {
     super(plugin);
 
@@ -225,7 +225,7 @@ export class DigitalTwinService extends BaseService {
       }
       if (updatedMeasureSlots.length === 0) {
         if (
-          !device._source.linkedMeasures.find(
+          !device._source.linkedMeasures.some(
             (link) => link.assetId === asset._id,
           )
         ) {

--- a/tests/scenario/modules/assets/action-add-measure-slot.test.ts
+++ b/tests/scenario/modules/assets/action-add-measure-slot.test.ts
@@ -1,0 +1,89 @@
+import { ApiAssetAddMeasureSlotRequest } from "../../../../index";
+
+import { beforeEachTruncateCollections } from "../../../hooks/collections";
+import { beforeAllCreateEngines } from "../../../hooks/engines";
+import { beforeEachLoadFixtures } from "../../../hooks/fixtures";
+
+import { useSdk } from "../../../helpers";
+
+jest.setTimeout(10000);
+
+describe("AssetController: add measure slot", () => {
+  const sdk = useSdk();
+
+  beforeAll(async () => {
+    await sdk.connect();
+    await beforeAllCreateEngines(sdk);
+  });
+
+  beforeEach(async () => {
+    await beforeEachTruncateCollections(sdk);
+    await beforeEachLoadFixtures(sdk);
+  });
+
+  afterAll(async () => {
+    sdk.disconnect();
+  });
+
+  const newSlot = {
+    name: "temperatureInt2",
+    type: "temperature",
+  };
+  const existingSlot = {
+    name: "temperatureInt",
+    type: "temperature",
+  };
+  const wrongMeasureType = {
+    name: "wrongMeasure",
+    type: "inexistingMeasureType",
+  };
+  it("should add a measure slot to the asset", async () => {
+    await expect(
+      sdk.query<ApiAssetAddMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "addMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: newSlot,
+        },
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        _source: {
+          measureSlots: expect.arrayContaining([newSlot]),
+        },
+      },
+    });
+  });
+  it("should throw an error if the measure type does not exist", async () => {
+    await expect(
+      sdk.query<ApiAssetAddMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "addMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: wrongMeasureType,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: `There is no measure of type ${wrongMeasureType.type} registered.`,
+    });
+  });
+  it("should throw an error if the measure name already exists", async () => {
+    await expect(
+      sdk.query<ApiAssetAddMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "addMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: existingSlot,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: `A measure slot with ${existingSlot.name} as a name already exists for Container-linked1`,
+    });
+  });
+});

--- a/tests/scenario/modules/assets/action-remove-measure-slot.test.ts
+++ b/tests/scenario/modules/assets/action-remove-measure-slot.test.ts
@@ -1,0 +1,155 @@
+import { beforeEachTruncateCollections } from "../../../hooks/collections";
+import { beforeAllCreateEngines } from "../../../hooks/engines";
+import { beforeEachLoadFixtures } from "../../../hooks/fixtures";
+
+import { useSdk } from "../../../helpers";
+import {
+  ApiAssetAddMeasureSlotRequest,
+  ApiAssetlinkDevicesRequest,
+  ApiAssetRemoveMeasureSlotRequest,
+} from "lib/modules/asset";
+
+jest.setTimeout(10000);
+
+describe("AssetController: add measure slot", () => {
+  const sdk = useSdk();
+
+  beforeAll(async () => {
+    await sdk.connect();
+    await beforeAllCreateEngines(sdk);
+  });
+
+  beforeEach(async () => {
+    await beforeEachTruncateCollections(sdk);
+    await beforeEachLoadFixtures(sdk);
+  });
+
+  afterAll(async () => {
+    sdk.disconnect();
+  });
+
+  const newSlot = {
+    name: "temperatureInt2",
+    type: "temperature",
+  };
+  const unknownSlotName = "unknownSlot";
+  const modelSlotName = "temperatureInt";
+  it("should remove a measure slot from the asset", async () => {
+    await expect(
+      sdk.query<ApiAssetAddMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "addMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: newSlot,
+        },
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        _source: {
+          measureSlots: expect.arrayContaining([newSlot]),
+        },
+      },
+    });
+
+    await expect(
+      sdk.query<ApiAssetRemoveMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "removeMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: newSlot.name,
+        },
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        _source: {
+          measureSlots: expect.not.arrayContaining([newSlot]),
+        },
+      },
+    });
+  });
+  it("should throw an error if the measure slot is linked", async () => {
+    await expect(
+      sdk.query<ApiAssetAddMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "addMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: newSlot,
+        },
+      }),
+    ).resolves.toMatchObject({
+      result: {
+        _source: {
+          measureSlots: expect.arrayContaining([newSlot]),
+        },
+      },
+    });
+    await sdk.query<ApiAssetlinkDevicesRequest>({
+      controller: "device-manager/assets",
+      action: "linkDevices",
+      engineId: "engine-ayse",
+      _id: "Container-linked1",
+      body: {
+        linkedMeasures: [
+          {
+            deviceId: "DummyTemp-unlinked1",
+            measureSlots: [
+              {
+                asset: newSlot.name,
+                device: "temperature",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    await expect(
+      sdk.query<ApiAssetRemoveMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "removeMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: newSlot.name,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: `Measure slot ${newSlot.name} can not be removed as it is currently linked to DummyTemp-unlinked1`,
+    });
+  });
+  it("should throw an error if the measure slot does not exist", async () => {
+    await expect(
+      sdk.query<ApiAssetRemoveMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "removeMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: unknownSlotName,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: `Asset Container-linked1 does not have a measure slot named ${unknownSlotName}`,
+    });
+  });
+  it("should throw an error if the measure slot is set in the model", async () => {
+    await expect(
+      sdk.query<ApiAssetRemoveMeasureSlotRequest>({
+        controller: "device-manager/assets",
+        action: "removeMeasureSlot",
+        engineId: "engine-ayse",
+        _id: "Container-linked1",
+        body: {
+          measureSlot: modelSlotName,
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: `Measure slot ${modelSlotName} can not be removed as it is set in the Container model`,
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do ?
This PR adds the possibility to add or remove a `measureSlot` to/from an asset. 
The measureSlot name must be unique.
A measureSlot that is linked to a device can not be removed.
A measureSlot that is defined in the asset model can not be removed.

