### PR TITLE
feat(actions): add action slot types and codec encoder interface (KZLPRD-925)

### DIFF
--- a/plugin/lib/modules/action/collections/actionsMappings.ts
+++ b/plugin/lib/modules/action/collections/actionsMappings.ts
@@ -1,0 +1,53 @@
+import { CollectionMappings } from "kuzzle-sdk";
+
+/**
+ * Base mappings for the "actions" collection.
+ *
+ * Stores action execution records: dispatched commands, their arguments,
+ * status, and timestamps.
+ */
+export const actionsMappings: CollectionMappings = {
+  dynamic: "strict",
+  properties: {
+    type: { type: "keyword" },
+
+    args: {
+      dynamic: "false",
+      properties: {},
+    },
+
+    /**
+     * Timestamp when the action was dispatched.
+     */
+    dispatchedAt: { type: "date" },
+
+    /**
+     * Timestamp when the action was acknowledged by the device.
+     */
+    acknowledgedAt: { type: "date" },
+
+    /**
+     * Current status of the action.
+     */
+    status: { type: "keyword" },
+
+    asset: {
+      properties: {
+        _id: { type: "keyword" },
+        model: { type: "keyword" },
+        reference: { type: "keyword" },
+        actionName: { type: "keyword" },
+      },
+    },
+
+    origin: {
+      properties: {
+        type: { type: "keyword" },
+        actionName: { type: "keyword" },
+        deviceModel: { type: "keyword" },
+        reference: { type: "keyword" },
+        _id: { type: "keyword" },
+      },
+    },
+  },
+};

--- a/plugin/lib/modules/asset/AssetService.ts
+++ b/plugin/lib/modules/asset/AssetService.ts
@@ -328,7 +328,9 @@ export class AssetService extends DigitalTwinService {
       {
         _id: assetId,
         _source: {
+          actionSlots: [],
           groups: [],
+          linkedActions: [],
           linkedMeasures: [],
           measureSlots: assetModel.asset.measures,
           metadata: { ...assetMetadata, ...metadata },

--- a/plugin/lib/modules/asset/collections/assetsMappings.ts
+++ b/plugin/lib/modules/asset/collections/assetsMappings.ts
@@ -75,5 +75,22 @@ export const assetsMappings: CollectionMappings = {
         type: { type: "keyword" },
       },
     },
+    linkedActions: {
+      properties: {
+        deviceId: { type: "keyword" },
+        actionSlots: {
+          properties: {
+            asset: { type: "keyword" },
+            device: { type: "keyword" },
+          },
+        },
+      },
+    },
+    actionSlots: {
+      properties: {
+        name: { type: "keyword" },
+        type: { type: "keyword" },
+      },
+    },
   },
 };

--- a/plugin/lib/modules/asset/types/AssetContent.ts
+++ b/plugin/lib/modules/asset/types/AssetContent.ts
@@ -28,6 +28,28 @@ export interface AssetContent<
      */
     measureSlots: Array<{ asset: string; device: string }>;
   }>;
+
+  /**
+   * Link with attached devices for action slots (outbound commands)
+   */
+  linkedActions: Array<{
+    /**
+     * Device ID
+     */
+    deviceId: string;
+
+    /**
+     * Names of the linked action slots
+     *
+     * @example
+     *
+     * [
+     *   { asset: "setTemperature", device: "setTemp" }
+     * ]
+     */
+    actionSlots: Array<{ asset: string; device: string }>;
+  }>;
+
   /**
    * Path's of asset groups
    */

--- a/plugin/lib/modules/decoder/Decoder.ts
+++ b/plugin/lib/modules/decoder/Decoder.ts
@@ -20,6 +20,17 @@ export type NamedMeasures = Array<{
 }>;
 
 /**
+ * Array of action slot declarations
+ *
+ * Used to declare which actions a device codec can encode (outbound commands).
+ */
+export type NamedActions = Array<{
+  name: string;
+
+  type: string;
+}>;
+
+/**
  * Base class to implement a decoder for a device model.
  * The device model must be passed to the parent constructor.
  * The abstract "decode" method must be implemented.
@@ -51,6 +62,18 @@ export abstract class Decoder {
    * ];
    */
   public measures: ReadonlyArray<NamedMeasures[0]> = [];
+
+  /**
+   * Declaration of the actions this codec can encode (outbound commands).
+   * Action types should be registered as action models on the plugin.
+   *
+   * @example
+   *
+   * this.actions = [
+   *   { type: 'temperatureSetpoint', name: 'setTemperature' },
+   * ];
+   */
+  public actions: ReadonlyArray<NamedActions[0]> = [];
 
   /**
    * Custom name for the associated API action in the "payload" controller
@@ -157,6 +180,22 @@ export abstract class Decoder {
   ): Promise<DecodedPayload<any>>;
 
   /**
+   * Encode an action request into a device-specific payload.
+   * Override this method in codecs that support outbound commands.
+   *
+   * @param actionName Name of the action slot on the device
+   * @param args Action arguments (validated against the action model's schema)
+   *
+   * @returns Device-specific payload to send
+   */
+  // eslint-disable-next-line no-unused-vars
+  async encode(actionName: string, args: JSONObject): Promise<JSONObject> {
+    throw new PreconditionError(
+      `Encoder not implemented for device model "${this.deviceModel}"`,
+    );
+  }
+
+  /**
    * Checks if the provided properties are present in the payload
    *
    * @param payload Raw payload received in the API action body
@@ -172,11 +211,20 @@ export abstract class Decoder {
     }
   }
 
+  get actionNames(): string[] {
+    return this.actions.map(({ name }) => name);
+  }
+
+  get actionTypes(): string[] {
+    return this.actions.map(({ type }) => type);
+  }
+
   serialize(): DecoderContent {
     return {
       action: this.action,
       deviceModel: this.deviceModel,
       measures: this.measures as NamedMeasures,
+      actions: this.actions as NamedActions,
     };
   }
 }

--- a/plugin/lib/modules/decoder/PayloadService.ts
+++ b/plugin/lib/modules/decoder/PayloadService.ts
@@ -398,6 +398,7 @@ export class PayloadService extends BaseService {
       const reference = rest.join("-");
 
       const body: DeviceProvisioningContent = {
+        actionSlots: [],
         engineId: null,
         lastMeasuredAt: 0,
         lastMeasures: [],

--- a/plugin/lib/modules/decoder/types/DecoderContent.ts
+++ b/plugin/lib/modules/decoder/types/DecoderContent.ts
@@ -1,8 +1,9 @@
-import { NamedMeasures } from "../Decoder";
+import { NamedActions, NamedMeasures } from "../Decoder";
 
 export interface DecoderContent {
   deviceModel: string;
   action?: string;
 
   measures: NamedMeasures;
+  actions: NamedActions;
 }

--- a/plugin/lib/modules/device/DeviceService.ts
+++ b/plugin/lib/modules/device/DeviceService.ts
@@ -80,8 +80,10 @@ export class DeviceService extends DigitalTwinService {
     let device: KDocument<DeviceContent> = {
       _id: deviceId,
       _source: {
+        actionSlots: [],
         engineId: null,
         groups: [],
+        linkedActions: [],
         linkedMeasures: [],
         measureSlots: [],
         metadata,
@@ -138,6 +140,7 @@ export class DeviceService extends DigitalTwinService {
         {
           _id: device._id,
           _source: {
+            actionSlots: [],
             engineId: null,
             lastMeasuredAt: null,
             lastMeasures: [],
@@ -514,8 +517,10 @@ export class DeviceService extends DigitalTwinService {
     const engineDevice: KDocument<DeviceContent> = {
       _id: device._id,
       _source: {
+        actionSlots: [],
         engineId,
         groups: [],
+        linkedActions: [],
         linkedMeasures: [],
         measureSlots: device._source.measureSlots,
         metadata: {},

--- a/plugin/lib/modules/device/collections/deviceMappings.ts
+++ b/plugin/lib/modules/device/collections/deviceMappings.ts
@@ -52,6 +52,23 @@ export const devicesMappings: CollectionMappings = {
         type: { type: "keyword" },
       },
     },
+    linkedActions: {
+      properties: {
+        assetId: { type: "keyword" },
+        actionSlots: {
+          properties: {
+            asset: { type: "keyword" },
+            device: { type: "keyword" },
+          },
+        },
+      },
+    },
+    actionSlots: {
+      properties: {
+        name: { type: "keyword" },
+        type: { type: "keyword" },
+      },
+    },
   },
 };
 
@@ -77,6 +94,12 @@ export const devicesPlatformMappings: CollectionMappings = {
     },
     lastMeasuredAt: { type: "date" },
     measureSlots: {
+      properties: {
+        name: { type: "keyword" },
+        type: { type: "keyword" },
+      },
+    },
+    actionSlots: {
       properties: {
         name: { type: "keyword" },
         type: { type: "keyword" },

--- a/plugin/lib/modules/device/types/DeviceContent.ts
+++ b/plugin/lib/modules/device/types/DeviceContent.ts
@@ -31,6 +31,27 @@ export interface DeviceContent<
   }>;
 
   /**
+   * Link with attached assets for action slots (outbound commands)
+   */
+  linkedActions: Array<{
+    /**
+     * Asset ID
+     */
+    assetId: string;
+
+    /**
+     * Names of the linked action slots
+     *
+     * @example
+     *
+     * [
+     *   { asset: "setTemperature", device: "setTemp" }
+     * ]
+     */
+    actionSlots: Array<{ asset: string; device: string }>;
+  }>;
+
+  /**
    */
   engineId: string | null;
   /**
@@ -48,7 +69,7 @@ export interface DeviceContent<
 
 interface DeviceProvisioningContentFields extends Pick<
   DeviceContent,
-  "model" | "reference" | "engineId" | "measureSlots"
+  "model" | "reference" | "engineId" | "measureSlots" | "actionSlots"
 > {
   /**
    * Date of provisioning of the device on the platform

--- a/plugin/lib/modules/model/ModelSerializer.ts
+++ b/plugin/lib/modules/model/ModelSerializer.ts
@@ -1,5 +1,6 @@
 import { BadRequestError } from "kuzzle";
 import {
+  ActionModelContent,
   AssetModelContent,
   DeviceModelContent,
   GroupModelContent,
@@ -48,6 +49,24 @@ export class ModelSerializer {
         return `model-measure-${sortedGroups}-${ModelSerializer.title(type, model)}`;
       }
       return `model-measure-${ModelSerializer.title(type, model)}`;
+    } else if (type === "action") {
+      const actionModel = model as ActionModelContent;
+      if (actionModel.engineIds?.length) {
+        const sortedEngines = [...actionModel.engineIds].sort().join("+");
+        if (actionModel.engineGroups?.length) {
+          const sortedGroups = [...actionModel.engineGroups].sort().join("+");
+          return `model-action-${sortedGroups}-${sortedEngines}-${ModelSerializer.title(type, model)}`;
+        }
+        return `model-action-${sortedEngines}-${ModelSerializer.title(type, model)}`;
+      }
+      if (
+        actionModel.engineGroups?.length &&
+        actionModel.engineGroups.length > 1
+      ) {
+        const sortedGroups = [...actionModel.engineGroups].sort().join("+");
+        return `model-action-${sortedGroups}-${ModelSerializer.title(type, model)}`;
+      }
+      return `model-action-${ModelSerializer.title(type, model)}`;
     }
 
     throw new BadRequestError(`Unknown model type "${type}"`);
@@ -62,6 +81,8 @@ export class ModelSerializer {
       return (model as GroupModelContent).group.model;
     } else if (type === "measure") {
       return (model as MeasureModelContent).measure.type;
+    } else if (type === "action") {
+      return (model as ActionModelContent).action.type;
     }
 
     throw new BadRequestError(`Unknown model type "${type}"`);

--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -22,6 +22,7 @@ import { AskAssetRefreshModel } from "../asset";
 import { BaseService, SearchParams, flattenObject } from "../shared";
 import { ModelSerializer } from "./ModelSerializer";
 import {
+  ActionModelContent,
   AssetModelContent,
   DeviceModelContent,
   GroupAffinity,
@@ -677,6 +678,151 @@ export class ModelService extends BaseService {
       this.config.platformIndex,
       InternalCollection.MODELS,
       _id,
+    );
+  }
+
+  async writeAction(
+    type: string,
+    argsSchema?: JSONObject,
+    locales?: { [valueName: string]: LocaleDetails },
+    engineIds?: string[],
+  ): Promise<KDocument<ActionModelContent>> {
+    const modelContent: ActionModelContent = {
+      action: {
+        argsSchema,
+        locales,
+        type,
+      },
+      type: "action",
+    };
+
+    if (engineIds?.length) {
+      modelContent.engineIds = engineIds;
+    }
+
+    const actionModel =
+      await this.sdk.document.createOrReplace<ActionModelContent>(
+        this.config.platformIndex,
+        InternalCollection.MODELS,
+        ModelSerializer.id<ActionModelContent>("action", modelContent),
+        modelContent,
+      );
+
+    await this.sdk.collection.refresh(
+      this.config.platformIndex,
+      InternalCollection.MODELS,
+    );
+
+    return actionModel;
+  }
+
+  async deleteAction(_id: string) {
+    await this.sdk.document.delete(
+      this.config.platformIndex,
+      InternalCollection.MODELS,
+      _id,
+    );
+  }
+
+  async getAction(
+    type: string,
+    engineId?: string,
+  ): Promise<KDocument<ActionModelContent>> {
+    const baseFilter = [
+      { term: { type: "action" } },
+      { term: { "action.type": type } },
+    ];
+
+    const scopeFilter = engineId
+      ? {
+          bool: {
+            should: [
+              { term: { engineIds: engineId } },
+              { bool: { must_not: [{ exists: { field: "engineIds" } }] } },
+            ],
+          },
+        }
+      : {
+          bool: {
+            must_not: [{ exists: { field: "engineIds" } }],
+          },
+        };
+
+    const result = await this.sdk.document.search<ActionModelContent>(
+      this.config.platformIndex,
+      InternalCollection.MODELS,
+      {
+        query: {
+          bool: {
+            must: [...baseFilter, scopeFilter],
+          },
+        },
+      },
+      { lang: "elasticsearch", size: 1 },
+    );
+
+    if (result.total > 0) {
+      return result.hits[0];
+    }
+
+    throw new NotFoundError(`Unknown Action type "${type}".`);
+  }
+
+  async listActions(
+    engineId?: string,
+  ): Promise<KDocument<ActionModelContent>[]> {
+    const result = await this.searchActions(engineId, {
+      searchBody: {
+        sort: { "action.type": "asc" },
+      },
+      size: 5000,
+    });
+
+    return result.hits;
+  }
+
+  async searchActions(
+    engineId: string | undefined,
+    searchParams: Partial<SearchParams>,
+  ): Promise<SearchResult<KHit<ActionModelContent>>> {
+    const scopeFilter = engineId
+      ? {
+          bool: {
+            should: [
+              { term: { engineIds: engineId } },
+              { bool: { must_not: [{ exists: { field: "engineIds" } }] } },
+            ],
+          },
+        }
+      : {
+          bool: {
+            must_not: [{ exists: { field: "engineIds" } }],
+          },
+        };
+
+    const query = {
+      bool: {
+        must: [
+          searchParams.searchBody.query,
+          { term: { type: "action" } },
+          scopeFilter,
+        ].filter(Boolean),
+      },
+    };
+
+    return this.sdk.document.search<ActionModelContent>(
+      this.config.platformIndex,
+      InternalCollection.MODELS,
+      {
+        ...searchParams.searchBody,
+        query,
+      },
+      {
+        from: searchParams.from,
+        lang: "elasticsearch",
+        scroll: searchParams.scrollTTL,
+        size: searchParams.size,
+      },
     );
   }
 

--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -401,6 +401,7 @@ export class ModelService extends BaseService {
 
     const modelContent: AssetModelContent = {
       asset: {
+        actions: [],
         defaultMetadata,
         locales,
         measures,
@@ -473,6 +474,7 @@ export class ModelService extends BaseService {
 
     const modelContent: DeviceModelContent = {
       device: {
+        actions: [],
         defaultMetadata,
         measures,
         metadataDetails,
@@ -1218,6 +1220,7 @@ export class ModelService extends BaseService {
 
     const assetModelContent: AssetModelContent = {
       asset: {
+        actions: [],
         defaultMetadata,
         locales,
         measures: measuresUpdated,

--- a/plugin/lib/modules/model/ModelsController.ts
+++ b/plugin/lib/modules/model/ModelsController.ts
@@ -5,19 +5,24 @@ import {
   ApiModelWriteAssetResult,
   ApiModelWriteDeviceResult,
   ApiModelWriteMeasureResult,
+  ApiModelWriteActionResult,
   ApiModelUpdateAssetResult,
   ApiModelDeleteAssetResult,
   ApiModelDeleteDeviceResult,
   ApiModelDeleteMeasureResult,
+  ApiModelDeleteActionResult,
   ApiModelListAssetsResult,
   ApiModelListDevicesResult,
   ApiModelListMeasuresResult,
+  ApiModelListActionsResult,
   ApiModelGetAssetResult,
   ApiModelGetDeviceResult,
   ApiModelGetMeasureResult,
+  ApiModelGetActionResult,
   ApiModelSearchAssetsResult,
   ApiModelSearchDevicesResult,
   ApiModelSearchMeasuresResult,
+  ApiModelSearchActionsResult,
   ApiModelDeleteGroupResult,
   ApiModelGetGroupResult,
   ApiModelListGroupsResult,
@@ -36,6 +41,10 @@ export class ModelsController {
     this.logger = logger;
     this.definition = {
       actions: {
+        deleteAction: {
+          handler: this.deleteAction.bind(this),
+          http: [{ path: "device-manager/models/action/:_id", verb: "delete" }],
+        },
         deleteAsset: {
           handler: this.deleteAsset.bind(this),
           http: [{ path: "device-manager/models/asset/:_id", verb: "delete" }],
@@ -54,6 +63,10 @@ export class ModelsController {
             { path: "device-manager/models/measure/:_id", verb: "delete" },
           ],
         },
+        getAction: {
+          handler: this.getAction.bind(this),
+          http: [{ path: "device-manager/models/action/:type", verb: "get" }],
+        },
         getAsset: {
           handler: this.getAsset.bind(this),
           http: [{ path: "device-manager/models/asset/:model", verb: "get" }],
@@ -70,6 +83,10 @@ export class ModelsController {
           handler: this.getMeasure.bind(this),
           http: [{ path: "device-manager/models/measure/:type", verb: "get" }],
         },
+        listActions: {
+          handler: this.listActions.bind(this),
+          http: [{ path: "device-manager/models/actions", verb: "get" }],
+        },
         listAssets: {
           handler: this.listAssets.bind(this),
           http: [{ path: "device-manager/models/assets", verb: "get" }],
@@ -85,6 +102,12 @@ export class ModelsController {
         listMeasures: {
           handler: this.listMeasures.bind(this),
           http: [{ path: "device-manager/models/measures", verb: "get" }],
+        },
+        searchActions: {
+          handler: this.searchActions.bind(this),
+          http: [
+            { path: "device-manager/models/actions/_search", verb: "post" },
+          ],
         },
         searchAssets: {
           handler: this.searchAssets.bind(this),
@@ -115,6 +138,10 @@ export class ModelsController {
           http: [
             { path: "device-manager/models/assets/:model", verb: "patch" },
           ],
+        },
+        writeAction: {
+          handler: this.writeAction.bind(this),
+          http: [{ path: "device-manager/models/actions", verb: "post" }],
         },
         writeAsset: {
           handler: this.writeAsset.bind(this),
@@ -172,6 +199,53 @@ export class ModelsController {
     const measureModel = await this.modelService.getMeasure(type, engineId);
 
     return measureModel;
+  }
+
+  async getAction(request: KuzzleRequest): Promise<ApiModelGetActionResult> {
+    const type = request.getString("type");
+    const engineId = request.input.args.engineId as string | undefined;
+
+    return this.modelService.getAction(type, engineId);
+  }
+
+  async writeAction(
+    request: KuzzleRequest,
+  ): Promise<ApiModelWriteActionResult> {
+    const type = request.getBodyString("type");
+    const argsSchema = request.getBodyObject("argsSchema", {});
+    const locales = request.getBodyObject("locales", {});
+    const engineIds = request.getBodyArray("engineIds", []);
+
+    return this.modelService.writeAction(type, argsSchema, locales, engineIds);
+  }
+
+  async deleteAction(
+    request: KuzzleRequest,
+  ): Promise<ApiModelDeleteActionResult> {
+    const _id = request.getId();
+
+    await this.modelService.deleteAction(_id);
+  }
+
+  async listActions(
+    request: KuzzleRequest,
+  ): Promise<ApiModelListActionsResult> {
+    const engineId = request.input.args.engineId as string | undefined;
+
+    const models = await this.modelService.listActions(engineId);
+
+    return {
+      models,
+      total: models.length,
+    };
+  }
+
+  async searchActions(
+    request: KuzzleRequest,
+  ): Promise<ApiModelSearchActionsResult> {
+    const engineId = request.input.args.engineId as string | undefined;
+
+    return this.modelService.searchActions(engineId, request.getSearchParams());
   }
 
   async writeAsset(request: KuzzleRequest): Promise<ApiModelWriteAssetResult> {

--- a/plugin/lib/modules/model/ModelsRegister.ts
+++ b/plugin/lib/modules/model/ModelsRegister.ts
@@ -5,10 +5,11 @@ import {
   DeviceManagerPlugin,
   InternalCollection,
 } from "../plugin";
-import { NamedMeasures } from "../decoder";
+import { NamedActions, NamedMeasures } from "../decoder";
 import { MeasureDefinition } from "../measure";
 
 import {
+  ActionModelContent,
   AssetModelContent,
   DeviceModelContent,
   GroupAffinity,
@@ -35,6 +36,7 @@ export class ModelsRegister {
   private deviceModels: DeviceModelContent[] = [];
   private groupModels: GroupModelContent[] = [];
   private measureModels: MeasureModelContent[] = [];
+  private actionModels: ActionModelContent[] = [];
   private logger: KuzzleLogger;
 
   private get sdk() {
@@ -53,6 +55,7 @@ export class ModelsRegister {
       this.load("device", this.deviceModels),
       this.load("group", this.groupModels),
       this.load("measure", this.measureModels),
+      this.load("action", this.actionModels),
     ]);
 
     await this.sdk.collection.refresh(
@@ -136,6 +139,7 @@ export class ModelsRegister {
     defaultMetadata: JSONObject = {},
     metadataDetails: MetadataDetails = {},
     metadataGroups: MetadataGroups = {},
+    actions: NamedActions = [],
   ) {
     if (Inflector.pascalCase(model) !== model) {
       throw new PluginImplementationError(
@@ -155,7 +159,7 @@ export class ModelsRegister {
     // Construct and push the new device model to the deviceModels array
     this.deviceModels.push({
       device: {
-        actions: [],
+        actions,
         defaultMetadata,
         measures,
         metadataDetails,
@@ -233,6 +237,23 @@ export class ModelsRegister {
         valuesMappings,
       },
       type: "measure",
+    });
+  }
+
+  registerAction(
+    type: string,
+    actionDefinition: {
+      argsSchema?: JSONObject;
+      locales?: { [locale: string]: LocaleDetails };
+    } = {},
+  ) {
+    this.actionModels.push({
+      action: {
+        argsSchema: actionDefinition.argsSchema,
+        locales: actionDefinition.locales,
+        type,
+      },
+      type: "action",
     });
   }
 

--- a/plugin/lib/modules/model/ModelsRegister.ts
+++ b/plugin/lib/modules/model/ModelsRegister.ts
@@ -103,6 +103,7 @@ export class ModelsRegister {
     // Construct and push the new asset model to the assetModels array
     this.assetModels.push({
       asset: {
+        actions: [],
         defaultMetadata,
         locales,
         measures,
@@ -154,6 +155,7 @@ export class ModelsRegister {
     // Construct and push the new device model to the deviceModels array
     this.deviceModels.push({
       device: {
+        actions: [],
         defaultMetadata,
         measures,
         metadataDetails,

--- a/plugin/lib/modules/model/collections/modelsMappings.ts
+++ b/plugin/lib/modules/model/collections/modelsMappings.ts
@@ -13,6 +13,23 @@ export const modelsMappings: CollectionMappings = {
     engineIds: { type: "keyword" },
 
     /**
+     * Action model
+     */
+    action: {
+      properties: {
+        type: { type: "keyword" },
+        argsSchema: {
+          dynamic: "false",
+          properties: {},
+        },
+        locales: {
+          dynamic: "false",
+          properties: {},
+        },
+      },
+    },
+
+    /**
      * Measure model
      */
     measure: {
@@ -65,6 +82,12 @@ export const modelsMappings: CollectionMappings = {
             name: { type: "keyword" },
           },
         },
+        actions: {
+          properties: {
+            type: { type: "keyword" },
+            name: { type: "keyword" },
+          },
+        },
         tooltipModels: {
           dynamic: "false",
           properties: {},
@@ -99,6 +122,12 @@ export const modelsMappings: CollectionMappings = {
           properties: {},
         },
         measures: {
+          properties: {
+            type: { type: "keyword" },
+            name: { type: "keyword" },
+          },
+        },
+        actions: {
           properties: {
             type: { type: "keyword" },
             name: { type: "keyword" },

--- a/plugin/lib/modules/model/types/ModelApi.ts
+++ b/plugin/lib/modules/model/types/ModelApi.ts
@@ -1,6 +1,7 @@
 import { JSONObject, KDocument, KHit, SearchResult } from "kuzzle-sdk";
 
 import {
+  ActionModelContent,
   AssetModelContent,
   DeviceModelContent,
   GroupAffinity,
@@ -235,4 +236,52 @@ export interface ApiModelSearchMeasuresRequest extends ModelsControllerRequest {
 }
 export type ApiModelSearchMeasuresResult = SearchResult<
   KHit<MeasureModelContent>
+>;
+
+// Action model API types
+
+export interface ApiModelGetActionRequest extends ModelsControllerRequest {
+  action: "getAction";
+  type: string;
+  engineId?: string;
+}
+export type ApiModelGetActionResult = KDocument<ActionModelContent>;
+
+export interface ApiModelWriteActionRequest extends ModelsControllerRequest {
+  action: "writeAction";
+
+  body: {
+    type: string;
+    engineIds?: string[];
+    argsSchema?: JSONObject;
+    locales?: { [locale: string]: LocaleDetails };
+  };
+}
+export type ApiModelWriteActionResult = KDocument<ActionModelContent>;
+
+export interface ApiModelDeleteActionRequest extends ModelsControllerRequest {
+  action: "deleteAction";
+  _id: string;
+}
+export type ApiModelDeleteActionResult = void;
+
+export interface ApiModelListActionsRequest extends ModelsControllerRequest {
+  action: "listActions";
+  engineId?: string;
+}
+export type ApiModelListActionsResult = {
+  models: KDocument<ActionModelContent>[];
+  total: number;
+};
+
+export interface ApiModelSearchActionsRequest extends ModelsControllerRequest {
+  action: "searchActions";
+  engineId?: string;
+  from?: number;
+  size?: number;
+  scrollTTL?: string;
+  body?: JSONObject;
+}
+export type ApiModelSearchActionsResult = SearchResult<
+  KHit<ActionModelContent>
 >;

--- a/plugin/lib/modules/model/types/ModelContent.ts
+++ b/plugin/lib/modules/model/types/ModelContent.ts
@@ -1,8 +1,24 @@
 import { JSONObject, KDocumentContent } from "kuzzle-sdk";
 
-import { NamedMeasures } from "../../decoder";
+import { NamedActions, NamedMeasures } from "../../decoder";
 
 import { MeasureDefinition } from "../../measure";
+
+export interface ActionModelContent extends KDocumentContent {
+  type: "action";
+
+  engineGroups?: string[];
+  engineIds?: string[];
+
+  action: {
+    type: string;
+    /**
+     * JSON Schema for validating action arguments
+     */
+    argsSchema?: JSONObject;
+    locales?: { [locale: string]: LocaleDetails };
+  };
+}
 
 export interface MeasureModelContent extends KDocumentContent {
   type: "measure";
@@ -278,6 +294,18 @@ export interface AssetModelContent extends KDocumentContent {
      */
     measures: NamedMeasures;
     /**
+     * List of accepted actions for this model (outbound commands)
+     *
+     * Array<{ type: string, name: string }>
+     *
+     * @example
+     *
+     * [
+     *   { type: "temperatureSetpoint", name: "setTemperature" }
+     * ]
+     */
+    actions: NamedActions;
+    /**
      * List of tooltip models for this asset model
      *
      * @example
@@ -420,6 +448,18 @@ export interface DeviceModelContent extends KDocumentContent {
      * ]
      */
     measures: NamedMeasures;
+    /**
+     * List of actions this device codec can encode (outbound commands)
+     *
+     * Array<{ type: string, name: string }>
+     *
+     * @example
+     *
+     * [
+     *   { type: "temperatureSetpoint", name: "setTemp" }
+     * ]
+     */
+    actions: NamedActions;
   };
 }
 
@@ -557,6 +597,7 @@ export interface GroupModelContent extends KDocumentContent {
 }
 export type ModelContent =
   | MeasureModelContent
+  | ActionModelContent
   | AssetModelContent
   | DeviceModelContent
   | GroupModelContent;

--- a/plugin/lib/modules/plugin/DeviceManagerEngine.ts
+++ b/plugin/lib/modules/plugin/DeviceManagerEngine.ts
@@ -381,6 +381,8 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   async onCreate(index: string, group = "commons") {
     const promises = [];
 
+    promises.push(this.createActionsCollection(index));
+
     promises.push(this.createAssetsCollection(index, group));
 
     promises.push(this.createAssetsHistoryCollection(index, group));
@@ -401,6 +403,8 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
   async onUpdate(index: string, group = "commons") {
     const promises = [];
 
+    promises.push(this.createActionsCollection(index));
+
     promises.push(this.createAssetsCollection(index, group));
 
     promises.push(this.createAssetsHistoryCollection(index, group));
@@ -418,6 +422,7 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
 
   async onDelete(index: string) {
     const collections = [
+      InternalCollection.ACTIONS,
       InternalCollection.ASSETS,
       InternalCollection.ASSETS_HISTORY,
       InternalCollection.GROUPS,
@@ -582,6 +587,25 @@ export class DeviceManagerEngine extends AbstractEngine<DeviceManagerPlugin> {
     });
 
     return InternalCollection.MEASURES;
+  }
+
+  /**
+   * Create the actions collection in the engine
+   *
+   * @param engineId The target engine Id
+   *
+   * @throws If it failed during the actions collection creation
+   */
+  async createActionsCollection(engineId: string) {
+    const mappings = this.config.engineCollections.actions.mappings;
+    const settings = this.config.engineCollections.actions.settings;
+
+    await this.tryCreateCollection(engineId, InternalCollection.ACTIONS, {
+      mappings,
+      settings,
+    });
+
+    return InternalCollection.ACTIONS;
   }
 
   /**

--- a/plugin/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/plugin/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -15,6 +15,7 @@ import { groupsMappings, AssetModule, assetsMappings } from "../asset";
 import {
   DecoderModule,
   DecodersRegister,
+  NamedActions,
   NamedMeasures,
   payloadsMappings,
 } from "../decoder";
@@ -246,6 +247,7 @@ export class DeviceManagerPlugin extends Plugin {
           definition.defaultMetadata,
           definition.metadataDetails,
           definition.metadataGroups,
+          definition.decoder.actions as NamedActions,
         );
       },
 
@@ -334,6 +336,41 @@ export class DeviceManagerPlugin extends Plugin {
        */
       registerMeasure: (name: string, measureDefinition: MeasureDefinition) => {
         this.modelsRegister.registerMeasure(name, measureDefinition);
+      },
+
+      /**
+       * Register a new action model
+       *
+       * @param name Name of the action type
+       * @param actionDefinition Action definition including argsSchema and locales
+       *
+       * @example
+       * ```
+       * deviceManager.models.registerAction("temperatureSetpoint", {
+       *   argsSchema: {
+       *     type: "object",
+       *     properties: {
+       *       temperature: { type: "number" },
+       *     },
+       *     required: ["temperature"],
+       *   },
+       *   locales: {
+       *     en: { friendlyName: "Set temperature", description: "Set target temperature" },
+       *     fr: { friendlyName: "Régler température", description: "Définir la température cible" },
+       *   },
+       * });
+       * ```
+       */
+      registerAction: (
+        name: string,
+        actionDefinition: {
+          argsSchema?: JSONObject;
+          locales?: {
+            [locale: string]: { friendlyName: string; description: string };
+          };
+        } = {},
+      ) => {
+        this.modelsRegister.registerAction(name, actionDefinition);
       },
     };
   }

--- a/plugin/lib/modules/plugin/DeviceManagerPlugin.ts
+++ b/plugin/lib/modules/plugin/DeviceManagerPlugin.ts
@@ -9,6 +9,7 @@ import { ConfigManager, EngineController } from "kuzzle-plugin-commons";
 import { JSONObject } from "kuzzle-sdk";
 import _ from "lodash";
 
+import { actionsMappings } from "../action/collections/actionsMappings";
 import { MeasureDefinition, measuresMappings, MeasureModule } from "../measure";
 
 import { groupsMappings, AssetModule, assetsMappings } from "../asset";
@@ -419,6 +420,10 @@ export class DeviceManagerPlugin extends Plugin {
         },
       },
       engineCollections: {
+        actions: {
+          name: InternalCollection.ACTIONS,
+          mappings: actionsMappings,
+        },
         config: {
           name: "config",
           mappings: {

--- a/plugin/lib/modules/plugin/types/DeviceManagerConfiguration.ts
+++ b/plugin/lib/modules/plugin/types/DeviceManagerConfiguration.ts
@@ -46,6 +46,11 @@ export type DeviceManagerConfiguration = {
   };
 
   engineCollections: {
+    actions: {
+      name: string;
+      mappings: CollectionMappings;
+      settings?: JSONObject;
+    };
     config: {
       name: string;
       mappings: JSONObject;

--- a/plugin/lib/modules/plugin/types/InternalCollection.ts
+++ b/plugin/lib/modules/plugin/types/InternalCollection.ts
@@ -1,4 +1,5 @@
 export enum InternalCollection {
+  ACTIONS = "actions",
   ASSETS = "assets",
   ASSETS_HISTORY = "assets-history",
   GROUPS = "groups",

--- a/plugin/lib/modules/shared/types/DigitalTwinContent.ts
+++ b/plugin/lib/modules/shared/types/DigitalTwinContent.ts
@@ -1,6 +1,6 @@
 import { KDocumentContent } from "kuzzle-sdk";
 
-import { NamedMeasures } from "../../decoder";
+import { NamedActions, NamedMeasures } from "../../decoder";
 import { Metadata } from "./Metadata";
 import { LocaleDetails } from "lib/modules/model";
 
@@ -16,4 +16,6 @@ export interface DigitalTwinContent<
   metadata: TMetadata;
 
   measureSlots: NamedMeasures;
+
+  actionSlots: NamedActions;
 }

--- a/plugin/tests/application/assets/Container.ts
+++ b/plugin/tests/application/assets/Container.ts
@@ -198,6 +198,8 @@ const measures = {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function neverCalled() {
   const container: ContainerAssetContent = {
+    actionSlots: [],
+    linkedActions: [],
     model: "Container",
     linkedMeasures: [],
     groups: [],

--- a/plugin/tests/hooks/collections.ts
+++ b/plugin/tests/hooks/collections.ts
@@ -16,18 +16,21 @@ export async function beforeEachTruncateCollections(sdk: Kuzzle) {
     truncateCollection(sdk, "device-manager", "devices"),
     truncateCollection(sdk, "device-manager", "payloads"),
 
+    truncateCollection(sdk, "engine-kuzzle", "actions"),
     truncateCollection(sdk, "engine-kuzzle", "assets"),
     truncateCollection(sdk, "engine-kuzzle", "assets-history"),
     truncateCollection(sdk, "engine-kuzzle", "groups"),
     truncateCollection(sdk, "engine-kuzzle", "measures"),
     truncateCollection(sdk, "engine-kuzzle", "devices"),
 
+    truncateCollection(sdk, "engine-ayse", "actions"),
     truncateCollection(sdk, "engine-ayse", "assets"),
     truncateCollection(sdk, "engine-ayse", "assets-history"),
     truncateCollection(sdk, "engine-ayse", "groups"),
     truncateCollection(sdk, "engine-ayse", "measures"),
     truncateCollection(sdk, "engine-ayse", "devices"),
 
+    truncateCollection(sdk, "engine-other-group", "actions"),
     truncateCollection(sdk, "engine-other-group", "assets"),
     truncateCollection(sdk, "engine-other-group", "assets-history"),
     truncateCollection(sdk, "engine-other-group", "groups"),

--- a/plugin/tests/scenario/modules/models/action-model.test.ts
+++ b/plugin/tests/scenario/modules/models/action-model.test.ts
@@ -162,11 +162,7 @@ describe("ModelsController:actions", () => {
     });
 
     await expect(
-      sdk.document.get(
-        "device-manager",
-        "models",
-        "model-action-toDelete",
-      ),
+      sdk.document.get("device-manager", "models", "model-action-toDelete"),
     ).rejects.toThrow();
   });
 

--- a/plugin/tests/scenario/modules/models/action-model.test.ts
+++ b/plugin/tests/scenario/modules/models/action-model.test.ts
@@ -1,0 +1,214 @@
+import { setupHooks } from "../../../helpers";
+
+describe("ModelsController:actions", () => {
+  const sdk = setupHooks();
+
+  beforeAll(async () => {
+    await Promise.allSettled([
+      sdk.document.delete("device-manager", "models", "model-action-valve"),
+      sdk.document.delete(
+        "device-manager",
+        "models",
+        "model-action-thermostat",
+      ),
+    ]);
+  });
+
+  it("Write and List an Action model", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAction",
+      body: {
+        type: "valve",
+        argsSchema: {
+          type: "object",
+          properties: {
+            position: { type: "number", minimum: 0, maximum: 100 },
+          },
+          required: ["position"],
+        },
+        locales: {
+          en: {
+            friendlyName: "Valve control",
+            description: "Open or close a valve",
+          },
+          fr: {
+            friendlyName: "Contrôle de vanne",
+            description: "Ouvrir ou fermer une vanne",
+          },
+        },
+      },
+    });
+
+    const modelContent = await sdk.document.get(
+      "device-manager",
+      "models",
+      "model-action-valve",
+    );
+    expect(modelContent._source).toMatchObject({
+      type: "action",
+      action: {
+        type: "valve",
+        argsSchema: {
+          type: "object",
+          properties: {
+            position: { type: "number", minimum: 0, maximum: 100 },
+          },
+          required: ["position"],
+        },
+        locales: {
+          en: {
+            friendlyName: "Valve control",
+            description: "Open or close a valve",
+          },
+        },
+      },
+    });
+
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAction",
+      body: {
+        type: "thermostat",
+        argsSchema: {
+          type: "object",
+          properties: {
+            targetTemperature: { type: "number" },
+          },
+        },
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const listActions = await sdk.query({
+      controller: "device-manager/models",
+      action: "listActions",
+    });
+
+    expect(listActions.result.total).toBeGreaterThanOrEqual(2);
+    const actionIds = listActions.result.models.map(
+      (m: { _id: string }) => m._id,
+    );
+    expect(actionIds).toContain("model-action-valve");
+    expect(actionIds).toContain("model-action-thermostat");
+  });
+
+  it("Get an Action model", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAction",
+      body: {
+        type: "valve",
+        argsSchema: { type: "object" },
+      },
+    });
+
+    const getAction = await sdk.query({
+      controller: "device-manager/models",
+      action: "getAction",
+      type: "valve",
+    });
+
+    expect(getAction.result).toMatchObject({
+      _id: "model-action-valve",
+      _source: {
+        type: "action",
+        action: { type: "valve" },
+      },
+    });
+  });
+
+  it("Search Action models", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAction",
+      body: {
+        type: "valve",
+        argsSchema: { type: "object" },
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const searchActions = await sdk.query({
+      controller: "device-manager/models",
+      action: "searchActions",
+      body: { query: { match: { "action.type": "valve" } } },
+    });
+
+    expect(searchActions.result).toMatchObject({
+      total: 1,
+      hits: [{ _id: "model-action-valve" }],
+    });
+  });
+
+  it("Delete an Action model", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAction",
+      body: {
+        type: "toDelete",
+        argsSchema: {},
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "deleteAction",
+      _id: "model-action-toDelete",
+    });
+
+    await expect(
+      sdk.document.get(
+        "device-manager",
+        "models",
+        "model-action-toDelete",
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("Update an existing Action model", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAction",
+      body: {
+        type: "valve",
+        argsSchema: {
+          type: "object",
+          properties: {
+            position: { type: "number", minimum: 0, maximum: 100 },
+            force: { type: "boolean" },
+          },
+        },
+      },
+    });
+
+    const updated = await sdk.document.get(
+      "device-manager",
+      "models",
+      "model-action-valve",
+    );
+    expect(updated._source).toMatchObject({
+      action: {
+        type: "valve",
+        argsSchema: {
+          properties: {
+            position: { type: "number", minimum: 0, maximum: 100 },
+            force: { type: "boolean" },
+          },
+        },
+      },
+    });
+  });
+
+  it("Actions collection exists in engines", async () => {
+    const collections = await sdk.collection.list("engine-kuzzle");
+    const collectionNames = collections.collections.map(
+      (c: { name: string }) => c.name,
+    );
+    expect(collectionNames).toContain("actions");
+  });
+});


### PR DESCRIPTION
## What does this PR do ?

This PR adds the foundational types and interfaces for device control (action slots), the symmetrical counterpart to measure slots for outbound commands.

### Changes

- `NamedActions` type and `ActionModelContent` interface (parallel to `NamedMeasures` / `MeasureModelContent`)
- `actionSlots` and `linkedActions` fields on `AssetContent` and `DeviceContent`
- `actions` field on `AssetModelContent` and `DeviceModelContent`
- `encode()` method and `actions` declaration on `Decoder` base class
- ES mappings for `actionSlots` and `linkedActions` on assets and devices collections
- Default empty arrays in all object constructors

### How should this be manually tested?

- Types compile cleanly (`npm run test:types`)
- Lint passes (`npm run lint`)
- Existing tests should pass unchanged (new fields default to empty arrays)