### PR TITLE
fix(models): return all asset models for super admin without engineGroups (KZLPRD-925)

### DIFF
--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -678,6 +678,21 @@ export class ModelService extends BaseService {
     );
   }
 
+  /**
+   * List all asset models regardless of engine group scope.
+   * Used for super admin global view.
+   */
+  async listAllAssets(): Promise<KDocument<AssetModelContent>[]> {
+    const result = await this.sdk.document.search(
+      this.config.platformIndex,
+      InternalCollection.MODELS,
+      { query: { term: { type: "asset" } } },
+      { size: 5000, sort: [{ "asset.model": "asc" }] },
+    );
+
+    return result.hits as unknown as KDocument<AssetModelContent>[];
+  }
+
   async listAsset(
     engineGroups: string[],
     engineId?: string,

--- a/plugin/lib/modules/model/ModelsController.ts
+++ b/plugin/lib/modules/model/ModelsController.ts
@@ -305,8 +305,20 @@ export class ModelsController {
   }
 
   async listAssets(request: KuzzleRequest): Promise<ApiModelListAssetsResult> {
-    const engineGroups = request.getArray("engineGroups", []) || ["commons"];
+    const engineGroups = request.getArray("engineGroups", []);
     const engineId = request.input.args.engineId as string | undefined;
+    const user = request.getUser() as { profileIds: string[] };
+    const isAdmin = user.profileIds.includes("admin");
+
+    // Super admin without engineGroups: return all asset models
+    if (isAdmin && engineGroups.length === 0) {
+      const models = await this.modelService.listAllAssets();
+      return { models, total: models.length };
+    }
+
+    if (engineGroups.length === 0) {
+      engineGroups.push("commons");
+    }
 
     const models = await this.modelService.listAsset(engineGroups, engineId);
 


### PR DESCRIPTION
## What does this PR do ?
Fixes `listAssets` returning empty results when a super admin calls it without `engineGroups`.

### Changes
- Add `listAllAssets()` to `ModelService` — queries all asset models from the models collection without scope filtering
- In `ModelsController.listAssets()`, detect admin profile and call `listAllAssets()` when `engineGroups` is empty
- Non-admin users are unaffected — they still require `engineGroups` for scoped access

### How should this be manually tested?
- As super admin, call `device-manager/models:listAssets` without `engineGroups` — should return all asset models
- As non-admin, same call should return only commons models (default behavior)