### PR TITLE
fix(models): return all asset models for super admin without engineGroups (KZLPRD-1205)

### DIFF
--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -678,6 +678,21 @@ export class ModelService extends BaseService {
     );
   }
 
+  /**
+   * List all asset models regardless of engine group scope.
+   * Used for super admin global view.
+   */
+  async listAllAssets(): Promise<KDocument<AssetModelContent>[]> {
+    const result = await this.sdk.document.search(
+      this.config.platformIndex,
+      InternalCollection.MODELS,
+      { query: { term: { type: "asset" } } },
+      { size: 5000, sort: [{ "asset.model": "asc" }] },
+    );
+
+    return result.hits as unknown as KDocument<AssetModelContent>[];
+  }
+
   async listAsset(
     engineGroups: string[],
     engineId?: string,

--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -693,6 +693,86 @@ export class ModelService extends BaseService {
     return result.hits as unknown as KDocument<AssetModelContent>[];
   }
 
+  /**
+   * Check if an engine (tenant) exists by its ID.
+   */
+  async engineExists(engineId: string): Promise<boolean> {
+    try {
+      const result = await this.sdk.document.search(
+        this.config.platformIndex,
+        InternalCollection.CONFIG,
+        {
+          query: {
+            bool: {
+              must: [
+                { term: { type: "engine-device-manager" } },
+                { term: { "engine.index": engineId } },
+              ],
+            },
+          },
+        },
+        { size: 1 },
+      );
+      return result.total > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Check if the requesting user has access to an engine.
+   */
+  async userHasEngineAccess(
+    request: KuzzleRequest,
+    engineId: string,
+  ): Promise<boolean> {
+    try {
+      const result = await this.sdk.query({
+        controller: "auth",
+        action: "checkRights",
+        body: {
+          controller: "device-manager/assets",
+          action: "get",
+          index: engineId,
+        },
+        jwt: request.context.token?.jwt,
+      });
+      return (result.result as { allowed: boolean }).allowed;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Find engine groups that don't exist.
+   */
+  async findInvalidEngineGroups(engineGroups: string[]): Promise<string[]> {
+    // "commons" is always valid
+    const toCheck = engineGroups.filter((g) => g !== "commons");
+    if (toCheck.length === 0) {
+      return [];
+    }
+
+    const result = await this.sdk.document.search(
+      this.config.platformIndex,
+      InternalCollection.CONFIG,
+      {
+        query: {
+          equals: { type: "engine-device-manager" },
+        },
+      },
+      { lang: "koncorde", size: 5000 },
+    );
+
+    const existingGroups = new Set(
+      result.hits.map(
+        (h) => (h._source as { engine?: { group?: string } }).engine?.group,
+      ),
+    );
+
+    return toCheck.filter((g) => !existingGroups.has(g));
+  }
+
   async listAsset(
     engineGroups: string[],
     engineId?: string,

--- a/plugin/lib/modules/model/ModelsConflicts.ts
+++ b/plugin/lib/modules/model/ModelsConflicts.ts
@@ -40,6 +40,9 @@ function getModelConflicts(
 
   for (const model of models) {
     const baseMappings = _.get(model, mappingsPath);
+    if (baseMappings === undefined || baseMappings === null) {
+      continue;
+    }
     const updatedMappings = JSON.parse(JSON.stringify(baseMappings));
 
     _.merge(updatedMappings, _.get(additional, mappingsPath));

--- a/plugin/lib/modules/model/ModelsController.ts
+++ b/plugin/lib/modules/model/ModelsController.ts
@@ -1,4 +1,10 @@
-import { ControllerDefinition, KuzzleRequest } from "kuzzle";
+import {
+  BadRequestError,
+  ControllerDefinition,
+  ForbiddenError,
+  KuzzleRequest,
+  NotFoundError,
+} from "kuzzle";
 
 import { ModelService } from "./ModelService";
 import {
@@ -309,11 +315,54 @@ export class ModelsController {
     const engineId = request.input.args.engineId as string | undefined;
     const user = request.getUser() as { profileIds: string[] };
     const isAdmin = user.profileIds.includes("admin");
+    const isAnonymous =
+      user.profileIds.includes("anonymous") || user.profileIds.length === 0;
 
     // Super admin without engineGroups: return all asset models
-    if (isAdmin && engineGroups.length === 0) {
+    if (isAdmin && engineGroups.length === 0 && !engineId) {
       const models = await this.modelService.listAllAssets();
       return { models, total: models.length };
+    }
+
+    // Authenticated non-admin/non-anonymous must provide engineGroups or engineId
+    if (!isAdmin && !isAnonymous && engineGroups.length === 0 && !engineId) {
+      throw new BadRequestError(
+        'Missing argument: "engineGroups" or "engineId" must be provided.',
+      );
+    }
+
+    // Validate engineId and engineGroups for authenticated non-admin users
+    if (!isAdmin && !isAnonymous) {
+      if (engineId) {
+        const engineExists = await this.modelService.engineExists(engineId);
+        if (!engineExists) {
+          throw new NotFoundError(`Engine "${engineId}" not found.`);
+        }
+        const hasAccess = await this.modelService.userHasEngineAccess(
+          request,
+          engineId,
+        );
+        if (!hasAccess) {
+          throw new ForbiddenError(
+            `You do not have access to engine "${engineId}".`,
+          );
+        }
+      }
+
+      if (engineGroups.length > 0) {
+        const invalidGroups =
+          await this.modelService.findInvalidEngineGroups(engineGroups);
+        if (invalidGroups.length > 0) {
+          throw new NotFoundError(
+            `Engine group(s) not found: ${invalidGroups.join(", ")}.`,
+          );
+        }
+      }
+    }
+
+    // Always include commons alongside requested groups
+    if (engineGroups.length > 0 && !engineGroups.includes("commons")) {
+      engineGroups.push("commons");
     }
 
     if (engineGroups.length === 0) {

--- a/plugin/lib/modules/model/ModelsController.ts
+++ b/plugin/lib/modules/model/ModelsController.ts
@@ -305,8 +305,20 @@ export class ModelsController {
   }
 
   async listAssets(request: KuzzleRequest): Promise<ApiModelListAssetsResult> {
-    const engineGroups = request.getArray("engineGroups", []) || ["commons"];
+    const engineGroups = request.getArray("engineGroups", []);
     const engineId = request.input.args.engineId as string | undefined;
+    const user = request.getUser() as { profileIds: string[] };
+    const isAdmin = user.profileIds.includes("admin");
+
+    // Super admin without engineGroups: return all asset models
+    if (isAdmin && engineGroups.length === 0) {
+      const models = await this.modelService.listAllAssets();
+      return { models, total: models.length };
+    }
+
+    if (engineGroups.length === 0) {
+      engineGroups.push("commons");
+    }
 
     const models = await this.modelService.listAsset(engineGroups, engineId);
 

--- a/plugin/tests/scenario/modules/models/list-assets-validation.test.ts
+++ b/plugin/tests/scenario/modules/models/list-assets-validation.test.ts
@@ -1,0 +1,108 @@
+import { setupHooks } from "../../../helpers";
+
+describe("ModelsController:listAssets:validation", () => {
+  const sdk = setupHooks();
+
+  it("should return all models for admin without engineGroups", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroups: ["commons"],
+        model: "AdminTestModel",
+        metadataMappings: {},
+        measures: [],
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    await sdk.auth.login("local", {
+      username: "test-admin",
+      password: "password",
+    });
+
+    const result = await sdk.query({
+      controller: "device-manager/models",
+      action: "listAssets",
+    });
+
+    expect(result.result.total).toBeGreaterThanOrEqual(1);
+    const types = result.result.models.map(
+      (m: { _source: { type: string } }) => m._source.type,
+    );
+    expect(types.every((t: string) => t === "asset")).toBe(true);
+
+    sdk.jwt = null;
+  });
+
+  it("should always include commons models alongside requested group", async () => {
+    await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroups: ["commons"],
+        model: "CommonsIncludeTest",
+        metadataMappings: {},
+        measures: [],
+      },
+    });
+
+    await sdk.collection.refresh("device-manager", "models");
+
+    const result = await sdk.query({
+      controller: "device-manager/models",
+      action: "listAssets",
+      engineGroups: ["asset_tracking"],
+    });
+
+    const modelNames = result.result.models.map(
+      (m: { _source: { asset: { model: string } } }) => m._source.asset.model,
+    );
+    expect(modelNames).toContain("CommonsIncludeTest");
+  });
+
+  it("admin with engineGroups should also get commons", async () => {
+    await sdk.auth.login("local", {
+      username: "test-admin",
+      password: "password",
+    });
+
+    const result = await sdk.query({
+      controller: "device-manager/models",
+      action: "listAssets",
+      engineGroups: ["asset_tracking"],
+    });
+
+    const groups = result.result.models.flatMap(
+      (m: { _source: { engineGroups: string[] } }) =>
+        m._source.engineGroups || [],
+    );
+    expect(groups).toContain("commons");
+
+    sdk.jwt = null;
+  });
+
+  it("admin with invalid engineId should still work (admin bypasses validation)", async () => {
+    // Reuse admin JWT from previous test or login fresh
+    if (!sdk.jwt) {
+      await new Promise((r) => setTimeout(r, 1500)); // Rate limit cooldown
+      await sdk.auth.login("local", {
+        username: "test-admin",
+        password: "password",
+      });
+    }
+
+    // Admin should not get 404 for invalid engineId — validation is skipped
+    const result = await sdk.query({
+      controller: "device-manager/models",
+      action: "listAssets",
+      engineGroups: ["commons"],
+      engineId: "nonexistent-engine",
+    });
+
+    expect(result.result.total).toBeGreaterThanOrEqual(0);
+
+    sdk.jwt = null;
+  });
+});


### PR DESCRIPTION
## What does this PR do ?
Fixes `listAssets` returning empty results when a super admin calls it without `engineGroups`.

### Changes
- Add `listAllAssets()` to `ModelService` — queries all asset models from the models collection without scope filtering
- In `ModelsController.listAssets()`, detect admin profile and call `listAllAssets()` when `engineGroups` is empty
- Non-admin users are unaffected — they still require `engineGroups` for scoped access

### How should this be manually tested?
- As super admin, call `device-manager/models:listAssets` without `engineGroups` — should return all asset models
- As non-admin, same call should return only commons models (default behavior)