### PR TITLE
fix(models): make engineGroups and engineIds mutually exclusive on as…

### DIFF
--- a/plugin/lib/modules/model/ModelSerializer.ts
+++ b/plugin/lib/modules/model/ModelSerializer.ts
@@ -13,8 +13,7 @@ export class ModelSerializer {
       const assetModel = model as AssetModelContent;
       if (assetModel.engineIds?.length) {
         const sortedEngines = [...assetModel.engineIds].sort().join("+");
-        const sortedGroups = [...assetModel.engineGroups].sort().join("+");
-        return `model-asset-${sortedGroups}-${sortedEngines}-${ModelSerializer.title(type, model)}`;
+        return `model-asset-${sortedEngines}-${ModelSerializer.title(type, model)}`;
       }
       if (assetModel.engineGroups.length > 1) {
         const sortedGroups = [...assetModel.engineGroups].sort().join("+");

--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -318,6 +318,13 @@ export class ModelService extends BaseService {
     if (Inflector.pascalCase(model) !== model) {
       throw new BadRequestError(`Asset model "${model}" must be PascalCase.`);
     }
+
+    if (engineIds?.length && engineGroups?.length) {
+      throw new BadRequestError(
+        `"engineIds" and "engineGroups" are mutually exclusive on an asset model.`,
+      );
+    }
+
     const duplicates = getNamedMeasuresDuplicates(measures);
 
     if (duplicates.length > 0) {
@@ -410,10 +417,11 @@ export class ModelService extends BaseService {
         model,
         tooltipModels,
       },
-      engineGroups: normalizedEngineGroups,
-      ...(engineIds?.length ? { engineIds } : {}),
+      ...(engineIds?.length
+        ? { engineIds }
+        : { engineGroups: normalizedEngineGroups }),
       type: "asset",
-    };
+    } as AssetModelContent;
 
     this.checkDefaultValues(metadataMappings, defaultMetadata);
 
@@ -1307,10 +1315,9 @@ export class ModelService extends BaseService {
     const measuresUpdated =
       measures.length === 0 ? existingAsset._source.asset.measures : measures;
 
-    const normalizedEngineGroups = engineGroups.includes("commons")
-      ? ["commons"]
-      : engineGroups;
-
+    // Preserve the existing scope: scope (engineGroups / engineIds) is decided
+    // at write time and must not be silently rewritten by an update payload.
+    // This also enforces engineGroups / engineIds mutual exclusivity (KZLPRD-1192).
     const assetModelContent: AssetModelContent = {
       asset: {
         defaultMetadata,
@@ -1322,7 +1329,7 @@ export class ModelService extends BaseService {
         model,
         tooltipModels,
       },
-      engineGroups: normalizedEngineGroups,
+      engineGroups: existingAsset._source.engineGroups,
       engineIds: existingAsset._source.engineIds,
       type: "asset",
     };

--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -843,10 +843,7 @@ export class ModelService extends BaseService {
             should: [
               {
                 bool: {
-                  must: [
-                    { term: { engineIds: engineId } },
-                    { terms: { engineGroups } },
-                  ],
+                  must: [{ term: { engineIds: engineId } }],
                 },
               },
               {
@@ -1069,11 +1066,7 @@ export class ModelService extends BaseService {
     if (engineId) {
       const tenantQuery = {
         bool: {
-          must: [
-            ...baseFilter,
-            { terms: { engineGroups } },
-            { term: { engineIds: engineId } },
-          ],
+          must: [...baseFilter, { term: { engineIds: engineId } }],
         },
       };
 

--- a/plugin/lib/modules/model/ModelsController.ts
+++ b/plugin/lib/modules/model/ModelsController.ts
@@ -181,7 +181,7 @@ export class ModelsController {
   }
 
   async writeAsset(request: KuzzleRequest): Promise<ApiModelWriteAssetResult> {
-    const engineGroups = request.getBodyArray("engineGroups") as string[];
+    const engineGroups = request.getBodyArray("engineGroups", []) as string[];
     const model = request.getBodyString("model");
     const metadataMappings = request.getBodyObject("metadataMappings", {});
     const defaultValues = request.getBodyObject("defaultValues", {});

--- a/plugin/tests/scenario/modules/models/asset-model-multi-group.test.ts
+++ b/plugin/tests/scenario/modules/models/asset-model-multi-group.test.ts
@@ -182,30 +182,19 @@ describe("ModelsController:assets:multi-group", () => {
     expect(resultPL.result._source.asset.model).toBe("SharedModel");
   });
 
-  it("Multi-group model with engines uses full composite ID", async () => {
-    await sdk.query({
-      controller: "device-manager/models",
-      action: "writeAsset",
-      body: {
-        engineGroups: ["air_quality", "public_lighting"],
-        model: "MultiGroupTenant",
-        metadataMappings: {},
-        measures: [],
-        engineIds: ["engine-ayse"],
-      },
-    });
-
-    const doc = await sdk.document.get(
-      "device-manager",
-      "models",
-      "model-asset-air_quality+public_lighting-engine-ayse-MultiGroupTenant",
-    );
-
-    expect(doc._source).toMatchObject({
-      type: "asset",
-      engineGroups: ["air_quality", "public_lighting"],
-      engineIds: ["engine-ayse"],
-      asset: { model: "MultiGroupTenant" },
-    });
+  it("Multi-group and tenant scope are mutually exclusive (KZLPRD-1192)", async () => {
+    await expect(
+      sdk.query({
+        controller: "device-manager/models",
+        action: "writeAsset",
+        body: {
+          engineGroups: ["air_quality", "public_lighting"],
+          model: "MultiGroupTenant",
+          metadataMappings: {},
+          measures: [],
+          engineIds: ["engine-ayse"],
+        },
+      }),
+    ).rejects.toThrow(/mutually exclusive/);
   });
 });

--- a/plugin/tests/scenario/modules/models/asset-model-shadowing.test.ts
+++ b/plugin/tests/scenario/modules/models/asset-model-shadowing.test.ts
@@ -27,7 +27,6 @@ describe("ModelsController:assets:anti-shadowing", () => {
       controller: "device-manager/models",
       action: "writeAsset",
       body: {
-        engineGroups: ["air_quality"],
         engineIds: ["engine-ayse"],
         model: "ShadowTestGlobal",
         metadataMappings: {},
@@ -88,7 +87,6 @@ describe("ModelsController:assets:anti-shadowing", () => {
       controller: "device-manager/models",
       action: "writeAsset",
       body: {
-        engineGroups: ["air_quality"],
         engineIds: ["engine-ayse"],
         model: "ShadowTestGroupToTenant",
         metadataMappings: {},

--- a/plugin/tests/scenario/modules/models/asset-model-tenant-scoped.test.ts
+++ b/plugin/tests/scenario/modules/models/asset-model-tenant-scoped.test.ts
@@ -11,7 +11,6 @@ describe("ModelsController:assets:tenant-scoped", () => {
       controller: "device-manager/models",
       action: "writeAsset",
       body: {
-        engineGroups: ["air_quality"],
         model: "TenantSensor",
         metadataMappings: { location: { type: "keyword" } },
         measures: [{ name: "temperatureExt", type: "temperature" }],
@@ -22,12 +21,11 @@ describe("ModelsController:assets:tenant-scoped", () => {
     const doc = await sdk.document.get(
       "device-manager",
       "models",
-      "model-asset-air_quality-engine-ayse-TenantSensor",
+      "model-asset-engine-ayse-TenantSensor",
     );
 
     expect(doc._source).toMatchObject({
       type: "asset",
-      engineGroups: ["air_quality"],
       engineIds: ["engine-ayse"],
       asset: {
         model: "TenantSensor",
@@ -35,6 +33,7 @@ describe("ModelsController:assets:tenant-scoped", () => {
         measures: [{ name: "temperatureExt", type: "temperature" }],
       },
     });
+    expect(doc._source).not.toHaveProperty("engineGroups");
   });
 
   it("Write without engineIds still works (backward compat)", async () => {
@@ -84,7 +83,6 @@ describe("ModelsController:assets:tenant-scoped", () => {
         controller: "device-manager/models",
         action: "writeAsset",
         body: {
-          engineGroups: ["air_quality"],
           model: "DualScope",
           metadataMappings: { version: { type: "keyword" } },
           measures: [],
@@ -100,7 +98,6 @@ describe("ModelsController:assets:tenant-scoped", () => {
       controller: "device-manager/models",
       action: "writeAsset",
       body: {
-        engineGroups: ["air_quality"],
         model: "TenantOnly",
         metadataMappings: {},
         measures: [],
@@ -124,7 +121,7 @@ describe("ModelsController:assets:tenant-scoped", () => {
     expect(ids).toContain("model-asset-Container");
     expect(ids).toContain("model-asset-Warehouse");
     expect(ids).toContain("model-asset-Room");
-    expect(ids).toContain("model-asset-air_quality-engine-ayse-TenantOnly");
+    expect(ids).toContain("model-asset-engine-ayse-TenantOnly");
   });
 
   it("List without engineId returns only group + commons models (no tenant-scoped)", async () => {
@@ -139,7 +136,7 @@ describe("ModelsController:assets:tenant-scoped", () => {
     expect(ids).toContain("model-asset-Room");
     expect(ids).toContain("model-asset-Container");
     // Should NOT include tenant-scoped models
-    expect(ids).not.toContain("model-asset-air_quality-engine-ayse-TenantOnly");
+    expect(ids).not.toContain("model-asset-engine-ayse-TenantOnly");
   });
 
   it("getAsset with engineId returns the tenant-scoped model", async () => {
@@ -147,7 +144,6 @@ describe("ModelsController:assets:tenant-scoped", () => {
       controller: "device-manager/models",
       action: "writeAsset",
       body: {
-        engineGroups: ["air_quality"],
         model: "TenantGetTest",
         metadataMappings: { scope: { type: "keyword" } },
         defaultValues: { scope: "tenant" },
@@ -207,7 +203,6 @@ describe("ModelsController:assets:tenant-scoped", () => {
       controller: "device-manager/models",
       action: "writeAsset",
       body: {
-        engineGroups: ["air_quality"],
         model: "SharedTenant",
         metadataMappings: {},
         measures: [],
@@ -226,7 +221,7 @@ describe("ModelsController:assets:tenant-scoped", () => {
     });
     const idsAyse = listAyse.result.models.map((m: { _id: string }) => m._id);
     expect(idsAyse).toContain(
-      "model-asset-air_quality-engine-ayse+engine-kuzzle-SharedTenant",
+      "model-asset-engine-ayse+engine-kuzzle-SharedTenant",
     );
 
     // Accessible from engine-kuzzle
@@ -240,7 +235,7 @@ describe("ModelsController:assets:tenant-scoped", () => {
       (m: { _id: string }) => m._id,
     );
     expect(idsKuzzle).toContain(
-      "model-asset-air_quality-engine-ayse+engine-kuzzle-SharedTenant",
+      "model-asset-engine-ayse+engine-kuzzle-SharedTenant",
     );
   });
 });

--- a/plugin/tests/scenario/modules/models/exclusive-engine-scope.test.ts
+++ b/plugin/tests/scenario/modules/models/exclusive-engine-scope.test.ts
@@ -1,0 +1,56 @@
+import { setupHooks } from "../../../helpers";
+
+describe("ModelsController:writeAsset:exclusiveEngineScope (KZLPRD-1192)", () => {
+  const sdk = setupHooks();
+
+  it("should reject writeAsset when both engineIds and engineGroups are provided", async () => {
+    let error: { status?: number; message?: string } | undefined;
+    try {
+      await sdk.query({
+        controller: "device-manager/models",
+        action: "writeAsset",
+        body: {
+          engineGroups: ["commons"],
+          engineIds: ["engine-ayse"],
+          model: "ExclusiveScopeRejected",
+          metadataMappings: {},
+          measures: [],
+        },
+      });
+    } catch (e) {
+      error = e as { status?: number; message?: string };
+    }
+    expect(error).toBeDefined();
+    expect(error?.status).toBe(400);
+    expect(error?.message).toMatch(/mutually exclusive/);
+  });
+
+  it("should accept tenant-scoped writeAsset (engineIds only)", async () => {
+    const result = await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineIds: ["engine-ayse"],
+        model: "ExclusiveScopeTenant",
+        metadataMappings: {},
+        measures: [],
+      },
+    });
+    expect(result.result._source.engineIds).toEqual(["engine-ayse"]);
+  });
+
+  it("should accept group-scoped writeAsset (engineGroups only)", async () => {
+    const result = await sdk.query({
+      controller: "device-manager/models",
+      action: "writeAsset",
+      body: {
+        engineGroups: ["asset_tracking"],
+        model: "ExclusiveScopeGroup",
+        metadataMappings: {},
+        measures: [],
+      },
+    });
+    expect(result.result._source.engineGroups).toEqual(["asset_tracking"]);
+    expect(result.result._source.engineIds).toBeUndefined();
+  });
+});


### PR DESCRIPTION
…set models

KZLPRD-1192. The frontend was sending both fields when creating tenant-scoped asset models, producing hybrid documents that downstream scope filtering could not classify, so newly created tenant-scoped models never appeared in the target tenant.

- writeAsset rejects requests carrying both engineIds and engineGroups (400).
- writeAsset stores only the relevant scope field on the document.
- updateAsset preserves the existing scope from the doc instead of overwriting it from the request payload (the same bug applied on edit).
- ModelsController.writeAsset accepts an empty engineGroups body for the tenant-scoped path.
- ModelSerializer no longer requires engineGroups when an asset model is tenant-scoped.
- Adds functional tests covering the three scope combinations.


<!--
  Thank you for submitting a Pull Request. Please:
    - Read our CONTRIBUTING guidelines.
      https://github.com/kuzzleio/kuzzle/blob/master/CONTRIBUTING.md
    - Associate an issue with the Pull Request.
    - IMPORTANT - Add the corresponding "changelog:xxx" label to your PR.
-->

<!--- This template is optional. -->

## What does this PR do ?

<!--
  Please include a summary of the change, relevant motivation and context.
  Also, list any dependencies that are required for this change.
-->

### How should this be manually tested?

<!--
  Please describe your test configuration, the tests ran to verify your changes
  And give us instructions on how to reproduce them.
-->
  - Step 1 :
  - Step 2 :
  - Step 3 :

### Other changes

<!--
  Please outline any changes not directly linked to the main issue, but made because of it.
  For instance: on-the-fly fixes, dependencies updates and so on.
-->

### Boyscout

<!--
  Finally, describe any improvements in the code base like:
  Typo fixes, improved/new comments, debug messages and so on.
-->
