### PR TITLE
fix(model): use sdk.security.checkRights instead of sdk.query in ModelService

### DIFF
--- a/plugin/lib/modules/model/ModelService.ts
+++ b/plugin/lib/modules/model/ModelService.ts
@@ -735,17 +735,15 @@ export class ModelService extends BaseService {
     engineId: string,
   ): Promise<boolean> {
     try {
-      const result = await this.sdk.query({
-        controller: "auth",
-        action: "checkRights",
-        body: {
+      const result = await this.sdk.security.checkRights(
+        request.context.user?._id,
+        {
           controller: "device-manager/assets",
           action: "get",
           index: engineId,
         },
-        jwt: request.context.token?.jwt,
-      });
-      return (result.result as { allowed: boolean }).allowed;
+      );
+      return result;
     } catch {
       return false;
     }


### PR DESCRIPTION
- Resolved a bug in ModelService.ts where sdk.query was used to checkRights but EmbeddedSDK only allow sdk.security.checkRights