### PR TITLE
feat(groups): add targetgroupid in the return of movegroup

### DIFF
--- a/plugin/lib/modules/group/GroupsService.ts
+++ b/plugin/lib/modules/group/GroupsService.ts
@@ -210,10 +210,10 @@ export class GroupsService extends BaseService {
     _id: string,
     targetGroupId: string | null,
     request: KuzzleRequest,
-  ): Promise<KDocument<GroupContent>> {
+  ): Promise<{ group: KDocument<GroupContent>; targetGroupId: string | null }> {
     const group = await this.get(engineId, _id, request);
     const currentPath = group._source.path;
-    const groupLeafId = currentPath.split(".").pop() as string; //NOSONAR
+    const groupLeafId = currentPath.split(".").pop() as string;
     const currentParentPath = currentPath.split(".").slice(0, -1).join(".");
 
     let newPath: string;
@@ -246,7 +246,17 @@ export class GroupsService extends BaseService {
       newPath = `${targetPath}.${groupLeafId}`;
     }
 
-    return this._updatePath(request, _id, engineId, newPath);
+    const updatedGroup = await this._updatePath(
+      request,
+      _id,
+      engineId,
+      newPath,
+    );
+
+    return {
+      group: updatedGroup,
+      targetGroupId,
+    };
   }
 
   async delete(_id: string, engineId: string, request: KuzzleRequest) {

--- a/plugin/lib/modules/group/types/GroupsApi.ts
+++ b/plugin/lib/modules/group/types/GroupsApi.ts
@@ -165,5 +165,7 @@ export interface ApiGroupMoveRequest extends GroupControllerRequest {
     targetGroupId: string | null;
   };
 }
-
-export type ApiGroupMoveResult = KDocument<GroupContent>;
+export type ApiGroupMoveResult = {
+  group: KDocument<GroupContent>;
+  targetGroupId: string | null;
+};

--- a/plugin/tests/scenario/modules/groups/group-permissions.test.ts
+++ b/plugin/tests/scenario/modules/groups/group-permissions.test.ts
@@ -152,22 +152,22 @@ describe("GroupsController", () => {
   });
 
   it("can move a group", async () => {
-    const { result: movedGroup } = await sdk.query<
-      ApiGroupMoveRequest,
-      ApiGroupMoveResult
-    >({
-      controller: "device-manager/groups",
-      engineId: "engine-ayse",
-      action: "moveGroup",
-      _id: groupTestChildrenId1,
-      body: { targetGroupId: groupTestId },
-    });
-
-    expect(movedGroup._id).toBe(groupTestChildrenId1);
-    expect(movedGroup._source.path).toBe(
-      groupTestId + "." + groupTestChildrenId1,
+    const { result } = await sdk.query<ApiGroupMoveRequest, ApiGroupMoveResult>(
+      {
+        controller: "device-manager/groups",
+        engineId: "engine-ayse",
+        action: "moveGroup",
+        _id: groupTestChildrenId1,
+        body: { targetGroupId: groupTestId },
+      },
     );
-    expect(movedGroup._source.lastUpdate).toBeGreaterThanOrEqual(now);
+
+    expect(result.group._id).toBe(groupTestChildrenId1);
+    expect(result.group._source.path).toBe(
+      `${groupTestId}.${groupTestChildrenId1}`,
+    );
+    expect(result.group._source.lastUpdate).toBeGreaterThanOrEqual(now);
+    expect(result.targetGroupId).toBe(groupTestId);
   });
 
   it("can delete a group", async () => {

--- a/plugin/tests/scenario/modules/groups/group.test.ts
+++ b/plugin/tests/scenario/modules/groups/group.test.ts
@@ -239,7 +239,6 @@ describe("GroupsController", () => {
     await expect(sdk.query(missingIdQuery)).rejects.toThrow(
       /^Missing argument "_id".$/,
     );
-
     const missingBodyQuery: Omit<ApiGroupMoveRequest, "body"> = {
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -249,7 +248,6 @@ describe("GroupsController", () => {
     await expect(sdk.query(missingBodyQuery)).rejects.toThrow(
       /^The request must specify a body.$/,
     );
-
     const selfMoveQuery: ApiGroupMoveRequest = {
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -260,7 +258,6 @@ describe("GroupsController", () => {
     await expect(sdk.query(selfMoveQuery)).rejects.toThrow(
       "Cannot move a group into itself",
     );
-
     const descendantMoveQuery: ApiGroupMoveRequest = {
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -271,7 +268,6 @@ describe("GroupsController", () => {
     await expect(sdk.query(descendantMoveQuery)).rejects.toThrow(
       `Cannot move group "${groupTestParentId1}" into one of its own descendants`,
     );
-
     const alreadyAtRootQuery: ApiGroupMoveRequest = {
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -282,7 +278,6 @@ describe("GroupsController", () => {
     await expect(sdk.query(alreadyAtRootQuery)).rejects.toThrow(
       `The group "${groupTestId}" is already at the root`,
     );
-
     const alreadyChildQuery: ApiGroupMoveRequest = {
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -293,6 +288,7 @@ describe("GroupsController", () => {
     await expect(sdk.query(alreadyChildQuery)).rejects.toThrow(
       `The group "${groupTestChildrenId1}" is already a child of "${groupTestParentId1}"`,
     );
+
     const { result: movedGroup } = await sdk.query<
       ApiGroupMoveRequest,
       ApiGroupMoveResult
@@ -303,12 +299,12 @@ describe("GroupsController", () => {
       _id: groupTestChildrenId1,
       body: { targetGroupId: groupTestId },
     });
-
-    expect(movedGroup._id).toBe(groupTestChildrenId1);
-    expect(movedGroup._source.path).toBe(
+    expect(movedGroup.group._id).toBe(groupTestChildrenId1);
+    expect(movedGroup.group._source.path).toBe(
       groupTestId + "." + groupTestChildrenId1,
     );
-    expect(movedGroup._source.lastUpdate).toBeGreaterThanOrEqual(now);
+    expect(movedGroup.group._source.lastUpdate).toBeGreaterThanOrEqual(now);
+    expect(movedGroup.targetGroupId).toBe(groupTestId);
 
     const { result: movedToRoot } = await sdk.query<
       ApiGroupMoveRequest,
@@ -320,9 +316,9 @@ describe("GroupsController", () => {
       _id: groupTestChildrenId1,
       body: { targetGroupId: null },
     });
-
-    expect(movedToRoot._source.path).toBe(groupTestChildrenId1);
-    expect(movedToRoot._source.lastUpdate).toBeGreaterThanOrEqual(now);
+    expect(movedToRoot.group._source.path).toBe(groupTestChildrenId1);
+    expect(movedToRoot.group._source.lastUpdate).toBeGreaterThanOrEqual(now);
+    expect(movedToRoot.targetGroupId).toBeNull();
 
     const { result: movedParent } = await sdk.query<
       ApiGroupMoveRequest,
@@ -334,17 +330,16 @@ describe("GroupsController", () => {
       _id: groupParentWithAssetId,
       body: { targetGroupId: groupTestId },
     });
-
-    expect(movedParent._source.path).toBe(
+    expect(movedParent.group._source.path).toBe(
       groupTestId + "." + groupParentWithAssetId,
     );
+    expect(movedParent.targetGroupId).toBe(groupTestId);
 
     const { _source: assetGrouped } = await sdk.document.get<AssetContent>(
       "engine-ayse",
       InternalCollection.ASSETS,
       "Container-grouped2",
     );
-
     expect(assetGrouped.groups[0].path).toBe(
       groupTestId + "." + groupParentWithAssetId,
     );
@@ -354,7 +349,6 @@ describe("GroupsController", () => {
       InternalCollection.GROUPS,
       groupChildrenWithAssetId,
     );
-
     expect(childrenGroup.path).toBe(
       groupTestId +
         "." +


### PR DESCRIPTION
add targetgroupid in the return of movegroup
This PR is linked to this [PR](https://github.com/kuzzleio/iot-platform/pull/888)