### PR TITLE
fix(groups): delete children groups on delete

### DIFF
--- a/plugin/lib/modules/group/GroupsService.ts
+++ b/plugin/lib/modules/group/GroupsService.ts
@@ -339,7 +339,7 @@ export class GroupsService extends BaseService {
     await this.sdk.document.mDelete(
       engineId,
       InternalCollection.GROUPS,
-      [...childrenGroups.map((g) => g._id), _id],
+      childrenGroups.map((g) => g._id),
       { strict: true, triggerEvents: true },
     );
 

--- a/plugin/lib/modules/group/GroupsService.ts
+++ b/plugin/lib/modules/group/GroupsService.ts
@@ -285,15 +285,9 @@ export class GroupsService extends BaseService {
       assets.map((asset) => ({
         _id: asset._id,
         body: {
-          groups: asset._source.groups
-            .filter((grp) => grp.path !== group._source.path)
-            .map((grp) => {
-              if (grp.path.includes(group._source.path)) {
-                grp.path = grp.path.replace(`${group._source.path}.`, "");
-                grp.date = Date.now();
-              }
-              return grp;
-            }),
+          groups: asset._source.groups.filter(
+            (grp) => !grp.path.includes(group._source.path),
+          ),
         },
       })),
       { strict: true },
@@ -319,15 +313,9 @@ export class GroupsService extends BaseService {
       devices.map((device) => ({
         _id: device._id,
         body: {
-          groups: device._source.groups
-            .filter((grp) => grp.path !== group._source.path)
-            .map((grp) => {
-              if (grp.path.includes(group._source.path)) {
-                grp.path = grp.path.replace(`${group._source.path}.`, "");
-                grp.date = Date.now();
-              }
-              return grp;
-            }),
+          groups: device._source.groups.filter(
+            (grp) => !grp.path.includes(group._source.path),
+          ),
         },
       })),
       { strict: true },
@@ -340,7 +328,7 @@ export class GroupsService extends BaseService {
           query: {
             prefix: {
               path: {
-                value: _id,
+                value: group._source.path,
               },
             },
           },
@@ -348,24 +336,14 @@ export class GroupsService extends BaseService {
         { lang: "koncorde" },
       );
 
-    await this.sdk.document.mUpdate(
+    await this.sdk.document.mDelete(
       engineId,
       InternalCollection.GROUPS,
-      childrenGroups.map((grp) => {
-        grp._source.path = grp._source.path.replace(
-          `${group._source.path}.`,
-          "",
-        );
-        grp._source.lastUpdate = Date.now();
-        return { _id: grp._id, body: grp._source };
-      }),
-      { strict: true },
+      [...childrenGroups.map((g) => g._id), _id],
+      { strict: true, triggerEvents: true },
     );
 
-    return this.deleteDocument(request, _id, {
-      collection: InternalCollection.GROUPS,
-      engineId,
-    });
+    return _id;
   }
 
   async search(

--- a/plugin/tests/scenario/modules/groups/group-permissions.test.ts
+++ b/plugin/tests/scenario/modules/groups/group-permissions.test.ts
@@ -30,7 +30,6 @@ import {
   ApiGroupSearchResult,
   ApiGroupUpdateRequest,
 } from "lib/modules/group/types/GroupsApi";
-import { GroupContent } from "lib/modules/group/types/GroupContent";
 
 describe("GroupsController", () => {
   const sdk = setupHooks();
@@ -188,17 +187,15 @@ describe("GroupsController", () => {
       _id: groupTestParentId1,
     });
 
-    const { _source: childrenGroup } = await sdk.document.get<GroupContent>(
-      "engine-ayse",
-      InternalCollection.GROUPS,
-      groupTestChildrenId1,
+    const deletedChildQuery = {
+      controller: "device-manager/groups",
+      action: "get",
+      engineId: "engine-ayse",
+      _id: groupTestChildrenId1,
+    };
+    await expect(sdk.query(deletedChildQuery)).rejects.toThrow(
+      /test-children-1/,
     );
-
-    expect(childrenGroup).toMatchObject({
-      path: groupTestChildrenId1,
-    });
-    expect(childrenGroup.lastUpdate).toBeGreaterThanOrEqual(now);
-
     await sdk.query<ApiGroupDeleteRequest>({
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -212,7 +209,7 @@ describe("GroupsController", () => {
       "Container-grouped",
     );
 
-    expect(assetGrouped).toMatchObject({
+    expect(assetGrouped).not.toMatchObject({
       groups: [
         {
           path: groupChildrenWithAssetId,

--- a/plugin/tests/scenario/modules/groups/group.test.ts
+++ b/plugin/tests/scenario/modules/groups/group.test.ts
@@ -385,18 +385,16 @@ describe("GroupsController", () => {
       action: "delete",
       _id: groupTestParentId1,
     });
-
-    const { _source: childrenGroup } = await sdk.document.get<GroupContent>(
-      "engine-ayse",
-      InternalCollection.GROUPS,
-      groupTestChildrenId1,
+    await sdk.collection.refresh("engine-ayse", "groups");
+    const deletedChildQuery = {
+      controller: "device-manager/groups",
+      action: "get",
+      engineId: "engine-ayse",
+      _id: groupTestChildrenId1,
+    };
+    await expect(sdk.query(deletedChildQuery)).rejects.toThrow(
+      /test-children-1/,
     );
-
-    expect(childrenGroup).toMatchObject({
-      path: groupTestChildrenId1,
-    });
-    expect(childrenGroup.lastUpdate).toBeGreaterThanOrEqual(now);
-
     await sdk.query<ApiGroupDeleteRequest>({
       controller: "device-manager/groups",
       engineId: "engine-ayse",
@@ -410,7 +408,7 @@ describe("GroupsController", () => {
       "Container-grouped",
     );
 
-    expect(assetGrouped).toMatchObject({
+    expect(assetGrouped).not.toMatchObject({
       groups: [
         {
           path: groupChildrenWithAssetId,


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the deletion of groups:
Now the children groups of deleted group are deleted and removed from assets and devices

### How should this be manually tested?

  - Step 1 : create a group with child group and grandchild group
  - Step 2 :add assets and devices in each 
  - Step 3 : delete child group
  - Step 4: Check that grand child has been deleted too and removed from assets and devices