### PR TITLE
fix(payloadService): await provision event trigger

### DIFF
--- a/plugin/lib/modules/decoder/PayloadService.ts
+++ b/plugin/lib/modules/decoder/PayloadService.ts
@@ -397,7 +397,7 @@ export class PayloadService extends BaseService {
       },
     );
 
-    const newDevices = deviceIds.map((deviceId) => {
+    const devicePromises = deviceIds.map(async (deviceId) => {
       // Reference may contains a "-"
       const [, ...rest] = deviceId.split("-");
       const reference = rest.join("-");
@@ -411,7 +411,7 @@ export class PayloadService extends BaseService {
         provisionedAt: Date.now(),
         reference,
       };
-      this.app.trigger<EventPayloadDeviceProvisioning>(
+      await this.app.trigger<EventPayloadDeviceProvisioning>(
         "device-manager:payload:provision-device:before",
         { device: body, request },
       );
@@ -420,6 +420,16 @@ export class PayloadService extends BaseService {
         body,
       };
     });
+    const newDevices = (await Promise.allSettled(devicePromises))
+      .filter((p) => p.status === "fulfilled")
+      .map(
+        (
+          p: PromiseFulfilledResult<{
+            _id: string;
+            body: DeviceProvisioningContent;
+          }>,
+        ) => p.value,
+      );
 
     const { successes, errors } =
       await this.sdk.document.mCreate<DeviceContent>(


### PR DESCRIPTION
## What does this PR do ?
This PR fixes the call to recently added event  ` "device-manager:payload:provision-device:before"` 
The trigger is properly awaited to not skip async pipes

### How should this be manually tested?
  - Step 1 : Add an async enrichement pipe on the event 
  - Step 2 :verify that it is well triggered and the resulting device is properly created  with enriched properties