### PR TITLE
fix(DigitalTwinService): asset is never unlinked when relinked to another asset

### DIFF
--- a/plugin/lib/modules/shared/services/DigitalTwinService.ts
+++ b/plugin/lib/modules/shared/services/DigitalTwinService.ts
@@ -583,7 +583,7 @@ export class DigitalTwinService extends BaseService {
     };
 
     for (const name of requestedMeasureNames) {
-      if (measureAlreadyProvided(name.asset)) {
+      if (measureAlreadyProvided(name.device)) {
         throw new BadRequestError(
           `Measure name "${name.device}" is already provided to another asset by this device.`,
         );


### PR DESCRIPTION
- fix a bug where asset is never unlinked when relinked to another asset