### PR TITLE
fix(DigitalTwinService): add tests

### DIFF
--- a/plugin/tests/scenario/modules/assets/action-link-devices.test.ts
+++ b/plugin/tests/scenario/modules/assets/action-link-devices.test.ts
@@ -325,6 +325,48 @@ describe("AssetController: linkDevices", () => {
     });
   });
 
+  it("should throw an error when linking a device already providing this measure to another asset", async () => {
+    await expect(
+      sdk.query<ApiAssetlinkDevicesRequest>({
+        controller: "device-manager/assets",
+        action: "linkDevices",
+        engineId: "engine-ayse",
+        _id: "Container-unlinked1",
+        body: {
+          linkedMeasures: [
+            {
+              deviceId: "DummyTemp-linked1",
+              measureSlots: [
+                {
+                  asset: "temperatureInt",
+                  device: "temperature",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({
+      message:
+        'Measure name "temperature" is already provided to another asset by this device.',
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "devices", "DummyTemp-linked1"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [
+        {
+          assetId: "Container-linked1",
+          measureSlots: [{ asset: "temperatureExt", device: "temperature" }],
+        },
+      ],
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "assets", "Container-unlinked1"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [],
+    });
+  });
+
   it("should throw an error when the device is not attached to an engine", async () => {
     await expect(
       sdk.query<ApiAssetlinkDevicesRequest>({

--- a/plugin/tests/scenario/modules/assets/action-link-devices.test.ts
+++ b/plugin/tests/scenario/modules/assets/action-link-devices.test.ts
@@ -367,6 +367,49 @@ describe("AssetController: linkDevices", () => {
     });
   });
 
+  it("should reject the whole link request (no partial link) when one of several requested measures is already provided to another asset by this device", async () => {
+    await expect(
+      sdk.query<ApiAssetlinkDevicesRequest>({
+        controller: "device-manager/assets",
+        action: "linkDevices",
+        engineId: "engine-ayse",
+        _id: "Container-unlinked1",
+        body: {
+          linkedMeasures: [
+            {
+              deviceId: "DummyTempPosition-linked2",
+              measureSlots: [
+                { asset: "batteryLevel", device: "battery" },
+                { asset: "temperatureInt", device: "temperature" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({
+      message:
+        'Measure name "temperature" is already provided to another asset by this device.',
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "devices", "DummyTempPosition-linked2"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [
+        {
+          assetId: "Container-linked2",
+          measureSlots: expect.arrayContaining([
+            { asset: "temperatureExt", device: "temperature" },
+            { asset: "position", device: "position" },
+          ]),
+        },
+      ],
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "assets", "Container-unlinked1"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [],
+    });
+  });
+
   it("should throw an error when the device is not attached to an engine", async () => {
     await expect(
       sdk.query<ApiAssetlinkDevicesRequest>({

--- a/plugin/tests/scenario/modules/devices/action-link-asset.test.ts
+++ b/plugin/tests/scenario/modules/devices/action-link-asset.test.ts
@@ -332,6 +332,91 @@ describe("DeviceController: receiveMeasure", () => {
     });
   });
 
+  it("should throw an error when linking a measure already provided to another asset by this device", async () => {
+    await expect(
+      sdk.query<ApiDeviceLinkAssetsRequest>({
+        controller: "device-manager/devices",
+        action: "linkAssets",
+        engineId: "engine-ayse",
+        _id: "DummyTemp-linked1",
+        body: {
+          linkedMeasures: [
+            {
+              assetId: "Container-unlinked1",
+              measureSlots: [
+                {
+                  asset: "temperatureInt",
+                  device: "temperature",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({
+      message:
+        'Measure name "temperature" is already provided to another asset by this device.',
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "devices", "DummyTemp-linked1"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [
+        {
+          assetId: "Container-linked1",
+          measureSlots: [{ asset: "temperatureExt", device: "temperature" }],
+        },
+      ],
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "assets", "Container-unlinked1"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [],
+    });
+  });
+
+  it("should reject the whole link request (no partial link) when one of several requested measures is already provided to another asset by this device", async () => {
+    await expect(
+      sdk.query<ApiDeviceLinkAssetsRequest>({
+        controller: "device-manager/devices",
+        action: "linkAssets",
+        engineId: "engine-ayse",
+        _id: "DummyTempPosition-linked2",
+        body: {
+          linkedMeasures: [
+            {
+              assetId: "Container-unlinked1",
+              measureSlots: [
+                { asset: "batteryLevel", device: "battery" },
+                { asset: "temperatureInt", device: "temperature" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({
+      message:
+        'Measure name "temperature" is already provided to another asset by this device.',
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "devices", "DummyTempPosition-linked2"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [
+        {
+          assetId: "Container-linked2",
+          measureSlots: expect.arrayContaining([
+            { asset: "temperatureExt", device: "temperature" },
+            { asset: "position", device: "position" },
+          ]),
+        },
+      ],
+    });
+    await expect(
+      documentGet(sdk, "engine-ayse", "assets", "Container-unlinked1"),
+    ).resolves.toMatchObject({
+      linkedMeasures: [],
+    });
+  });
+
   it("should throw an error when the device is not attached to an engine", async () => {
     await expect(
       sdk.query<ApiDeviceLinkAssetsRequest>({


### PR DESCRIPTION
- add test to verify if an error is throw when linking a measure already provided to another asset by this device
- add test to verify no partial link occurs when one of several requested measures in the same request is already provided to another asset by this device